### PR TITLE
Add php-parser enum generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+- switched enum generation to php-parser-based builder
+- updated EnumCreatedHook signature
+- added validation for mixed enum values
+- enum customization now testable via hooks
+
+
 ## v4.0.0
 
 This version introduces a substantial update across the project with new features, bug fixes, and refactoring. Key highlights:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## Unreleased
-- switched enum generation to php-parser-based builder
-- updated EnumCreatedHook signature
-- added validation for mixed enum values
-- enum customization now testable via hooks
-
-
 ## v4.0.0
 
 This version introduces a substantial update across the project with new features, bug fixes, and refactoring. Key highlights:
@@ -48,6 +41,12 @@ Now it:
 
 - `StringUtils` adds transliteration via `voku/portable-ascii`, robust identifier sanitization, and improved camelCase/PascalCase handling.
 
+### Enums
+- switched enum generation to php-parser-based builder
+- updated EnumCreatedHook signature
+- added validation for mixed enum values
+- enum customization now testable via hooks
+
 ### Documentation
 
 - README expanded with examples for JSON schema input, specification files, and programmatic API usage.
@@ -57,7 +56,7 @@ Now it:
 - Several new classes and interfaces to handle new functionality; extensive refactoring of existing classes.
 - **Updated tests and fixtures**: Many new test cases covering new functionality such as typed arrays, non-ASCII identifiers, and the programmatic API.
 - **Dependency updates**:
-  - New dependency `voku/portable-ascii`
+  - New dependencies: `voku/portable-ascii`, `nikic/php-parser`
   - Bumped PHPUnit to 12 and Psalm to 6
 
 ### Breaking changes?

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "ext-json": "*",
         "composer/semver": "^3.0",
         "laminas/laminas-code": "^4.12",
+        "nikic/php-parser": "^5.0",
         "voku/portable-ascii": "^2.0"
     },
     "autoload": {

--- a/src/Generator/GeneratorHookRunner.php
+++ b/src/Generator/GeneratorHookRunner.php
@@ -3,8 +3,8 @@
 namespace Helmich\Schema2Class\Generator;
 
 use Laminas\Code\Generator\ClassGenerator;
-use Laminas\Code\Generator\EnumGenerator\EnumGenerator;
 use Laminas\Code\Generator\FileGenerator;
+use Helmich\Schema2Class\Generator\PhpParserEnumGenerator;
 
 trait GeneratorHookRunner
 {
@@ -38,7 +38,7 @@ trait GeneratorHookRunner
         }
     }
 
-    public function onEnumCreated(string $enumName, EnumGenerator $enum): void
+    public function onEnumCreated(string $enumName, PhpParserEnumGenerator $enum): void
     {
         foreach ($this->hooks as ['hook' => $hook]) {
             if ($hook instanceof Hook\EnumCreatedHook) {

--- a/src/Generator/Hook/EnumCreatedHook.php
+++ b/src/Generator/Hook/EnumCreatedHook.php
@@ -2,12 +2,12 @@
 
 namespace Helmich\Schema2Class\Generator\Hook;
 
-use Laminas\Code\Generator\EnumGenerator\EnumGenerator;
+use Helmich\Schema2Class\Generator\PhpParserEnumGenerator;
 
 /**
  * Interface definition for hooks that are called when an enumeration is created.
  */
 interface EnumCreatedHook
 {
-    function onEnumCreated(string $enumName, EnumGenerator $enum): void;
+    function onEnumCreated(string $enumName, PhpParserEnumGenerator $enum): void;
 }

--- a/src/Generator/PhpParserEnumGenerator.php
+++ b/src/Generator/PhpParserEnumGenerator.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Generator;
+
+use PhpParser\Builder\Enum_ as EnumBuilder;
+use PhpParser\Builder\EnumCase;
+use PhpParser\BuilderFactory;
+use PhpParser\Node\Stmt;
+use PhpParser\PrettyPrinter\Standard;
+
+/**
+ * Simple wrapper around nikic/php-parser to build an enum and generate code.
+ *
+ * @internal This class is not considered part of the public API.
+ */
+class PhpParserEnumGenerator
+{
+    private EnumBuilder $builder;
+    private BuilderFactory $factory;
+    private Standard $printer;
+    private string $namespace;
+
+    /**
+     * @param array<non-empty-string,string|int> $cases
+     */
+    public function __construct(string $enumName, string $type, array $cases)
+    {
+        $this->factory  = new BuilderFactory();
+        $this->printer  = new Standard();
+        $parts          = explode('\\', $enumName);
+        $short          = array_pop($parts);
+        $this->namespace = implode('\\', $parts);
+        $this->builder  = $this->factory->enum($short)->setScalarType($type);
+        foreach ($cases as $name => $value) {
+            $this->builder->addStmt(
+                $this->factory->enumCase($name)->setValue($value)
+            );
+        }
+    }
+
+    public function getBuilder(): EnumBuilder
+    {
+        return $this->builder;
+    }
+
+    /**
+     * Generate PHP code for the enum.
+     */
+    public function generate(): string
+    {
+        $stmts   = [new Stmt\Declare_([
+            new Stmt\DeclareDeclare(
+                new \PhpParser\Node\Identifier('strict_types'),
+                new \PhpParser\Node\Scalar\LNumber(1)
+            ),
+        ])];
+
+        $enumNode = $this->builder->getNode();
+        if ($this->namespace !== '') {
+            $ns = $this->factory->namespace($this->namespace)->addStmt($enumNode)->getNode();
+            $stmts[] = $ns;
+        } else {
+            $stmts[] = $enumNode;
+        }
+
+        $code = "<?php\n\n" . $this->printer->prettyPrint($stmts) . "\n";
+        $code = preg_replace('/declare \(strict_types=1\);\nnamespace/', 'declare(strict_types=1);' . PHP_EOL . PHP_EOL . 'namespace', $code);
+        $code = preg_replace('/enum ([^:]+) : /', 'enum $1: ', $code);
+        $code = preg_replace('/(enum[^\n]+)\n\{/', '$1 {', $code);
+        return $code;
+    }
+}

--- a/src/Generator/PhpParserEnumGenerator.php
+++ b/src/Generator/PhpParserEnumGenerator.php
@@ -65,7 +65,11 @@ class PhpParserEnumGenerator
         }
 
         $code = "<?php\n\n" . $this->printer->prettyPrint($stmts) . "\n";
-        $code = preg_replace('/declare \(strict_types=1\);\nnamespace/', 'declare(strict_types=1);' . PHP_EOL . PHP_EOL . 'namespace', $code);
+        $code = preg_replace(
+            '/declare \(strict_types=1\);\nnamespace/',
+            "declare(strict_types=1);\n\nnamespace",
+            $code,
+        );
         $code = preg_replace('/enum ([^:]+) : /', 'enum $1: ', $code);
         $code = preg_replace('/(enum[^\n]+)\n\{/', '$1 {', $code);
         return $code;

--- a/src/Generator/SchemaToEnum.php
+++ b/src/Generator/SchemaToEnum.php
@@ -3,9 +3,8 @@
 namespace Helmich\Schema2Class\Generator;
 
 use Helmich\Schema2Class\Writer\WriterInterface;
-use Laminas\Code\DeclareStatement;
-use Laminas\Code\Generator\EnumGenerator\EnumGenerator;
 use Laminas\Code\Generator\FileGenerator;
+use Helmich\Schema2Class\Generator\PhpParserEnumGenerator;
 
 class SchemaToEnum
 {
@@ -24,10 +23,14 @@ class SchemaToEnum
 
         /** @var array<non-empty-string, string|int> $cases */
         $cases = [];
+        $hasInt = false;
+        $hasString = false;
         foreach ($req->getSchema()["enum"] as $case) {
             if (!is_string($case) && !is_int($case)) {
                 throw new GeneratorException("cannot generate enum classes for non-string/non-int enum values");
             }
+            $hasInt = $hasInt || is_int($case);
+            $hasString = $hasString || is_string($case);
 
             $name = self::enumCaseName($case);
 
@@ -43,17 +46,15 @@ class SchemaToEnum
             $cases[$name] = $case;
         }
 
+        if ($hasInt && $hasString) {
+            throw new GeneratorException("cannot generate enum classes for mixed int/string enum values");
+        }
+
         $cases = self::makeCaseNamesConsistent($cases);
 
         $type     = $req->getSchema()["type"] === "string" ? "string" : "int";
         $enumName = $req->getTargetNamespace() . "\\" . $req->getTargetClass();
-        $enum     = EnumGenerator::withConfig([
-            "name"        => $enumName,
-            "backedCases" => [
-                "type"  => $type,
-                "cases" => $cases,
-            ],
-        ]);
+        $enum     = new PhpParserEnumGenerator($enumName, $type, $cases);
 
         $req->onEnumCreated($enumName, $enum);
 
@@ -63,15 +64,10 @@ class SchemaToEnum
 
         $req->onFileCreated($filename, $file);
 
-        $file->setDeclares([DeclareStatement::strictTypes(1)]);
-
-        $content = $file->generate();
-
-        // Do some corrections because the Zend code generation library is stupid.
-        $content = preg_replace('/ : \\\\self/', ' : self', $content);
-        $content = preg_replace('/\\\\' . preg_quote($req->getTargetNamespace(), '/') . '\\\\/', '', $content);
+        $content = $file->getBody();
 
         $this->writer->writeFile($filename, $content);
+    
     }
 
 

--- a/tests/Generator/SchemaToEnumTest.php
+++ b/tests/Generator/SchemaToEnumTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Generator;
+
+use Helmich\Schema2Class\Spec\SpecificationOptions;
+use Helmich\Schema2Class\Spec\ValidatedSpecificationFilesItem;
+use Helmich\Schema2Class\Writer\DebugWriter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
+use function PHPUnit\Framework\assertStringContainsString;
+
+class SchemaToEnumTest extends TestCase
+{
+    public function testMixedEnumTypesThrows(): void
+    {
+        $schema = [
+            'enum' => [1, '1', 2, 'two'],
+            'type' => ['integer', 'string'],
+        ];
+
+        $req = new GeneratorRequest(
+            $schema,
+            new ValidatedSpecificationFilesItem('Ns\\Mixed', 'Foo', __DIR__),
+            (new SpecificationOptions())->withTargetPHPVersion('8.2')
+        );
+
+        $writer = new DebugWriter(new NullOutput());
+        $generator = new SchemaToClassFactory();
+
+        $this->expectException(GeneratorException::class);
+        $generator->build($writer, new NullOutput())->schemaToClass($req);
+    }
+
+    public function testEnumCustomizationHook(): void
+    {
+        $schema = [
+            'enum' => ['foo'],
+            'type' => 'string',
+        ];
+
+        $req = new GeneratorRequest(
+            $schema,
+            new ValidatedSpecificationFilesItem('Ns\\HookEnum', 'Foo', __DIR__),
+            (new SpecificationOptions())->withTargetPHPVersion('8.2')
+        );
+
+        $writer = new DebugWriter(new NullOutput());
+
+        $hook = new class implements Hook\EnumCreatedHook {
+            public function onEnumCreated(string $enumName, PhpParserEnumGenerator $enum): void
+            {
+                $enum->getBuilder()->addStmt((new \PhpParser\BuilderFactory())->enumCase('BAR')->setValue('bar'));
+            }
+        };
+
+        $req = $req->withHook($hook);
+        (new SchemaToClassFactory())->build($writer, new NullOutput())->schemaToClass($req);
+
+        $written = current($writer->getWrittenFiles());
+        assertStringContainsString("case BAR = 'bar';", $written);
+    }
+}


### PR DESCRIPTION
## Summary
- switch enum generation to a php-parser based generator
- update enum hook signature
- validate mixed int/string enums
- add tests for enum hooks and mixed enum values
- document migration notes

## Testing
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685055b3bc84832d8f914b077a656e0a