### PR TITLE
Fix full-qualified names in docblocks

### DIFF
--- a/src/Generator/ReferencedTypeClass.php
+++ b/src/Generator/ReferencedTypeClass.php
@@ -27,7 +27,7 @@ readonly class ReferencedTypeClass implements ReferencedType
 
     public function typeAnnotation(GeneratorRequest $req): string
     {
-        return ltrim($this->relativeName($req), '\\');
+        return $this->relativeName($req);
     }
 
     public function typeHint(GeneratorRequest $req): ?string
@@ -47,7 +47,7 @@ readonly class ReferencedTypeClass implements ReferencedType
 
     public function typeAssertionExpr(GeneratorRequest $req, string $expr): string
     {
-        $cls = ltrim($this->relativeName($req), '\\');
+        $cls = $this->relativeName($req);
         return "({$expr}) instanceof {$cls}";
     }
 

--- a/src/Generator/ReferencedTypeEnum.php
+++ b/src/Generator/ReferencedTypeEnum.php
@@ -35,7 +35,7 @@ readonly class ReferencedTypeEnum implements ReferencedType
     public function typeAnnotation(GeneratorRequest $req): string
     {
         if ($this->useNativeEnum($req)) {
-            return ltrim($this->relativeName($req), '\\');
+            return $this->relativeName($req);
         }
 
         $literals = array_map(fn(string|int $v) => var_export($v, true), $this->schema['enum']);
@@ -64,7 +64,7 @@ readonly class ReferencedTypeEnum implements ReferencedType
     public function typeAssertionExpr(GeneratorRequest $req, string $expr): string
     {
         if ($this->useNativeEnum($req)) {
-            return "({$expr}) instanceof " . ltrim($this->relativeName($req), '\\');
+            return "({$expr}) instanceof " . $this->relativeName($req);
         }
 
         $values = var_export($this->schema['enum'], true);
@@ -74,7 +74,7 @@ readonly class ReferencedTypeEnum implements ReferencedType
     public function inputAssertionExpr(GeneratorRequest $req, string $expr): string
     {
         if ($this->useNativeEnum($req)) {
-            return "" . ltrim($this->relativeName($req), '\\') . "::tryFrom({$expr}) !== null";
+            return "" . $this->relativeName($req) . "::tryFrom({$expr}) !== null";
         }
 
         $values = var_export($this->schema['enum'], true);
@@ -84,7 +84,7 @@ readonly class ReferencedTypeEnum implements ReferencedType
     public function inputMappingExpr(GeneratorRequest $req, string $expr, ?string $validateExpr): string
     {
         if ($this->useNativeEnum($req)) {
-            return ltrim($this->relativeName($req), '\\') . "::from({$expr})";
+            return $this->relativeName($req) . "::from({$expr})";
         }
 
         return $expr;

--- a/src/Generator/ReferencedTypeEnum.php
+++ b/src/Generator/ReferencedTypeEnum.php
@@ -6,7 +6,7 @@ readonly class ReferencedTypeEnum implements ReferencedType
 {
     /**
      * @param string $enumName Fully-qualified enum class name
-     * @param array<array-key, string|int> $schema Schema definition of the enum
+     * @param array<array-key, string|int|array> $schema Schema definition of the enum
      */
     public function __construct(private string $enumName, private array $schema)
     {

--- a/tests/Generator/Fixtures/RefList/Output/Foo.php
+++ b/tests/Generator/Fixtures/RefList/Output/Foo.php
@@ -26,12 +26,12 @@ class Foo
     ];
 
     /**
-     * @var Helmich\Schema2Class\Example\CustomerAddress[]|null
+     * @var \Helmich\Schema2Class\Example\CustomerAddress[]|null
      */
     private ?array $foo = null;
 
     /**
-     * @return Helmich\Schema2Class\Example\CustomerAddress[]|null
+     * @return \Helmich\Schema2Class\Example\CustomerAddress[]|null
      */
     public function getFoo() : ?array
     {
@@ -39,7 +39,7 @@ class Foo
     }
 
     /**
-     * @param Helmich\Schema2Class\Example\CustomerAddress[] $foo
+     * @param \Helmich\Schema2Class\Example\CustomerAddress[] $foo
      * @return self
      */
     public function withFoo(array $foo) : self


### PR DESCRIPTION
## Summary
- ensure referenced class names in PHPDoc keep the leading backslash
- update RefList fixture to reflect the new docblock style
- remove trimming of class names when generating runtime assertions and enum helpers

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6859c404b4b4832d8db9e239ccd4fd37