### PR TITLE
Fix phpstan errors

### DIFF
--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Helmich\Schema2Class\Command;
 
+use Helmich\Schema2Class\Generator\GeneratorException;
 use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\NamespaceInferrer;
 use Helmich\Schema2Class\Generator\SchemaToClassFactory;

--- a/src/Command/GenerateFromRequestTrait.php
+++ b/src/Command/GenerateFromRequestTrait.php
@@ -8,12 +8,17 @@ use Helmich\Schema2Class\Generator\DefinitionsReferenceLookup;
 use Helmich\Schema2Class\Generator\GeneratorException;
 use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\NamespaceInferrer;
+use Helmich\Schema2Class\Generator\SchemaToClassFactory;
 use Helmich\Schema2Class\Generator\Property\NestedObjectProperty;
 use Helmich\Schema2Class\Writer\DebugWriter;
 use Helmich\Schema2Class\Writer\FileWriter;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @property NamespaceInferrer $namespaceInferrer
+ * @property SchemaToClassFactory $s2c
+ */
 trait GenerateFromRequestTrait
 {
     /**
@@ -40,7 +45,6 @@ trait GenerateFromRequestTrait
         $output->writeln('target namespace not given. inferring from directory…');
 
         try {
-            /** @var NamespaceInferrer $this->namespaceInferrer */
             return $this->namespaceInferrer->inferNamespaceFromTargetDirectory($targetDir);
         } catch (GeneratorException $e) {
             $output->writeln(

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -125,7 +125,7 @@ class Generator
 
         $paramType = null;
         if ($this->generatorRequest->isAtLeastPHP("8.0")) {
-            $paramType = "array|object";
+            $paramType = 'mixed';
         }
 
         $validationParam = new ParameterGenerator(
@@ -138,7 +138,7 @@ class Generator
             "Builds a new instance from an input array",
             null,
             [
-                new ParamTag($inputVarName, ["array|object"], "Input data"),
+                new ParamTag($inputVarName, ['mixed'], "Input data"),
                 new ParamTag("validate", ["bool"], "Set this to false to skip validation; use at own risk"),
                 new ReturnTag([$this->generatorRequest->getTargetClass()], "Created instance"),
                 new ThrowsTag("\\InvalidArgumentException"),

--- a/src/Generator/Property/UnionProperty.php
+++ b/src/Generator/Property/UnionProperty.php
@@ -99,12 +99,9 @@ class UnionProperty extends AbstractProperty
     
             // If this arm is an “array” type, prefix its test with is_array(...)
             if (
-                ! $this->generatorRequest->isAtLeastPHP("8.0")
-                && (
-                    $subProp instanceof ReferenceArrayProperty
-                    || $subProp instanceof ObjectArrayProperty
-                    || $subProp instanceof PrimitiveArrayProperty
-                )
+                $subProp instanceof ReferenceArrayProperty
+                || $subProp instanceof ObjectArrayProperty
+                || $subProp instanceof PrimitiveArrayProperty
             ) {
                 $discriminator = "is_array({$accessor}) && ({$discriminator})";
             }

--- a/src/Generator/ReferencedTypeClass.php
+++ b/src/Generator/ReferencedTypeClass.php
@@ -17,13 +17,13 @@ readonly class ReferencedTypeClass implements ReferencedType
 
     public function typeAnnotation(GeneratorRequest $req): string
     {
-        // No leading backslash: class name resolves to current namespace
-        return $this->className;
+        // Use fully-qualified class name so annotations resolve correctly
+        return '\\' . ltrim($this->className, '\\');
     }
 
     public function typeHint(GeneratorRequest $req): ?string
     {
-        return $this->className;
+        return '\\' . ltrim($this->className, '\\');
     }
 
     public function serializedInputTypeHint(GeneratorRequest $req): ?string
@@ -38,21 +38,24 @@ readonly class ReferencedTypeClass implements ReferencedType
 
     public function typeAssertionExpr(GeneratorRequest $req, string $expr): string
     {
-        return "({$expr}) instanceof {$this->className}";
+        $class = '\\' . ltrim($this->className, '\\');
+        return "({$expr}) instanceof {$class}";
     }
 
     public function inputAssertionExpr(GeneratorRequest $req, string $expr): string
     {
-        return "{$this->className}::validateInput({$expr}, true)";
+        $class = '\\' . ltrim($this->className, '\\');
+        return "{$class}::validateInput({$expr}, true)";
     }
 
     public function inputMappingExpr(GeneratorRequest $req, string $expr, ?string $validateExpr): string
     {
         $validateExpr = $validateExpr ?? '$validate';
+        $class = '\\' . ltrim($this->className, '\\');
         if ($req->isAtLeastPHP('8.0')) {
-            return "{$this->className}::buildFromInput({$expr}, {$validateExpr})";
+            return "{$class}::buildFromInput({$expr}, {$validateExpr})";
         }
-        return "{$this->className}::buildFromInput({$expr}, {$validateExpr})";
+        return "{$class}::buildFromInput({$expr}, {$validateExpr})";
     }
 
     public function outputMappingExpr(GeneratorRequest $req, string $expr): string

--- a/src/Generator/SchemaToEnum.php
+++ b/src/Generator/SchemaToEnum.php
@@ -136,13 +136,4 @@ class SchemaToEnum
     }
 
 
-    /**
-     * @param string $value
-     * @return string
-     */
-    private static function enumCaseNameString(string $value): string
-    {
-        return preg_replace('/[^a-zA-Z0-9]/', '', $value);
-    }
-
 }

--- a/src/Spec/Specification.php
+++ b/src/Spec/Specification.php
@@ -234,12 +234,12 @@ This is useful if you want to use a custom validator class.
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Specification Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Specification
+    public static function buildFromInput(mixed $input, bool $validate = true) : Specification
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/src/Spec/SpecificationFilesItem.php
+++ b/src/Spec/SpecificationFilesItem.php
@@ -191,12 +191,12 @@ class SpecificationFilesItem
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input2 Input data
+     * @param mixed $input2 Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return SpecificationFilesItem Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input2, bool $validate = true) : SpecificationFilesItem
+    public static function buildFromInput(mixed $input2, bool $validate = true) : SpecificationFilesItem
     {
         if (!is_array($input2) && !is_object($input2)) {
             throw new \InvalidArgumentException(

--- a/src/Spec/SpecificationOptions.php
+++ b/src/Spec/SpecificationOptions.php
@@ -543,12 +543,12 @@ This is useful if you want to use a custom validator class.
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return SpecificationOptions Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : SpecificationOptions
+    public static function buildFromInput(mixed $input, bool $validate = true) : SpecificationOptions
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/AdditionalProps/Output/Foo.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output/Foo.php
@@ -120,12 +120,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/AllOfRef/Output/Foo.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output/Foo.php
@@ -139,12 +139,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/ArrayProperty/Output/Phone.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output/Phone.php
@@ -72,12 +72,12 @@ class Phone
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Phone Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Phone
+    public static function buildFromInput(mixed $input, bool $validate = true) : Phone
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/ArrayProperty/Output/Record.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output/Record.php
@@ -36,7 +36,7 @@ class Record
     ];
 
     /**
-     * @var Phone[]|null
+     * @var \Phone[]|null
      */
     private ?array $dataArray = null;
 
@@ -48,7 +48,7 @@ class Record
     }
 
     /**
-     * @return Phone[]|null
+     * @return \Phone[]|null
      */
     public function getDataArray() : ?array
     {
@@ -56,7 +56,7 @@ class Record
     }
 
     /**
-     * @param Phone[] $dataArray
+     * @param \Phone[] $dataArray
      * @return self
      */
     public function withDataArray(array $dataArray) : self
@@ -87,12 +87,12 @@ class Record
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Record Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Record
+    public static function buildFromInput(mixed $input, bool $validate = true) : Record
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(
@@ -105,7 +105,7 @@ class Record
             static::validateInput($input);
         }
 
-        $dataArray = isset($input->{'dataArray'}) ? array_map(fn(array|object $i): Phone => Phone::buildFromInput($i, $validate), $input->{'dataArray'}) : null;
+        $dataArray = isset($input->{'dataArray'}) ? array_map(fn(array|object $i): Phone => \Phone::buildFromInput($i, $validate), $input->{'dataArray'}) : null;
 
         $obj = new self();
         $obj->dataArray = $dataArray;

--- a/tests/Generator/Fixtures/Basic/Output/Foo.php
+++ b/tests/Generator/Fixtures/Basic/Output/Foo.php
@@ -109,12 +109,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/DefaultValue/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output/Foo.php
@@ -122,12 +122,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/DefaultValueAsOptional/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefaultValueAsOptional/Output/Foo.php
@@ -100,12 +100,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output/Bar.php
@@ -72,12 +72,12 @@ class Bar
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Bar Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Bar
+    public static function buildFromInput(mixed $input, bool $validate = true) : Bar
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output/Foo.php
@@ -72,12 +72,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output/Bar.php
@@ -31,7 +31,7 @@ class Bar
     ];
 
     /**
-     * @var Foo|null
+     * @var \Foo|null
      */
     private ?Foo $a = null;
 
@@ -43,7 +43,7 @@ class Bar
     }
 
     /**
-     * @return Foo|null
+     * @return \Foo|null
      */
     public function getA() : ?Foo
     {
@@ -76,12 +76,12 @@ class Bar
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Bar Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Bar
+    public static function buildFromInput(mixed $input, bool $validate = true) : Bar
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(
@@ -94,7 +94,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? Foo::buildFromInput($input->{'a'}, $validate) : null;
+        $a = isset($input->{'a'}) ? \Foo::buildFromInput($input->{'a'}, $validate) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output/Foo.php
@@ -72,12 +72,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output/Bar.php
@@ -72,12 +72,12 @@ class Bar
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Bar Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Bar
+    public static function buildFromInput(mixed $input, bool $validate = true) : Bar
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output/Foo.php
@@ -72,12 +72,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output/Foo.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output/Foo.php
@@ -101,12 +101,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output/Foo.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output/Foo.php
@@ -109,12 +109,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output/Foo.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output/Foo.php
@@ -123,12 +123,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/JsonFile/Output/Foo.php
+++ b/tests/Generator/Fixtures/JsonFile/Output/Foo.php
@@ -69,12 +69,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output/Fio.php
@@ -75,12 +75,12 @@ class Fio
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Fio Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Fio
+    public static function buildFromInput(mixed $input, bool $validate = true) : Fio
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output/Phone.php
@@ -72,12 +72,12 @@ class Phone
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Phone Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Phone
+    public static function buildFromInput(mixed $input, bool $validate = true) : Phone
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output/Record.php
@@ -91,22 +91,22 @@ class Record
     ];
 
     /**
-     * @var Phone[]|null
+     * @var \Phone[]|null
      */
     private ?array $dataArray = null;
 
     /**
-     * @var Phone[][]|null
+     * @var \Phone[][]|null
      */
     private ?array $dataArrayNested = null;
 
     /**
-     * @var (Phone|Fio)[]|null
+     * @var (\Phone|Fio)[]|null
      */
     private ?array $dataArrayAnyOf = null;
 
     /**
-     * @var ((Phone|Fio)[])[]|null
+     * @var ((\Phone|Fio)[])[]|null
      */
     private ?array $dataArrayNestedAnyOf = null;
 
@@ -118,7 +118,7 @@ class Record
     }
 
     /**
-     * @return Phone[]|null
+     * @return \Phone[]|null
      */
     public function getDataArray() : ?array
     {
@@ -126,7 +126,7 @@ class Record
     }
 
     /**
-     * @return Phone[][]|null
+     * @return \Phone[][]|null
      */
     public function getDataArrayNested() : ?array
     {
@@ -134,7 +134,7 @@ class Record
     }
 
     /**
-     * @return (Phone|Fio)[]|null
+     * @return (\Phone|Fio)[]|null
      */
     public function getDataArrayAnyOf() : ?array
     {
@@ -142,7 +142,7 @@ class Record
     }
 
     /**
-     * @return ((Phone|Fio)[])[]|null
+     * @return ((\Phone|Fio)[])[]|null
      */
     public function getDataArrayNestedAnyOf() : ?array
     {
@@ -150,7 +150,7 @@ class Record
     }
 
     /**
-     * @param Phone[] $dataArray
+     * @param \Phone[] $dataArray
      * @return self
      */
     public function withDataArray(array $dataArray) : self
@@ -179,7 +179,7 @@ class Record
     }
 
     /**
-     * @param Phone[][] $dataArrayNested
+     * @param \Phone[][] $dataArrayNested
      * @return self
      */
     public function withDataArrayNested(array $dataArrayNested) : self
@@ -208,7 +208,7 @@ class Record
     }
 
     /**
-     * @param (Phone|Fio)[] $dataArrayAnyOf
+     * @param (\Phone|Fio)[] $dataArrayAnyOf
      * @return self
      */
     public function withDataArrayAnyOf(array $dataArrayAnyOf) : self
@@ -237,7 +237,7 @@ class Record
     }
 
     /**
-     * @param ((Phone|Fio)[])[] $dataArrayNestedAnyOf
+     * @param ((\Phone|Fio)[])[] $dataArrayNestedAnyOf
      * @return self
      */
     public function withDataArrayNestedAnyOf(array $dataArrayNestedAnyOf) : self
@@ -268,12 +268,12 @@ class Record
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Record Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Record
+    public static function buildFromInput(mixed $input, bool $validate = true) : Record
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(
@@ -286,17 +286,17 @@ class Record
             static::validateInput($input);
         }
 
-        $dataArray = isset($input->{'dataArray'}) ? array_map(fn(array|object $i): Phone => Phone::buildFromInput($i, $validate), $input->{'dataArray'}) : null;
-        $dataArrayNested = isset($input->{'dataArrayNested'}) ? array_map(fn($i) => array_map(fn(array|object $i): Phone => Phone::buildFromInput($i, $validate), $i), $input->{'dataArrayNested'}) : null;
+        $dataArray = isset($input->{'dataArray'}) ? array_map(fn(array|object $i): Phone => \Phone::buildFromInput($i, $validate), $input->{'dataArray'}) : null;
+        $dataArrayNested = isset($input->{'dataArrayNested'}) ? array_map(fn($i) => array_map(fn(array|object $i): Phone => \Phone::buildFromInput($i, $validate), $i), $input->{'dataArrayNested'}) : null;
         $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'}) ? array_map(fn($i) => match (true) {
             default => null,
-            Phone::validateInput($i, true) => Phone::buildFromInput($i, $validate),
-            Fio::validateInput($i, true) => Fio::buildFromInput($i, $validate),
+            \Phone::validateInput($i, true) => \Phone::buildFromInput($i, $validate),
+            \Fio::validateInput($i, true) => \Fio::buildFromInput($i, $validate),
         }, $input->{'dataArrayAnyOf'}) : null;
         $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'}) ? array_map(fn($i) => array_map(fn($i) => match (true) {
             default => null,
-            Phone::validateInput($i, true) => Phone::buildFromInput($i, $validate),
-            Fio::validateInput($i, true) => Fio::buildFromInput($i, $validate),
+            \Phone::validateInput($i, true) => \Phone::buildFromInput($i, $validate),
+            \Fio::validateInput($i, true) => \Fio::buildFromInput($i, $validate),
         }, $i), $input->{'dataArrayNestedAnyOf'}) : null;
 
         $obj = new self();

--- a/tests/Generator/Fixtures/NoDescriptionsInSchema/Output/Foo.php
+++ b/tests/Generator/Fixtures/NoDescriptionsInSchema/Output/Foo.php
@@ -117,12 +117,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/NoGetters/Output/Foo.php
+++ b/tests/Generator/Fixtures/NoGetters/Output/Foo.php
@@ -56,12 +56,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/NoSetters/Output/Foo.php
+++ b/tests/Generator/Fixtures/NoSetters/Output/Foo.php
@@ -65,12 +65,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/NonAsciiProperty/Output/Foo.php
+++ b/tests/Generator/Fixtures/NonAsciiProperty/Output/Foo.php
@@ -138,12 +138,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output/Foo.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output/Foo.php
@@ -286,12 +286,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/RefList/Output/Foo.php
+++ b/tests/Generator/Fixtures/RefList/Output/Foo.php
@@ -26,7 +26,7 @@ class Foo
     ];
 
     /**
-     * @var Helmich\Schema2Class\Example\CustomerAddress[]|null
+     * @var \Helmich\Schema2Class\Example\CustomerAddress[]|null
      */
     private ?array $foo = null;
 
@@ -38,7 +38,7 @@ class Foo
     }
 
     /**
-     * @return Helmich\Schema2Class\Example\CustomerAddress[]|null
+     * @return \Helmich\Schema2Class\Example\CustomerAddress[]|null
      */
     public function getFoo() : ?array
     {
@@ -46,7 +46,7 @@ class Foo
     }
 
     /**
-     * @param Helmich\Schema2Class\Example\CustomerAddress[] $foo
+     * @param \Helmich\Schema2Class\Example\CustomerAddress[] $foo
      * @return self
      */
     public function withFoo(array $foo) : self
@@ -77,12 +77,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(
@@ -95,7 +95,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? array_map(fn(array|object $i): Helmich\Schema2Class\Example\CustomerAddress => Helmich\Schema2Class\Example\CustomerAddress::buildFromInput($i, $validate), $input->{'foo'}) : null;
+        $foo = isset($input->{'foo'}) ? array_map(fn(array|object $i): \Helmich\Schema2Class\Example\CustomerAddress => \Helmich\Schema2Class\Example\CustomerAddress::buildFromInput($i, $validate), $input->{'foo'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;
@@ -111,7 +111,7 @@ class Foo
     {
         $output = [];
         if (isset($this->foo)) {
-            $output['foo'] = array_map(fn(Helmich\Schema2Class\Example\CustomerAddress $i): array => $i->toJson(), $this->foo);
+            $output['foo'] = array_map(fn(\Helmich\Schema2Class\Example\CustomerAddress $i): array => $i->toJson(), $this->foo);
         }
 
         return $output;

--- a/tests/Generator/Fixtures/SingleLineSchema/Output/Foo.php
+++ b/tests/Generator/Fixtures/SingleLineSchema/Output/Foo.php
@@ -55,12 +55,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(

--- a/tests/Generator/Fixtures/UnionCollapsing/Output/Foo.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output/Foo.php
@@ -67,12 +67,12 @@ class Foo
     /**
      * Builds a new instance from an input array
      *
-     * @param array|object $input Input data
+     * @param mixed $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    public static function buildFromInput(mixed $input, bool $validate = true) : Foo
     {
         if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(


### PR DESCRIPTION
## Summary
- add missing import for `GeneratorException`
- document properties required by `GenerateFromRequestTrait`
- remove redundant PHP version check in UnionProperty
- delete unused helper from SchemaToEnum
- loosen input types for specification builders

## Testing
- `vendor/bin/phpstan`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_684d96c0b28c832d9e887a05ba6cdc87