### PR TITLE
Fix enum reference lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Now it:
 ### Enums
 
 - Laminas's immutable EnumGenerator replaced with own mutable implementation PhpParserEnumGenerator built on nikic/php-parser which allows modifications via the hook system.
+- Enum definitions referenced from object properties are now handled correctly on
+  all PHP versions.
 
 ### Documentation
 

--- a/src/Generator/DefinitionsReferenceLookup.php
+++ b/src/Generator/DefinitionsReferenceLookup.php
@@ -21,10 +21,17 @@ class DefinitionsReferenceLookup implements ReferenceLookup
 
     public function lookupReference(string $reference): ReferencedType
     {
-        if (isset($this->definitions[$reference])) {
-            return new ReferencedTypeClass($this->definitions[$reference]->classFQN);
+        if (!isset($this->definitions[$reference])) {
+            return new ReferencedTypeUnknown();
         }
-        return new ReferencedTypeUnknown();
+
+        $def = $this->definitions[$reference];
+
+        if (isset($def->schema['enum'])) {
+            return new ReferencedTypeEnum($def->classFQN, $def->schema);
+        }
+
+        return new ReferencedTypeClass($def->classFQN);
     }
 
     public function lookupSchema(string $reference): array

--- a/src/Generator/Property/ReferenceProperty.php
+++ b/src/Generator/Property/ReferenceProperty.php
@@ -52,6 +52,10 @@ class ReferenceProperty extends AbstractProperty
 
     public function isComplex(): bool
     {
+        if ($this->type instanceof \Helmich\Schema2Class\Generator\ReferencedTypeEnum) {
+            return $this->type->usesNativeEnum($this->generatorRequest);
+        }
+
         return true;
     }
 

--- a/src/Generator/ReferencedTypeEnum.php
+++ b/src/Generator/ReferencedTypeEnum.php
@@ -4,8 +4,27 @@ namespace Helmich\Schema2Class\Generator;
 
 readonly class ReferencedTypeEnum implements ReferencedType
 {
-    public function __construct(private string $enumName)
+    /**
+     * @param string $enumName Fully-qualified enum class name
+     * @param array<array-key, string|int> $schema Schema definition of the enum
+     */
+    public function __construct(private string $enumName, private array $schema)
     {
+    }
+
+    private function useNativeEnum(GeneratorRequest $req): bool
+    {
+        return $req->isAtLeastPHP('8.1') && !$req->getNoEnums();
+    }
+
+    private function relativeName(GeneratorRequest $req): string
+    {
+        $ns = $req->getTargetNamespace();
+        if ($ns !== '' && str_starts_with($this->enumName, $ns . '\\')) {
+            return substr($this->enumName, strlen($ns) + 1);
+        }
+
+        return '\\' . $this->enumName;
     }
 
     function name(): string
@@ -15,42 +34,74 @@ readonly class ReferencedTypeEnum implements ReferencedType
 
     public function typeAnnotation(GeneratorRequest $req): string
     {
-        return "\\" . $this->enumName;
+        if ($this->useNativeEnum($req)) {
+            return ltrim($this->relativeName($req), '\\');
+        }
+
+        $literals = array_map(fn(string|int $v) => var_export($v, true), $this->schema['enum']);
+        return implode('|', $literals);
     }
 
     public function typeHint(GeneratorRequest $req): ?string
     {
-        return "\\" . $this->enumName;
+        if ($this->useNativeEnum($req)) {
+            return $this->relativeName($req);
+        }
+
+        return is_int($this->schema['enum'][0]) ? 'int' : 'string';
     }
 
     function serializedInputTypeHint(GeneratorRequest $req): ?string
     {
-        return "string";
+        return $this->typeHint($req);
     }
 
     public function serializedTypeHint(GeneratorRequest $req): ?string
     {
-        return "string";
+        return $this->typeHint($req);
     }
 
     public function typeAssertionExpr(GeneratorRequest $req, string $expr): string
     {
-        return "({$expr}) instanceof \\{$this->enumName}";
+        if ($this->useNativeEnum($req)) {
+            return "({$expr}) instanceof " . ltrim($this->relativeName($req), '\\');
+        }
+
+        $values = var_export($this->schema['enum'], true);
+        return "in_array({$expr}, {$values}, true)";
     }
 
     public function inputAssertionExpr(GeneratorRequest $req, string $expr): string
     {
-        return "\\{$this->enumName}::tryFrom({$expr}) !== null";
+        if ($this->useNativeEnum($req)) {
+            return "" . ltrim($this->relativeName($req), '\\') . "::tryFrom({$expr}) !== null";
+        }
+
+        $values = var_export($this->schema['enum'], true);
+        return "in_array({$expr}, {$values}, true)";
     }
 
     public function inputMappingExpr(GeneratorRequest $req, string $expr, ?string $validateExpr): string
     {
-        return "\\{$this->enumName}::from({$expr})";
+        if ($this->useNativeEnum($req)) {
+            return ltrim($this->relativeName($req), '\\') . "::from({$expr})";
+        }
+
+        return $expr;
     }
 
     public function outputMappingExpr(GeneratorRequest $req, string $expr): string
     {
-        return "{$expr}->value";
+        if ($this->useNativeEnum($req)) {
+            return "{$expr}->value";
+        }
+
+        return $expr;
+    }
+
+    public function usesNativeEnum(GeneratorRequest $req): bool
+    {
+        return $this->useNativeEnum($req);
     }
 
 }

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output/Color.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output/Color.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\DefinitionsEnum;
+
+enum Color: string {
+    case RED = 'red';
+    case GREEN = 'green';
+}

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output/Foo.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\DefinitionsEnum;
+
+class Foo
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        'type' => 'object',
+        'additionalProperties' => false,
+        'properties' => [
+            'color' => [
+                '$ref' => '#/definitions/Color',
+            ],
+            'size' => [
+                '$ref' => '#/definitions/Size',
+            ],
+        ],
+        'required' => [
+            'color',
+        ],
+        'definitions' => [
+            'Color' => [
+                'enum' => [
+                    'red',
+                    'green',
+                ],
+                'type' => 'string',
+            ],
+            'Size' => [
+                'enum' => [
+                    'small',
+                    'big',
+                ],
+                'type' => 'string',
+            ],
+        ],
+    ];
+
+    /**
+     * @var Color
+     */
+    private Color $color;
+
+    /**
+     * @var Size|null
+     */
+    private ?Size $size = null;
+
+    /**
+     * @param Color $color
+     */
+    public function __construct(Color $color)
+    {
+        $this->color = $color;
+    }
+
+    /**
+     * @return Color
+     */
+    public function getColor() : Color
+    {
+        return $this->color;
+    }
+
+    /**
+     * @return Size|null
+     */
+    public function getSize() : ?Size
+    {
+        return $this->size ?? null;
+    }
+
+    /**
+     * @param Color $color
+     * @return self
+     */
+    public function withColor(Color $color) : self
+    {
+        $clone = clone $this;
+        $clone->color = $color;
+
+        return $clone;
+    }
+
+    /**
+     * @param Size $size
+     * @return self
+     */
+    public function withSize(Size $size) : self
+    {
+        $clone = clone $this;
+        $clone->size = $size;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutSize() : self
+    {
+        $clone = clone $this;
+        unset($clone->size);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return Foo Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $color = Color::from($input->{'color'});
+        $size = isset($input->{'size'}) ? Size::from($input->{'size'}) : null;
+
+        $obj = new self($color);
+        $obj->size = $size;
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray() : array
+    {
+        $output = [];
+        $output['color'] = $this->color->value;
+        if (isset($this->size)) {
+            $output['size'] = $this->size->value;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output/Size.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output/Size.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\DefinitionsEnum;
+
+enum Size: string {
+    case SMALL = 'small';
+    case BIG = 'big';
+}

--- a/tests/Generator/Fixtures/DefinitionsEnum/schema.yaml
+++ b/tests/Generator/Fixtures/DefinitionsEnum/schema.yaml
@@ -1,0 +1,16 @@
+definitions:
+  Color:
+    enum: [red, green]
+    type: string
+  Size:
+    enum: [small, big]
+    type: string
+  Foo:
+    type: object
+    additionalProperties: false
+    properties:
+      color:
+        $ref: '#/definitions/Color'
+      size:
+        $ref: '#/definitions/Size'
+    required: [color]

--- a/tests/Generator/Fixtures/DefinitionsEnumPhp7/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnumPhp7/Output/Foo.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\DefinitionsEnumPhp7;
+
+class Foo
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        'type' => 'object',
+        'additionalProperties' => false,
+        'properties' => [
+            'color' => [
+                '$ref' => '#/definitions/Color',
+            ],
+            'size' => [
+                '$ref' => '#/definitions/Size',
+            ],
+        ],
+        'required' => [
+            'color',
+        ],
+        'definitions' => [
+            'Color' => [
+                'enum' => [
+                    'red',
+                    'green',
+                ],
+                'type' => 'string',
+            ],
+            'Size' => [
+                'enum' => [
+                    'small',
+                    'big',
+                ],
+                'type' => 'string',
+            ],
+        ],
+    ];
+
+    /**
+     * @var 'red'|'green'
+     */
+    private string $color;
+
+    /**
+     * @var 'small'|'big'|null
+     */
+    private ?string $size = null;
+
+    /**
+     * @param 'red'|'green' $color
+     */
+    public function __construct(string $color)
+    {
+        $this->color = $color;
+    }
+
+    /**
+     * @return 'red'|'green'
+     */
+    public function getColor() : string
+    {
+        return $this->color;
+    }
+
+    /**
+     * @return 'small'|'big'|null
+     */
+    public function getSize() : ?string
+    {
+        return $this->size ?? null;
+    }
+
+    /**
+     * @param 'red'|'green' $color
+     * @return self
+     */
+    public function withColor(string $color) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($color, self::$schema['properties']['color']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->color = $color;
+
+        return $clone;
+    }
+
+    /**
+     * @param 'small'|'big' $size
+     * @return self
+     */
+    public function withSize(string $size) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($size, self::$schema['properties']['size']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->size = $size;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutSize() : self
+    {
+        $clone = clone $this;
+        unset($clone->size);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return Foo Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput($input, bool $validate = true) : Foo
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to buildFromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $color = $input->{'color'};
+        $size = isset($input->{'size'}) ? $input->{'size'} : null;
+
+        $obj = new self($color);
+        $obj->size = $size;
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray() : array
+    {
+        $output = [];
+        $output['color'] = $this->color;
+        if (isset($this->size)) {
+            $output['size'] = $this->size;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/DefinitionsEnumPhp7/options.yaml
+++ b/tests/Generator/Fixtures/DefinitionsEnumPhp7/options.yaml
@@ -1,0 +1,1 @@
+targetPHPVersion: '7.4'

--- a/tests/Generator/Fixtures/DefinitionsEnumPhp7/schema.yaml
+++ b/tests/Generator/Fixtures/DefinitionsEnumPhp7/schema.yaml
@@ -1,0 +1,16 @@
+definitions:
+  Color:
+    enum: [red, green]
+    type: string
+  Size:
+    enum: [small, big]
+    type: string
+  Foo:
+    type: object
+    additionalProperties: false
+    properties:
+      color:
+        $ref: '#/definitions/Color'
+      size:
+        $ref: '#/definitions/Size'
+    required: [color]

--- a/tests/Generator/Fixtures/ReferencedUnion/Output/A.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output/A.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\ReferencedUnion;
+
+enum A: string {
+    case FOO = 'foo';
+    case BAR = 'bar';
+}

--- a/tests/Generator/Fixtures/ReferencedUnion/Output/B.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output/B.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\ReferencedUnion;
+
+enum B: string {
+    case BAZ = 'baz';
+    case QUZ = 'quz';
+}

--- a/tests/Generator/Fixtures/ReferencedUnion/Output/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output/MyObject.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\ReferencedUnion;
+
+class MyObject
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        'type' => 'object',
+        'additionalProperties' => false,
+        'properties' => [
+            'foo' => [
+                '$ref' => '#/definitions/C',
+            ],
+        ],
+        'required' => [
+            'foo',
+        ],
+        'definitions' => [
+            'A' => [
+                'enum' => [
+                    'foo',
+                    'bar',
+                ],
+                'type' => 'string',
+            ],
+            'B' => [
+                'enum' => [
+                    'baz',
+                    'quz',
+                ],
+                'type' => 'string',
+            ],
+            'C' => [
+                'anyOf' => [
+                    [
+                        '$ref' => '#/definitions/A',
+                    ],
+                    [
+                        '$ref' => '#/definitions/B',
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * @var A|B
+     */
+    private A|B $foo;
+
+    /**
+     * @param A|B $foo
+     */
+    public function __construct(A|B $foo)
+    {
+        $this->foo = $foo;
+    }
+
+    /**
+     * @return A|B
+     */
+    public function getFoo() : A|B
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @param A|B $foo
+     * @return self
+     */
+    public function withFoo(A|B $foo) : self
+    {
+        $clone = clone $this;
+        $clone->foo = $foo;
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return MyObject Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput(array|object $input, bool $validate = true) : MyObject
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $foo = match (true) {
+            A::tryFrom($input->{'foo'}) !== null => A::from($input->{'foo'}),
+            B::tryFrom($input->{'foo'}) !== null => B::from($input->{'foo'}),
+            default => throw new \InvalidArgumentException("could not build property 'foo' from JSON"),
+        };
+
+        $obj = new self($foo);
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray() : array
+    {
+        $output = [];
+        $output['foo'] = match (true) {
+            ($this->foo) instanceof A, ($this->foo) instanceof B => $this->foo->value,
+        };
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+
+    public function __clone()
+    {
+        $this->foo = match (true) {
+            ($this->foo) instanceof A, ($this->foo) instanceof B => $this->foo,
+        };
+    }
+}

--- a/tests/Generator/Fixtures/ReferencedUnion/schema.json
+++ b/tests/Generator/Fixtures/ReferencedUnion/schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "A": {
+      "enum": ["foo", "bar"],
+      "type": "string"
+    },
+    "B": {
+      "enum": ["baz", "quz"],
+      "type": "string"
+    },
+    "C": {
+      "anyOf": [
+        {"$ref": "#/definitions/A"},
+        {"$ref": "#/definitions/B"}
+      ]
+    },
+    "MyObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "foo": {"$ref": "#/definitions/C"}
+      },
+      "required": ["foo"]
+    }
+  }
+}

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -9,8 +9,6 @@ use Helmich\Schema2Class\Command\GenerateCommand;
 use Symfony\Component\Console\Tester\CommandTester;
 use Helmich\Schema2Class\Generator\NamespaceInferrer;
 use Helmich\Schema2Class\Generator\SchemaToClassFactory;
-use Helmich\Schema2Class\Generator\Property\IntersectProperty;
-use Helmich\Schema2Class\Generator\Property\NestedObjectProperty;
 use Helmich\Schema2Class\Spec\SpecificationOptions;
 use Helmich\Schema2Class\Spec\ValidatedSpecificationFilesItem;
 use Helmich\Schema2Class\Writer\DebugWriter;


### PR DESCRIPTION
## Summary
- handle enums in definition reference lookups
- add regression test for enums in definitions
- support PHP 7 by falling back to string values for referenced enums
- add new test fixture for PHP 7 referenced enums

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit --filter testCodeGeneration tests/Generator/SchemaToClassTest.php`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_685947cf2a30832da2127bfdaff526c9