### PR TITLE
Fix noDescriptionsInSchema behavior

### DIFF
--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -64,7 +64,9 @@ class SchemaToClass
             throw new GeneratorException("cannot generate class for types other than 'object'");
         }
 
-        // remove descriptions from schema if such option is set
+        // remove descriptions from schema if such option is set, but keep them
+        // for building property documentation
+        $validationSchema = $schema;
         if ($req->getOptions()->getNoDescriptionsInSchema()) {
             $stripDescriptions = function (&$node) use (&$stripDescriptions) {
                 if (!is_array($node)) {
@@ -79,12 +81,12 @@ class SchemaToClass
                     }
                 }
             };
-            $stripDescriptions($schema);
+            $stripDescriptions($validationSchema);
         }
 
         $schemaProperty = new PropertyGenerator(
             "schema",
-            $schema,
+            $validationSchema,
             PropertyGenerator::FLAG_PRIVATE | PropertyGenerator::FLAG_STATIC
         );
 

--- a/tests/Generator/Fixtures/NoDescriptionsInSchema/Output/Foo.php
+++ b/tests/Generator/Fixtures/NoDescriptionsInSchema/Output/Foo.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\Fixture;
+
+class Foo
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        'required' => [
+            'foo',
+        ],
+        'properties' => [
+            'foo' => [
+                'type' => 'string',
+            ],
+            'bar' => [
+                'type' => 'integer',
+            ],
+        ],
+    ];
+
+    /**
+     * Foo description
+     *
+     * @var string
+     */
+    private string $foo;
+
+    /**
+     * Bar description
+     *
+     * @var int|null
+     */
+    private ?int $bar = null;
+
+    /**
+     * @param string $foo
+     */
+    public function __construct(string $foo)
+    {
+        $this->foo = $foo;
+    }
+
+    /**
+     * Foo description
+     *
+     * @return string
+     */
+    public function getFoo() : string
+    {
+        return $this->foo;
+    }
+
+    /**
+     * Bar description
+     *
+     * @return int|null
+     */
+    public function getBar() : ?int
+    {
+        return $this->bar ?? null;
+    }
+
+    /**
+     * @param string $foo
+     * @return self
+     */
+    public function withFoo(string $foo) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($foo, self::$schema['properties']['foo']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->foo = $foo;
+
+        return $clone;
+    }
+
+    /**
+     * @param int $bar
+     * @return self
+     */
+    public function withBar(int $bar) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($bar, self::$schema['properties']['bar']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->bar = $bar;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutBar() : self
+    {
+        $clone = clone $this;
+        unset($clone->bar);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return Foo Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to buildFromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $foo = $input->{'foo'};
+        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+
+        $obj = new self($foo);
+        $obj->bar = $bar;
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toJson() : array
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+
+    public function __clone()
+    {
+    }
+}

--- a/tests/Generator/Fixtures/NoDescriptionsInSchema/Output/Foo.php
+++ b/tests/Generator/Fixtures/NoDescriptionsInSchema/Output/Foo.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ns\Fixture;
+namespace Ns\NoDescriptionsInSchema;
 
 class Foo
 {

--- a/tests/Generator/Fixtures/NoDescriptionsInSchema/options.yaml
+++ b/tests/Generator/Fixtures/NoDescriptionsInSchema/options.yaml
@@ -1,0 +1,1 @@
+noDescriptionsInSchema: true

--- a/tests/Generator/Fixtures/NoDescriptionsInSchema/schema.yaml
+++ b/tests/Generator/Fixtures/NoDescriptionsInSchema/schema.yaml
@@ -1,0 +1,9 @@
+required:
+  - foo
+properties:
+  foo:
+    type: string
+    description: Foo description
+  bar:
+    type: integer
+    description: Bar description


### PR DESCRIPTION
## Summary
- ensure descriptions are only removed from validation schema
- add regression fixture for noDescriptionsInSchema option

## Testing
- `vendor/bin/phpunit` *(fails: TypeError & assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_684b1d693dd0832da2537fb802958666