### PR TITLE
Add --no-enums CLI option

### DIFF
--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -57,6 +57,7 @@ class GenerateCommand extends Command
         $this->addOption("no-setters", null, InputOption::VALUE_NONE, "Do not generate withX()/withoutX() methods");
         $this->addOption("no-schema-descriptions", null, InputOption::VALUE_NONE, "Omit description fields from schema property");
         $this->addOption("single-line-schema", null, InputOption::VALUE_NONE, "Store schema property as single line");
+        $this->addOption('no-enums', null, InputOption::VALUE_NONE, 'Disable PHP enum generation');
     }
 
     /**
@@ -117,6 +118,9 @@ class GenerateCommand extends Command
         }
         if ($input->getOption("single-line-schema")) {
             $opts = $opts->withSingleLineSchema(true);
+        }
+        if ($input->getOption('no-enums')) {
+            $opts = $opts->withNoEnums(true);
         }
 
         $baseRequest = new GeneratorRequest($schema, $spec, $opts);

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -5,7 +5,10 @@ namespace Helmich\Schema2Class\Generator;
 
 use Helmich\Schema2Class\Example\CustomerAddress;
 use Helmich\Schema2Class\Loader\SchemaLoader;
-use Helmich\Schema2Class\Command\GenerateSpecCommand;
+use Helmich\Schema2Class\Command\GenerateCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+use Helmich\Schema2Class\Generator\NamespaceInferrer;
+use Helmich\Schema2Class\Generator\SchemaToClassFactory;
 use Helmich\Schema2Class\Generator\Property\IntersectProperty;
 use Helmich\Schema2Class\Generator\Property\NestedObjectProperty;
 use Helmich\Schema2Class\Spec\SpecificationOptions;
@@ -176,5 +179,35 @@ class SchemaToClassTest extends TestCase
 
             $this->addToAssertionCount(1);
         }
+    }
+
+    public function testCliNoEnumsMatchesFixture(): void
+    {
+        $schemaFile = __DIR__ . '/Fixtures/NoEnums/schema.yaml';
+        $expected   = trim(file_get_contents(__DIR__ . '/Fixtures/NoEnums/Output/Foo.php'));
+
+        $dir = sys_get_temp_dir() . '/s2c_' . uniqid();
+        mkdir($dir);
+
+        $command = new GenerateCommand(
+            new SchemaLoader(),
+            new NamespaceInferrer(),
+            new SchemaToClassFactory(),
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'schema' => $schemaFile,
+            'target-dir' => $dir,
+            '--target-namespace' => 'Ns\\NoEnums',
+            '--class' => 'Foo',
+            '--no-enums' => true,
+        ]);
+
+        $generated = trim(file_get_contents($dir . '/Foo.php'));
+        assertThat($generated, equalTo($expected));
+
+        unlink($dir . '/Foo.php');
+        rmdir($dir);
     }
 }


### PR DESCRIPTION
## Summary
- support `--no-enums` in GenerateCommand
- test CLI `--no-enums` behaviour against fixture

## Testing
- `vendor/bin/phpunit -c phpunit.xml --stop-on-failure tests/Generator/SchemaToClassTest.php`
- `vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68529288c74c832d8e8494f88bcf6a57