### PR TITLE
Fix enum annotation quoting

### DIFF
--- a/src/Generator/Property/StringEnumProperty.php
+++ b/src/Generator/Property/StringEnumProperty.php
@@ -51,7 +51,7 @@ class StringEnumProperty extends AbstractProperty
 
         // fallback: a literal‑union of all enum values
         $literals = array_map(
-            fn(string|int $v) => "'" . $v . "'",
+            fn(string|int $v) => var_export($v, true),
             $this->schema['enum']
         );
 

--- a/tests/Generator/Property/StringEnumPropertyTest.php
+++ b/tests/Generator/Property/StringEnumPropertyTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Generator\Property;
+
+use Helmich\Schema2Class\Generator\GeneratorRequest;
+use Helmich\Schema2Class\Spec\SpecificationOptions;
+use Helmich\Schema2Class\Spec\ValidatedSpecificationFilesItem;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use function PHPUnit\Framework\assertSame;
+
+class StringEnumPropertyTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private StringEnumProperty $property;
+    private GeneratorRequest $generatorRequest;
+
+    protected function setUp(): void
+    {
+        $options = (new SpecificationOptions())->withNoEnums(true);
+        $this->generatorRequest = new GeneratorRequest([], new ValidatedSpecificationFilesItem('Ns', 'Foo', ''), $options);
+        $this->property = new StringEnumProperty('color', ['type' => 'string', 'enum' => ['foo', "bar's"]], $this->generatorRequest);
+    }
+
+    public function testTypeAnnotationEscapesQuotes(): void
+    {
+        assertSame("'foo'|'bar\\'s'", $this->property->typeAnnotation());
+    }
+}


### PR DESCRIPTION
## Summary
- handle single quotes in enum PHPDoc output
- add regression test for StringEnumProperty

## Testing
- `vendor/bin/phpstan analyse`
- `vendor/bin/psalm` *(fails: requires PHP >= 8.3.16)*
- `vendor/bin/phpunit --display-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68529ca9b250832d9c8296fa17cdd229