### PR TITLE
Add simpler programmatic API

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,30 @@ See [`src/Spec/Spec.yaml`](src/Spec/Spec.yaml) for a full list of available opti
 
 ### Programmatic usage
 
-The generator can be invoked from PHP code without the CLI.  Create a `GeneratorRequest` and pass it to `SchemaToClassFactory`:
+The generator can be invoked from PHP code without the CLI.  The easiest way is
+to use the `SchemaGenerator` class which accepts either a specification file or
+an array describing the configuration:
+
+```php
+use Helmich\Schema2Class\SchemaGenerator;
+
+$generator = new SchemaGenerator();
+$generator->generateFromSpecFile('.s2c.yaml');
+// or
+$generator->generateFromArray([
+    'files' => [
+        [
+            'input' => 'example.json',
+            'className' => 'User',
+            'targetDirectory' => 'src/Target',
+            'targetNamespace' => 'My\\Target',
+        ],
+    ],
+]);
+```
+
+If you need more control you can still create a `GeneratorRequest` and pass it
+to `SchemaToClassFactory` directly:
 
 ```php
 use Helmich\Schema2Class\Generator\GeneratorRequest;

--- a/README.md
+++ b/README.md
@@ -248,16 +248,16 @@ See [`src/Spec/Spec.yaml`](src/Spec/Spec.yaml) for a full list of available opti
 ### Programmatic usage
 
 The generator can be invoked from PHP code without the CLI.  The easiest way is
-to use the `SchemaGenerator` class which accepts either a specification file or
+to use the `Schema2Class` class which accepts either a specification file or
 an array describing the configuration:
 
 ```php
-use Helmich\Schema2Class\SchemaGenerator;
+use Helmich\Schema2Class\Schema2Class;
 
-$generator = new SchemaGenerator();
+$generator = new Schema2Class();
 $generator->generateFromSpecFile('.s2c.yaml');
 // or
-$generator->generateFromArray([
+$generator->generateFromSpecArray([
     'files' => [
         [
             'input' => 'example.json',

--- a/src/Schema2Class.php
+++ b/src/Schema2Class.php
@@ -22,7 +22,7 @@ use Symfony\Component\Yaml\Yaml;
  * This class can load a StructBuilder specification from a YAML file or from
  * an associative array and generate all classes described therein.
  */
-class SchemaGenerator
+class Schema2Class
 {
     use GenerateFromRequestTrait;
 
@@ -47,14 +47,14 @@ class SchemaGenerator
     {
         $output = $output ?? new NullOutput();
         $config = Yaml::parse(file_get_contents($specFile));
-        $this->generateFromArray($config, $output);
+        $this->generateFromSpecArray($config, $output);
     }
 
     /**
      * Generate classes from a specification provided as an associative array.
      * The array structure is the same as used in .s2c.yaml files.
      */
-    public function generateFromArray(array $config, ?OutputInterface $output = null): void
+    public function generateFromSpecArray(array $config, ?OutputInterface $output = null): void
     {
         $output = $output ?? new NullOutput();
 

--- a/src/SchemaGenerator.php
+++ b/src/SchemaGenerator.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class;
+
+use Helmich\Schema2Class\Command\GenerateFromRequestTrait;
+use Helmich\Schema2Class\Generator\GeneratorRequest;
+use Helmich\Schema2Class\Generator\NamespaceInferrer;
+use Helmich\Schema2Class\Loader\SchemaLoader;
+use Helmich\Schema2Class\Generator\SchemaToClassFactory;
+use Helmich\Schema2Class\Spec\Specification;
+use Helmich\Schema2Class\Spec\SpecificationOptions;
+use Helmich\Schema2Class\Spec\ValidatedSpecificationFilesItem;
+use Helmich\Schema2Class\Util\StringUtils;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Convenience API for generating classes without using the CLI commands.
+ *
+ * This class can load a StructBuilder specification from a YAML file or from
+ * an associative array and generate all classes described therein.
+ */
+class SchemaGenerator
+{
+    use GenerateFromRequestTrait;
+
+    private SchemaLoader $loader;
+    private NamespaceInferrer $namespaceInferrer;
+    private SchemaToClassFactory $s2c;
+
+    public function __construct(
+        ?SchemaLoader $loader = null,
+        ?NamespaceInferrer $namespaceInferrer = null,
+        ?SchemaToClassFactory $factory = null
+    ) {
+        $this->loader = $loader ?? new SchemaLoader();
+        $this->namespaceInferrer = $namespaceInferrer ?? new NamespaceInferrer();
+        $this->s2c = $factory ?? new SchemaToClassFactory();
+    }
+
+    /**
+     * Generate classes from a specification file.
+     */
+    public function generateFromSpecFile(string $specFile, ?OutputInterface $output = null): void
+    {
+        $output = $output ?? new NullOutput();
+        $config = Yaml::parse(file_get_contents($specFile));
+        $this->generateFromArray($config, $output);
+    }
+
+    /**
+     * Generate classes from a specification provided as an associative array.
+     * The array structure is the same as used in .s2c.yaml files.
+     */
+    public function generateFromArray(array $config, ?OutputInterface $output = null): void
+    {
+        $output = $output ?? new NullOutput();
+
+        $specification = Specification::buildFromInput($config);
+        $opts = $specification->getOptions() ?? new SpecificationOptions();
+        if ($v = $specification->getTargetPHPVersion()) {
+            $opts = $opts->withTargetPHPVersion($v);
+        }
+
+        $tpv = $opts->getTargetPHPVersion();
+        if (is_int($tpv)) {
+            $tpv = $tpv === 5 ? '5.6.0' : '7.4.0';
+        }
+        $opts = $opts->withTargetPHPVersion($tpv);
+
+        foreach ($specification->getFiles() as $file) {
+            $schemaFile = $file->getInput();
+            $targetDirectory = $file->getTargetDirectory();
+
+            $output->writeln("loading schema from <comment>{$schemaFile}</comment>");
+
+            $className = $file->getClassName();
+            if ($className === null) {
+                $basename = pathinfo($schemaFile, PATHINFO_FILENAME);
+                $className = StringUtils::pascalCase($basename);
+                $file = $file->withClassName($className);
+            }
+
+            $targetNamespace = $this->inferNamespace(
+                $output,
+                $file->getTargetNamespace(),
+                $targetDirectory,
+                $className
+            );
+            $file = $file->withTargetNamespace($targetNamespace);
+
+            $output->writeln(
+                "using target namespace <comment>{$targetNamespace}</comment> in directory <comment>{$targetDirectory}</comment>"
+            );
+
+            $schema = $this->loader->loadSchema($schemaFile);
+
+            $baseRequest = new GeneratorRequest(
+                $schema,
+                ValidatedSpecificationFilesItem::fromSpecificationFilesItem($file, $targetNamespace),
+                $opts
+            );
+
+            $this->generateFromRequest($baseRequest, $output, false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `SchemaGenerator` class as a convenience wrapper
- extend README programmatic usage documentation with new API

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --error-format=raw` *(fails: Property ... is never read, only written)*

------
https://chatgpt.com/codex/tasks/task_e_684ca6a9b848832d94726f168e74c78a