### PR TITLE
Fix snapshot generation for JSON fixture

### DIFF
--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -190,30 +190,31 @@ class SchemaToClassTest extends TestCase
             $factory->build($writer, $output)->schemaToClass($req);
         }
 
+        $writtenFiles = $writer->getWrittenFiles();
+
         if (getenv('UPDATE_SNAPSHOTS') !== '1') {
             $this->assertCount(
                 expectedCount: count($expectedOutput),
-                haystack: $writer->getWrittenFiles(),
+                haystack: $writtenFiles,
                 message: sprintf(
                     'Expected file count [%s] does not match the written file count [%s]',
                     implode(', ', array_keys($expectedOutput)),
-                    implode(', ', array_keys($writer->getWrittenFiles())),
+                    implode(', ', array_keys($writtenFiles)),
                 ),
             );
-        }
-        foreach ($expectedOutput as $file => $content) {
-            $filename      = __DIR__ . '/' . $file;
-            $actualContent = $writer->getWrittenFiles()[$filename];
 
-            if (getenv("UPDATE_SNAPSHOTS") === "1") {
-                $outputFilename = join(DIRECTORY_SEPARATOR, [__DIR__, "Fixtures", $name, "Output", $file]);
-                file_put_contents($outputFilename, $actualContent . "\n");
-            } else {
+            foreach ($expectedOutput as $file => $content) {
+                $filename      = __DIR__ . '/' . $file;
+                $actualContent = $writtenFiles[$filename];
                 assertThat($actualContent, equalTo($content));
             }
-        }
+        } else {
+            foreach ($writtenFiles as $filename => $content) {
+                $file          = basename($filename);
+                $outputFilename = join(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', $name, 'Output', $file]);
+                file_put_contents($outputFilename, $content . "\n");
+            }
 
-        if (getenv('UPDATE_SNAPSHOTS') === '1') {
             $this->addToAssertionCount(1);
         }
     }


### PR DESCRIPTION
## Summary
- ensure `UPDATE_SNAPSHOTS=1` writes files even when no prior snapshots exist

## Testing
- `./vendor/bin/phpunit`
- `env UPDATE_SNAPSHOTS=1 ./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684c046f073c832d8bcbbc9b6b00d860