### PR TITLE
Refactor helper into private method

### DIFF
--- a/src/Command/GenerateSpecCommand.php
+++ b/src/Command/GenerateSpecCommand.php
@@ -126,7 +126,7 @@ class GenerateSpecCommand extends Command
             // 1) Emit one class per definition
             foreach ($definitions as $defName => $defSchema) {
                 // collect *transitive* dependencies of this definition
-                $deps = collect_all_local_refs($defSchema, $definitions);
+                $deps = self::collectAllLocalRefs($defSchema, $definitions);
 
                 // build a trimmed map containing exactly those dependencies
                 $trimmedDefs = array_intersect_key($definitions, array_flip($deps));
@@ -159,48 +159,44 @@ class GenerateSpecCommand extends Command
         return 0;
     }
 
-}
+    /**
+     * Recursively collect *all* local #/definitions/... dependencies of $schema.
+     *
+     * @param array<string,mixed> $schema         object/definition currently emitted
+     * @param array<string,mixed> $allDefinitions full root-level "definitions" map
+     * @return string[]                           list of definition names actually needed
+     */
+    private static function collectAllLocalRefs(array $schema, array $allDefinitions): array
+    {
+        $needed  = [];
+        $queue   = [$schema];
+        $visited = [];
 
-/**
- * Recursively collect *all* local #/definitions/... dependencies of $schema.
- *
- * @param array<string,mixed> $schema          object/definition currently emitted
- * @param array<string,mixed> $allDefinitions  full root‑level "definitions" map
- * @return string[]                            list of definition names actually needed
- */
-function collect_all_local_refs(array $schema, array $allDefinitions): array
-{
-    $needed   = [];            // discovered definition names
-    $queue    = [$schema];     // schemas still to scan
-    $visited  = [];            // names we have already expanded
+        while ($cur = array_pop($queue)) {
+            $iter = function ($node) use (&$iter, &$needed, &$queue, &$visited, $allDefinitions) {
+                if (is_array($node)) {
+                    foreach ($node as $k => $v) {
+                        if ($k === '$ref'
+                            && is_string($v)
+                            && str_starts_with($v, '#/definitions/')) {
+                            $name = substr($v, 14);
+                            if (!isset($visited[$name])) {
+                                $visited[$name] = true;
+                                $needed[]       = $name;
 
-    while ($cur = array_pop($queue)) {
-        // walk recursively through this schema node
-        $iter = function ($node) use (&$iter, &$needed, &$queue, &$visited, $allDefinitions) {
-            if (is_array($node)) {
-                foreach ($node as $k => $v) {
-                    if ($k === '$ref'
-                        && is_string($v)
-                        && str_starts_with($v, '#/definitions/')) {
-
-                        $name = substr($v, 14);        // strip "#/definitions/"
-                        if (!isset($visited[$name])) {
-                            $visited[$name] = true;
-                            $needed[] = $name;
-
-                            // enqueue the referenced definition’s own schema
-                            if (isset($allDefinitions[$name])) {
-                                $queue[] = $allDefinitions[$name];
+                                if (isset($allDefinitions[$name])) {
+                                    $queue[] = $allDefinitions[$name];
+                                }
                             }
+                        } elseif (is_array($v)) {
+                            $iter($v);
                         }
-                    } elseif (is_array($v)) {
-                        $iter($v);                     // drill down
                     }
                 }
-            }
-        };
-        $iter($cur);
-    }
+            };
+            $iter($cur);
+        }
 
-    return $needed;   // de‑duplicated by $visited already
+        return $needed;
+    }
 }


### PR DESCRIPTION
## Summary
- turn the standalone `collect_all_local_refs` function into a private static method of `GenerateSpecCommand`
- update the call site accordingly

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b361bccf4832dad461006bb8d4bdd