### PR TITLE
Add method for programmatic schema generation

### DIFF
--- a/src/Schema2Class.php
+++ b/src/Schema2Class.php
@@ -106,4 +106,38 @@ class Schema2Class
             $this->generateFromRequest($baseRequest, $output, false);
         }
     }
+
+    /**
+     * Generate classes from a JSON schema that is already parsed into an array.
+     *
+     * This bypasses reading the schema from disk and can be useful if the
+     * schema was retrieved from another source, e.g. a database or network.
+     */
+    public function generateFromSchema(
+        array $schema,
+        string $className,
+        string $targetDirectory,
+        ?string $targetNamespace = null,
+        ?SpecificationOptions $options = null,
+        ?OutputInterface $output = null
+    ): void {
+        $output = $output ?? new NullOutput();
+        $options = $options ?? new SpecificationOptions();
+
+        $targetNamespace = $this->inferNamespace($output, $targetNamespace, $targetDirectory, $className);
+        $output->writeln(
+            "using target namespace <comment>{$targetNamespace}</comment> in directory <comment>{$targetDirectory}</comment>"
+        );
+
+        $tpv = $options->getTargetPHPVersion();
+        if (is_int($tpv)) {
+            $tpv = $tpv === 5 ? '5.6.0' : '7.4.0';
+        }
+        $options = $options->withTargetPHPVersion($tpv);
+
+        $spec = new ValidatedSpecificationFilesItem($targetNamespace, $className, $targetDirectory);
+        $req  = new GeneratorRequest($schema, $spec, $options);
+
+        $this->generateFromRequest($req, $output, false);
+    }
 }

--- a/tests/Schema2Class/Schema2ClassTest.php
+++ b/tests/Schema2Class/Schema2ClassTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class;
+
+use PHPUnit\Framework\TestCase;
+
+class Schema2ClassTest extends TestCase
+{
+    public function testGenerateFromSchemaCreatesFile(): void
+    {
+        $schema = [
+            'required' => ['name'],
+            'properties' => [
+                'name' => ['type' => 'string'],
+            ],
+        ];
+
+        $dir = sys_get_temp_dir() . '/s2c_' . uniqid();
+        mkdir($dir);
+
+        $generator = new Schema2Class();
+        $generator->generateFromSchema($schema, 'Person', $dir, 'My\\Ns');
+
+        $file = $dir . '/Person.php';
+        $this->assertFileExists($file);
+        $content = file_get_contents($file);
+        $this->assertStringContainsString('namespace My\\Ns;', $content);
+        $this->assertStringContainsString('class Person', $content);
+
+        unlink($file);
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary
- extend Schema2Class with `generateFromSchema` for already-parsed schemas
- add a basic test covering the new API

## Testing
- `vendor/bin/phpunit --testsuite unit`

------
https://chatgpt.com/codex/tasks/task_e_684cac278c5c832dbe890f64d8880e1b