### PR TITLE
Fix duplicate property name collisions

### DIFF
--- a/src/Generator/Property/AbstractProperty.php
+++ b/src/Generator/Property/AbstractProperty.php
@@ -58,6 +58,11 @@ abstract class AbstractProperty implements PropertyInterface
         return $this->name;
     }
 
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
     public function description(): ?string
     {
         return $this->description;

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -117,6 +117,8 @@ class SchemaToClass
             }
         }
 
+        $this->ensureUniquePropertyNames($propertiesFromSchema);
+
         foreach ($propertiesFromSchema as $property) {
             $property->generateSubTypes($this);
         }
@@ -179,4 +181,26 @@ class SchemaToClass
         $this->writer->writeFile($filename, $content);
     }
 
+    /**
+     * Ensures that property names are unique after sanitization. When a
+     * collision is detected, an underscore is prepended until the name is
+     * unique within the given property collection.
+     */
+    private function ensureUniquePropertyNames(PropertyCollection $properties): void
+    {
+        $used = [];
+        foreach ($properties as $property) {
+            $base = $property->name();
+            $unique = $base;
+            $i = 1;
+            while (in_array($unique, $used, true)) {
+                $unique = $base . '_' . $i;
+                $i++;
+            }
+            if ($unique !== $base && method_exists($property, 'setName')) {
+                $property->setName($unique);
+            }
+            $used[] = $unique;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output/Foo.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output/Foo.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\DuplicateSanitizedNames;
+
+class Foo
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        'required' => [
+            'foo-bar',
+            'foo bar',
+        ],
+        'properties' => [
+            'foo-bar' => [
+                'type' => 'string',
+            ],
+            'foo bar' => [
+                'type' => 'string',
+            ],
+        ],
+    ];
+
+    /**
+     * @var string
+     */
+    private string $foo_bar;
+
+    /**
+     * @var string
+     */
+    private string $foo_bar_1;
+
+    /**
+     * @param string $foo_bar
+     * @param string $foo_bar_1
+     */
+    public function __construct(string $foo_bar, string $foo_bar_1)
+    {
+        $this->foo_bar = $foo_bar;
+        $this->foo_bar_1 = $foo_bar_1;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFooBar() : string
+    {
+        return $this->foo_bar;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFooBar1() : string
+    {
+        return $this->foo_bar_1;
+    }
+
+    /**
+     * @param string $foo_bar
+     * @return self
+     */
+    public function withFooBar(string $foo_bar) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($foo_bar, self::$schema['properties']['foo-bar']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar = $foo_bar;
+
+        return $clone;
+    }
+
+    /**
+     * @param string $foo_bar_1
+     * @return self
+     */
+    public function withFooBar1(string $foo_bar_1) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($foo_bar_1, self::$schema['properties']['foo bar']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar_1 = $foo_bar_1;
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return Foo Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to buildFromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $foo_bar = $input->{'foo-bar'};
+        $foo_bar_1 = $input->{'foo bar'};
+
+        $obj = new self($foo_bar, $foo_bar_1);
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toJson() : array
+    {
+        $output = [];
+        $output['foo-bar'] = $this->foo_bar;
+        $output['foo bar'] = $this->foo_bar_1;
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+
+    public function __clone()
+    {
+    }
+}

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/options.yaml
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/options.yaml
@@ -1,0 +1,1 @@
+preservePropertyNames: true

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/schema.yaml
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/schema.yaml
@@ -1,0 +1,8 @@
+required:
+  - "foo-bar"
+  - "foo bar"
+properties:
+  "foo-bar":
+    type: string
+  "foo bar":
+    type: string

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output/Foo.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output/Foo.php
@@ -14,7 +14,9 @@ class Foo
     private static array $schema = [
         'required' => [
             'foo-bar',
+            'foo bar',
             'baz qux',
+            '123 qwe',
             'Город',
             'название юр.лица',
             'IP-адрес',
@@ -23,7 +25,13 @@ class Foo
             'foo-bar' => [
                 'type' => 'string',
             ],
+            'foo bar' => [
+                'type' => 'string',
+            ],
             'baz qux' => [
+                'type' => 'string',
+            ],
+            '123 qwe' => [
                 'type' => 'string',
             ],
             'Город' => [
@@ -46,7 +54,17 @@ class Foo
     /**
      * @var string
      */
+    private string $foo_bar_1;
+
+    /**
+     * @var string
+     */
     private string $baz_qux;
+
+    /**
+     * @var string
+     */
+    private string $_123_qwe;
 
     /**
      * @var string
@@ -65,15 +83,19 @@ class Foo
 
     /**
      * @param string $foo_bar
+     * @param string $foo_bar_1
      * @param string $baz_qux
+     * @param string $_123_qwe
      * @param string $Gorod
      * @param string $nazvanie_iur_litsa
      * @param string $IP_adres
      */
-    public function __construct(string $foo_bar, string $baz_qux, string $Gorod, string $nazvanie_iur_litsa, string $IP_adres)
+    public function __construct(string $foo_bar, string $foo_bar_1, string $baz_qux, string $_123_qwe, string $Gorod, string $nazvanie_iur_litsa, string $IP_adres)
     {
         $this->foo_bar = $foo_bar;
+        $this->foo_bar_1 = $foo_bar_1;
         $this->baz_qux = $baz_qux;
+        $this->_123_qwe = $_123_qwe;
         $this->Gorod = $Gorod;
         $this->nazvanie_iur_litsa = $nazvanie_iur_litsa;
         $this->IP_adres = $IP_adres;
@@ -90,9 +112,25 @@ class Foo
     /**
      * @return string
      */
+    public function getFooBar1() : string
+    {
+        return $this->foo_bar_1;
+    }
+
+    /**
+     * @return string
+     */
     public function getBazQux() : string
     {
         return $this->baz_qux;
+    }
+
+    /**
+     * @return string
+     */
+    public function get_123Qwe() : string
+    {
+        return $this->_123_qwe;
     }
 
     /**
@@ -138,6 +176,24 @@ class Foo
     }
 
     /**
+     * @param string $foo_bar_1
+     * @return self
+     */
+    public function withFooBar1(string $foo_bar_1) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($foo_bar_1, self::$schema['properties']['foo bar']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar_1 = $foo_bar_1;
+
+        return $clone;
+    }
+
+    /**
      * @param string $baz_qux
      * @return self
      */
@@ -151,6 +207,24 @@ class Foo
 
         $clone = clone $this;
         $clone->baz_qux = $baz_qux;
+
+        return $clone;
+    }
+
+    /**
+     * @param string $_123_qwe
+     * @return self
+     */
+    public function with_123Qwe(string $_123_qwe) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($_123_qwe, self::$schema['properties']['123 qwe']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->_123_qwe = $_123_qwe;
 
         return $clone;
     }
@@ -231,12 +305,14 @@ class Foo
         }
 
         $foo_bar = $input->{'foo-bar'};
+        $foo_bar_1 = $input->{'foo bar'};
         $baz_qux = $input->{'baz qux'};
+        $_123_qwe = $input->{'123 qwe'};
         $Gorod = $input->{'Город'};
         $nazvanie_iur_litsa = $input->{'название юр.лица'};
         $IP_adres = $input->{'IP-адрес'};
 
-        $obj = new self($foo_bar, $baz_qux, $Gorod, $nazvanie_iur_litsa, $IP_adres);
+        $obj = new self($foo_bar, $foo_bar_1, $baz_qux, $_123_qwe, $Gorod, $nazvanie_iur_litsa, $IP_adres);
 
         return $obj;
     }
@@ -250,7 +326,9 @@ class Foo
     {
         $output = [];
         $output['foo-bar'] = $this->foo_bar;
+        $output['foo bar'] = $this->foo_bar_1;
         $output['baz qux'] = $this->baz_qux;
+        $output['123 qwe'] = $this->_123_qwe;
         $output['Город'] = $this->Gorod;
         $output['название юр.лица'] = $this->nazvanie_iur_litsa;
         $output['IP-адрес'] = $this->IP_adres;

--- a/tests/Generator/Fixtures/PreservePropertyNames/schema.yaml
+++ b/tests/Generator/Fixtures/PreservePropertyNames/schema.yaml
@@ -1,13 +1,19 @@
 required:
   - "foo-bar"
+  - "foo bar"
   - "baz qux"
+  - "123 qwe"
   - "Город"
   - "название юр.лица"
   - "IP-адрес"
 properties:
   "foo-bar":
     type: string
+  "foo bar":
+    type: string
   "baz qux":
+    type: string
+  "123 qwe":
     type: string
   "Город":
     type: string


### PR DESCRIPTION
## Summary
- ensure sanitized property names are unique
- support renaming properties after creation
- add regression test for duplicate sanitized names

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684b30d7bd0c832d901c24b2ffb43960