### PR TITLE
feat: introduce RenameablePropertyInterface

### DIFF
--- a/src/Generator/Property/AbstractProperty.php
+++ b/src/Generator/Property/AbstractProperty.php
@@ -9,7 +9,7 @@ use Helmich\Schema2Class\Generator\SchemaToClass;
 use Helmich\Schema2Class\Util\StringUtils;
 use Laminas\Code\Generator\PropertyValueGenerator;
 
-abstract class AbstractProperty implements PropertyInterface
+abstract class AbstractProperty implements PropertyInterface, RenameablePropertyInterface
 {
     protected string $key;
 

--- a/src/Generator/Property/DefaultPropertyDecorator.php
+++ b/src/Generator/Property/DefaultPropertyDecorator.php
@@ -6,7 +6,7 @@ namespace Helmich\Schema2Class\Generator\Property;
 use Helmich\Schema2Class\Generator\SchemaToClass;
 use Laminas\Code\Generator\PropertyValueGenerator;
 
-class DefaultPropertyDecorator implements PropertyDecoratorInterface
+class DefaultPropertyDecorator implements PropertyDecoratorInterface, RenameablePropertyInterface
 {
     use CodeFormatting;
 
@@ -159,6 +159,13 @@ class DefaultPropertyDecorator implements PropertyDecoratorInterface
     public function formatValue(mixed $value): PropertyValueGenerator
     {
         return $this->inner->formatValue($value);
+    }
+
+    public function setName(string $name): void
+    {
+        if ($this->inner instanceof RenameablePropertyInterface) {
+            $this->inner->setName($name);
+        }
     }
 
     public function allowsNull(): bool { return $this->inner->allowsNull(); }

--- a/src/Generator/Property/NullablePropertyDecorator.php
+++ b/src/Generator/Property/NullablePropertyDecorator.php
@@ -8,7 +8,7 @@ use Composer\Semver\Semver;
 use Helmich\Schema2Class\Generator\SchemaToClass;
 use Laminas\Code\Generator\PropertyValueGenerator;
 
-class NullablePropertyDecorator implements PropertyDecoratorInterface
+class NullablePropertyDecorator implements PropertyDecoratorInterface, RenameablePropertyInterface
 {
     use CodeFormatting;
 
@@ -184,5 +184,12 @@ class NullablePropertyDecorator implements PropertyDecoratorInterface
     public function formatValue(mixed $value): PropertyValueGenerator
     {
         return $this->inner->formatValue($value);
+    }
+
+    public function setName(string $name): void
+    {
+        if ($this->inner instanceof RenameablePropertyInterface) {
+            $this->inner->setName($name);
+        }
     }
 }

--- a/src/Generator/Property/OptionalPropertyDecorator.php
+++ b/src/Generator/Property/OptionalPropertyDecorator.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Helmich\Schema2Class\Generator\Property;
 
-class OptionalPropertyDecorator extends NullablePropertyDecorator
+class OptionalPropertyDecorator extends NullablePropertyDecorator implements RenameablePropertyInterface
 {
     use CodeFormatting;
 

--- a/src/Generator/Property/RenameablePropertyInterface.php
+++ b/src/Generator/Property/RenameablePropertyInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Generator\Property;
+
+interface RenameablePropertyInterface
+{
+    public function setName(string $name): void;
+}
+

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -8,6 +8,7 @@ use Helmich\Schema2Class\Codegen\PropertyGenerator;
 use Helmich\Schema2Class\Generator\Property\IntersectProperty;
 use Helmich\Schema2Class\Generator\Property\NestedObjectProperty;
 use Helmich\Schema2Class\Generator\Property\PropertyCollection;
+use Helmich\Schema2Class\Generator\Property\RenameablePropertyInterface;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Laminas\Code\DeclareStatement;
 use Laminas\Code\Generator\ClassGenerator;
@@ -205,7 +206,7 @@ class SchemaToClass
                 $unique = $base . '_' . $i;
                 $i++;
             }
-            if ($unique !== $base && method_exists($property, 'setName')) {
+            if ($unique !== $base && $property instanceof RenameablePropertyInterface) {
                 $property->setName($unique);
             }
             $used[] = $unique;

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output/Foo.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output/Foo.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\DuplicateSanitizedNamesOptional;
+
+class Foo
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        'required' => [
+            'foo-bar',
+        ],
+        'properties' => [
+            'foo-bar' => [
+                'type' => 'string',
+            ],
+            'foo bar' => [
+                'type' => 'string',
+            ],
+        ],
+    ];
+
+    /**
+     * @var string
+     */
+    private string $foo_bar;
+
+    /**
+     * @var string|null
+     */
+    private ?string $foo_bar_1 = null;
+
+    /**
+     * @param string $foo_bar
+     */
+    public function __construct(string $foo_bar)
+    {
+        $this->foo_bar = $foo_bar;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFooBar() : string
+    {
+        return $this->foo_bar;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFooBar1() : ?string
+    {
+        return $this->foo_bar_1 ?? null;
+    }
+
+    /**
+     * @param string $foo_bar
+     * @return self
+     */
+    public function withFooBar(string $foo_bar) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($foo_bar, self::$schema['properties']['foo-bar']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar = $foo_bar;
+
+        return $clone;
+    }
+
+    /**
+     * @param string $foo_bar_1
+     * @return self
+     */
+    public function withFooBar1(string $foo_bar_1) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($foo_bar_1, self::$schema['properties']['foo bar']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar_1 = $foo_bar_1;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutFooBar1() : self
+    {
+        $clone = clone $this;
+        unset($clone->foo_bar_1);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return Foo Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to buildFromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $foo_bar = $input->{'foo-bar'};
+        $foo_bar_1 = isset($input->{'foo bar'}) ? $input->{'foo bar'} : null;
+
+        $obj = new self($foo_bar);
+        $obj->foo_bar_1 = $foo_bar_1;
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toJson() : array
+    {
+        $output = [];
+        $output['foo-bar'] = $this->foo_bar;
+        if (isset($this->foo_bar_1)) {
+            $output['foo bar'] = $this->foo_bar_1;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+
+    public function __clone()
+    {
+    }
+}

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/options.yaml
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/options.yaml
@@ -1,0 +1,1 @@
+preservePropertyNames: true

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/schema.yaml
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/schema.yaml
@@ -1,0 +1,7 @@
+required:
+  - "foo-bar"
+properties:
+  "foo-bar":
+    type: string
+  "foo bar":
+    type: string


### PR DESCRIPTION
## Summary
- add `RenameablePropertyInterface`
- implement renameable interface in `AbstractProperty` and decorators
- update `SchemaToClass` to rename only renameable properties
- add forwarding of `setName` in decorators

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684d7477d6fc832d9c06de892a53ee71