### PR TITLE
Skip empty constructor/clone methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Now it:
 - Omits the default `null` value for properties listed in the `required` schema block.
 - Improves type hints and PHPDoc type generation for complex types like unions, nested arrays, etc.
 - Adds a guard against passing anything other than an array/object to `buildFromInput`, building multi-line validation error messages.
+- Skips emitting empty `__construct` or `__clone` methods.
 
 ### Older PHP version support:
 

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -274,7 +274,7 @@ class Generator
      * @param PropertyCollection $properties
      * @return MethodGenerator
      */
-    public function generateCloneMethod(PropertyCollection $properties): MethodGenerator
+    public function generateCloneMethod(PropertyCollection $properties): ?MethodGenerator
     {
         $clones = [];
 
@@ -283,6 +283,10 @@ class Generator
             if ($c !== null) {
                 $clones[] = $c;
             }
+        }
+
+        if ($clones === []) {
+            return null;
         }
 
         return new MethodGenerator(
@@ -482,7 +486,7 @@ return \$clone;",
         return $unsetMethod;
     }
 
-    public function generateConstructor(PropertyCollection $properties): MethodGenerator
+    public function generateConstructor(PropertyCollection $properties): ?MethodGenerator
     {
         $params      = [];
         $tags        = [];
@@ -503,6 +507,10 @@ return \$clone;",
             );
 
             $assignments[] = "\$this->{$requiredProperty->name()} = \${$paramName};";
+        }
+
+        if ($assignments === []) {
+            return null;
         }
 
         $docBlock = new DocBlockGenerator("", "", $tags);

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -272,7 +272,7 @@ class Generator
 
     /**
      * @param PropertyCollection $properties
-     * @return MethodGenerator
+     * @return ?MethodGenerator
      */
     public function generateCloneMethod(PropertyCollection $properties): ?MethodGenerator
     {

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -155,6 +155,7 @@ class SchemaToClass
             $codeGenerator->generateValidateMethod(),
             $codeGenerator->generateCloneMethod($propertiesFromSchema),
         ];
+        $methods = array_values(array_filter($methods));
 
         $cls = new ClassGenerator(
             $req->getTargetClass(),

--- a/src/Spec/SpecificationFilesItem.php
+++ b/src/Spec/SpecificationFilesItem.php
@@ -320,9 +320,5 @@ before writing new ones.
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }
 

--- a/src/Spec/SpecificationOptions.php
+++ b/src/Spec/SpecificationOptions.php
@@ -168,13 +168,6 @@ handled like in earlier PHP versions.
     private bool $noEnums = false;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return bool
      */
     public function getDisableStrictTypes() : bool

--- a/tests/Generator/Fixtures/AdditionalProps/Output/Foo.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output/Foo.php
@@ -37,13 +37,6 @@ class Foo
     private ?array $params = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return string|null
      */
     public function getName() : ?string
@@ -181,9 +174,5 @@ class Foo
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/AllOfRef/Output/Foo.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output/Foo.php
@@ -198,8 +198,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/ArrayProperty/Output/Phone.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output/Phone.php
@@ -26,13 +26,6 @@ class Phone
     private ?string $foo = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return string|null
      */
     public function getFoo() : ?string
@@ -128,9 +121,5 @@ class Phone
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/ArrayProperty/Output/Record.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output/Record.php
@@ -41,13 +41,6 @@ class Record
     private ?array $dataArray = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return Phone[]|null
      */
     public function getDataArray() : ?array
@@ -143,9 +136,5 @@ class Record
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/Basic/Output/Foo.php
+++ b/tests/Generator/Fixtures/Basic/Output/Foo.php
@@ -168,8 +168,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/DefaultValue/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output/Foo.php
@@ -39,13 +39,6 @@ class Foo
     private int $skip = 0;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return int
      */
     public function getLimit() : int
@@ -183,9 +176,5 @@ class Foo
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/DefaultValueAsOptional/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefaultValueAsOptional/Output/Foo.php
@@ -39,13 +39,6 @@ class Foo
     private int $skip = 0;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return int
      */
     public function getLimit() : int
@@ -163,9 +156,5 @@ class Foo
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/Definitions/Output/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output/Address.php
@@ -173,8 +173,4 @@ class Address
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/Definitions/Output/Address/Defs/Name.php
+++ b/tests/Generator/Fixtures/Definitions/Output/Address/Defs/Name.php
@@ -26,13 +26,6 @@ class Name
     private ?string $first = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return string|null
      */
     public function getFirst() : ?string
@@ -128,9 +121,5 @@ class Name
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/Definitions/Output/Foo.php
+++ b/tests/Generator/Fixtures/Definitions/Output/Foo.php
@@ -193,8 +193,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output/Bar.php
@@ -26,13 +26,6 @@ class Bar
     private ?int $b = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return int|null
      */
     public function getB() : ?int
@@ -128,9 +121,5 @@ class Bar
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output/Foo.php
@@ -26,13 +26,6 @@ class Foo
     private ?string $a = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return string|null
      */
     public function getA() : ?string
@@ -128,9 +121,5 @@ class Foo
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output/Bar.php
@@ -36,13 +36,6 @@ class Bar
     private ?Foo $a = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return Foo|null
      */
     public function getA() : ?Foo
@@ -132,9 +125,5 @@ class Bar
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output/Foo.php
@@ -26,13 +26,6 @@ class Foo
     private ?string $a = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return string|null
      */
     public function getA() : ?string
@@ -128,9 +121,5 @@ class Foo
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output/Bar.php
@@ -26,13 +26,6 @@ class Bar
     private ?string $a = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return string|null
      */
     public function getA() : ?string
@@ -128,9 +121,5 @@ class Bar
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output/Foo.php
@@ -26,13 +26,6 @@ class Foo
     private ?string $a = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return string|null
      */
     public function getA() : ?string
@@ -128,9 +121,5 @@ class Foo
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output/Foo.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output/Foo.php
@@ -158,8 +158,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output/Foo.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output/Foo.php
@@ -168,8 +168,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output/Foo.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output/Foo.php
@@ -187,8 +187,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/JsonFile/Output/Foo.php
+++ b/tests/Generator/Fixtures/JsonFile/Output/Foo.php
@@ -124,8 +124,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output/Fio.php
@@ -29,13 +29,6 @@ class Fio
     private ?string $bar = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return string|null
      */
     public function getBar() : ?string
@@ -131,9 +124,5 @@ class Fio
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output/Phone.php
@@ -26,13 +26,6 @@ class Phone
     private ?string $foo = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return string|null
      */
     public function getFoo() : ?string
@@ -128,9 +121,5 @@ class Phone
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output/Record.php
@@ -111,13 +111,6 @@ class Record
     private ?array $dataArrayNestedAnyOf = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return Phone[]|null
      */
     public function getDataArray() : ?array

--- a/tests/Generator/Fixtures/NoDescriptionsInSchema/Output/Foo.php
+++ b/tests/Generator/Fixtures/NoDescriptionsInSchema/Output/Foo.php
@@ -176,8 +176,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/NoEnums/Output/Foo.php
+++ b/tests/Generator/Fixtures/NoEnums/Output/Foo.php
@@ -123,8 +123,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/NoGetters/Output/Foo.php
+++ b/tests/Generator/Fixtures/NoGetters/Output/Foo.php
@@ -111,8 +111,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/NoSetters/Output/Foo.php
+++ b/tests/Generator/Fixtures/NoSetters/Output/Foo.php
@@ -122,8 +122,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/NonAsciiProperty/Output/Foo.php
+++ b/tests/Generator/Fixtures/NonAsciiProperty/Output/Foo.php
@@ -197,8 +197,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output/Foo.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output/Foo.php
@@ -353,8 +353,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }

--- a/tests/Generator/Fixtures/RefList/Output/Foo.php
+++ b/tests/Generator/Fixtures/RefList/Output/Foo.php
@@ -31,13 +31,6 @@ class Foo
     private ?array $foo = null;
 
     /**
-     *
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * @return Helmich\Schema2Class\Example\CustomerAddress[]|null
      */
     public function getFoo() : ?array
@@ -133,9 +126,5 @@ class Foo
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
     }
 }

--- a/tests/Generator/Fixtures/SingleLineSchema/Output/Foo.php
+++ b/tests/Generator/Fixtures/SingleLineSchema/Output/Foo.php
@@ -110,8 +110,4 @@ class Foo
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-    }
 }


### PR DESCRIPTION
## Summary
- omit generating `__construct()` or `__clone()` when their bodies would be empty
- filter null methods when assembling the class
- update all code generation snapshots

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68543132176c832d85405f3a4d29b271