### PR TITLE
Fix class handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,10 @@ You can use this tool in three different ways:
 ### A. Via the CLI, passing options and the schema path directly
 
 ```sh
-vendor/bin/s2c generate:fromschema my-schema.json src/TargetDir   # or ./my-schema.yaml
-# specify the class name explicitly if needed; when omitted it is inferred from
-# the file name if the schema contains a top-level object
-vendor/bin/s2c generate:fromschema --class User my-schema.json src/TargetDir
+vendor/bin/s2c generate:fromschema --class User my-schema.json src/TargetDir   # or ./my-schema.yaml
 
 # On Windows CMD:
-php vendor\bin\s2c generate:fromschema my-schema.json src\TargetDir
+php vendor\bin\s2c generate:fromschema --class User my-schema.json src\TargetDir
 ```
 
 See [all available options](#options).
@@ -109,8 +106,7 @@ $schema = [
     ],
 ];
 
-$generator->generateFromSchema($schema, 'MyDir', 'User', 'MyNamespace');
-// omit the class name only when the schema consists solely of definitions
+$generator->generateFromSchema($schema, 'MyDir', 'MyNamespace', 'MyClass');
 ```
 
 See also the [advanced programmatic usage](#advanced-programmatic-usage) section.
@@ -238,7 +234,7 @@ The generated classes offer:
 - All PHP properties are `private` (unless `--no-getters` is used), with getter methods and explicit return type declarations (PHPDoc for PHP 5 mode).
 - Namespacing: Specify the namespace for all classes with `--target-namespace` (`targetNamespace`). If omitted, the generator inspects your `composer.json` and tries to infer it from the PSR‑4 configuration. If no match is found, the generator falls back to the name of the target directory.
   Generating classes without namespaces is currently not supported.
-  - Class names are derived from the names in the `"definitions"` section. When calling `generate:fromschema` without the `--class` option, the root class name defaults to the schema file's base name **only** if the schema defines a top-level object. Schemas that consist solely of definitions work without a class name.
+- Class names are derived from the names in the `"definitions"` section. If input schema is a top-level object (not `"definitions"`), the class name will be infered from schema file name, unless you set it explicitly with the `--class` (`className`) option.
 - Class/enum names for sub‑objects are derived from property names.
 - Classes generated for array items are suffixed with "Item". See [`Example\Advanced\User::$hobbies`](examples/advanced/generated/User.php#L203).
 - `oneOf`/`anyOf` alternatives are suffixed with "AlternativeX", where _X_ is an incrementing integer. See [`Example\Advanced\User::$payment`](examples/advanced/generated/User.php#L188).

--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ You can use this tool in three different ways:
 ### A. Via the CLI, passing options and the schema path directly
 
 ```sh
-vendor/bin/s2c generate:fromschema --class User my-schema.json src/TargetDir   # or ./my-schema.yaml
+vendor/bin/s2c generate:fromschema my-schema.json src/TargetDir   # or ./my-schema.yaml
+# specify the class name explicitly if needed; when omitted it is inferred from
+# the file name if the schema contains a top-level object
+vendor/bin/s2c generate:fromschema --class User my-schema.json src/TargetDir
 
 # On Windows CMD:
-php vendor\bin\s2c generate:fromschema --class User my-schema.json src\TargetDir
+php vendor\bin\s2c generate:fromschema my-schema.json src\TargetDir
 ```
 
 See [all available options](#options).
@@ -106,7 +109,8 @@ $schema = [
     ],
 ];
 
-$generator->generateFromSchema($schema, 'MyDir', 'MyClass', 'MyNamespace');
+$generator->generateFromSchema($schema, 'MyDir', 'User', 'MyNamespace');
+// omit the class name only when the schema consists solely of definitions
 ```
 
 See also the [advanced programmatic usage](#advanced-programmatic-usage) section.
@@ -234,7 +238,7 @@ The generated classes offer:
 - All PHP properties are `private` (unless `--no-getters` is used), with getter methods and explicit return type declarations (PHPDoc for PHP 5 mode).
 - Namespacing: Specify the namespace for all classes with `--target-namespace` (`targetNamespace`). If omitted, the generator inspects your `composer.json` and tries to infer it from the PSR‑4 configuration. If no match is found, the generator falls back to the name of the target directory.
   Generating classes without namespaces is currently not supported.
-- Class names are derived from the names in the `"definitions"` section. If you generate from a schema with a top-level object and no definitions, set the class name with the `--class` (`className`) option.
+  - Class names are derived from the names in the `"definitions"` section. When calling `generate:fromschema` without the `--class` option, the root class name defaults to the schema file's base name **only** if the schema defines a top-level object. Schemas that consist solely of definitions work without a class name.
 - Class/enum names for sub‑objects are derived from property names.
 - Classes generated for array items are suffixed with "Item". See [`Example\Advanced\User::$hobbies`](examples/advanced/generated/User.php#L203).
 - `oneOf`/`anyOf` alternatives are suffixed with "AlternativeX", where _X_ is an incrementing integer. See [`Example\Advanced\User::$payment`](examples/advanced/generated/User.php#L188).

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -14,6 +14,9 @@ use Helmich\Schema2Class\Spec\SpecificationOptions;
 use Helmich\Schema2Class\Spec\OptionsDefaults;
 use Helmich\Schema2Class\Spec\ValidatedSpecificationFilesItem;
 use Helmich\Schema2Class\Command\GenerateFromRequestTrait;
+use Helmich\Schema2Class\Util\StringUtils;
+use Helmich\Schema2Class\Generator\Property\IntersectProperty;
+use Helmich\Schema2Class\Generator\Property\NestedObjectProperty;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -48,7 +51,7 @@ class GenerateCommand extends Command
         $this->addOption("target-namespace", null, InputOption::VALUE_REQUIRED, "Target namespace (will try to determine automatically from composer.json if omitted)");
         $this->addOption("target-php", "p", InputOption::VALUE_REQUIRED, "Target PHP version");
         $this->addOption("dry-run", null, InputOption::VALUE_NONE, "Print output to console instead of writing to files");
-        $this->addOption("class", "c", InputOption::VALUE_REQUIRED, "Target class name", "Object");
+        $this->addOption("class", "c", InputOption::VALUE_REQUIRED, "Target class name");
         $this->addOption("disable-strict-types", null, InputOption::VALUE_NONE, "Do not emit strict_types declaration");
         $this->addOption("treat-default-as-optional", null, InputOption::VALUE_NONE, "Treat properties with defaults as optional");
         $this->addOption("inline-allof", null, InputOption::VALUE_NONE, "Inline allOf references");
@@ -78,13 +81,20 @@ class GenerateCommand extends Command
         $targetDirectory = $input->getArgument("target-dir");
         /** @var string $targetNamespace */
         $targetNamespace = $input->getOption("target-namespace");
-        /** @var string $class */
+        /** @var string|null $class */
         $class = $input->getOption("class");
         /** @var string|null $targetPHPVersion */
         $targetPHPVersion = $input->getOption("target-php");
 
         $output->writeln("loading schema from <comment>$schemaFile</comment>");
         $schema = $this->loader->loadSchema($schemaFile);
+        $needsClass = IntersectProperty::canHandleSchema($schema)
+            || NestedObjectProperty::canHandleSchema($schema)
+            || array_key_exists('enum', $schema);
+        if ($class === null && $needsClass) {
+            $basename = pathinfo($schemaFile, PATHINFO_FILENAME);
+            $class = StringUtils::pascalCase($basename);
+        }
 
         $targetNamespace = $this->inferNamespace($targetDirectory, $targetNamespace, $output);
 

--- a/src/Generator/Definitions/DefinitionsGenerator.php
+++ b/src/Generator/Definitions/DefinitionsGenerator.php
@@ -65,7 +65,9 @@ class DefinitionsGenerator
             }
             return ltrim($cls, '\\');
         }, $definitions);
-        $generatedClasses[] = $request->getTargetClass();
+        if ($request->getTargetClass() !== null) {
+            $generatedClasses[] = $request->getTargetClass();
+        }
 
         $rootDefinitions = $request->getSchema()['definitions'] ?? [];
 

--- a/src/Generator/GeneratorRequest.php
+++ b/src/Generator/GeneratorRequest.php
@@ -125,7 +125,7 @@ class GeneratorRequest
         return $clone;
     }
 
-    public function withClass(string $targetClass): self
+    public function withClass(?string $targetClass): self
     {
         $clone       = clone $this;
         $clone->spec = $this->spec->withTargetClass($targetClass);
@@ -260,7 +260,7 @@ class GeneratorRequest
     /**
      * @return string
      */
-    public function getTargetClass(): string
+    public function getTargetClass(): ?string
     {
         return $this->spec->getTargetClass();
     }

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -239,7 +239,9 @@ class SchemaToClass
             }
             return ltrim($cls, '\\');
         }, $collected);
-        $generatedClasses[] = $req->getTargetClass();
+        if ($req->getTargetClass() !== null) {
+            $generatedClasses[] = $req->getTargetClass();
+        }
 
         $req = $req
             ->withAdditionalReferenceLookup(new DefinitionsReferenceLookup($collected))

--- a/src/Schema2Class.php
+++ b/src/Schema2Class.php
@@ -81,8 +81,8 @@ class Schema2Class
     public function generateFromSchema(
         array $schema,
         string $targetDirectory,
-        ?string $className = null,
         ?string $targetNamespace = null,
+        ?string $className = null,
         bool $cleanTargetDirectory = false,
         ?SpecificationOptions $options = null,
         ?OutputInterface $output = null,

--- a/src/Schema2Class.php
+++ b/src/Schema2Class.php
@@ -14,6 +14,8 @@ use Helmich\Schema2Class\Spec\OptionsDefaults;
 use Helmich\Schema2Class\Spec\ValidatedSpecificationFilesItem;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Helmich\Schema2Class\Generator\Property\NestedObjectProperty;
+use Helmich\Schema2Class\Generator\Property\IntersectProperty;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -59,6 +61,18 @@ class Schema2Class
     }
 
     /**
+     * Determine if the schema describes a top-level class or enum.
+     *
+     * @param array<string,mixed> $schema
+     */
+    private static function schemaNeedsClass(array $schema): bool
+    {
+        return IntersectProperty::canHandleSchema($schema)
+            || NestedObjectProperty::canHandleSchema($schema)
+            || array_key_exists('enum', $schema);
+    }
+
+    /**
      * Generate classes from a JSON schema that is already parsed into an array.
      *
      * This bypasses reading the schema from disk and can be useful if the
@@ -67,7 +81,7 @@ class Schema2Class
     public function generateFromSchema(
         array $schema,
         string $targetDirectory,
-        string $className,
+        ?string $className = null,
         ?string $targetNamespace = null,
         bool $cleanTargetDirectory = false,
         ?SpecificationOptions $options = null,
@@ -95,6 +109,13 @@ class Schema2Class
             $this->cleanDirectory($targetDirectory, $output);
         }
 
+        if ($className === null) {
+            if (self::schemaNeedsClass($schema)) {
+                throw new \InvalidArgumentException(
+                    'Class name is required when the schema describes a top-level object or enum.'
+                );
+            }
+        }
         $spec = new ValidatedSpecificationFilesItem($targetNamespace, $className, $targetDirectory, $cleanTargetDirectory);
         $req  = new GeneratorRequest($schema, $spec, $options);
 

--- a/src/Spec/ValidatedSpecificationFilesItem.php
+++ b/src/Spec/ValidatedSpecificationFilesItem.php
@@ -6,17 +6,17 @@ namespace Helmich\Schema2Class\Spec;
 class ValidatedSpecificationFilesItem
 {
     private string $targetNamespace;
-    private string $targetClass;
+    private ?string $targetClass;
     private string $targetDirectory;
     private bool $cleanTargetDirectory;
 
     /**
      * ValidatedSpecificationFilesItem constructor.
-     * @param string $targetNamespace
-     * @param string $targetClass
-     * @param string $targetDirectory
+     * @param string      $targetNamespace
+     * @param string|null $targetClass
+     * @param string      $targetDirectory
      */
-    public function __construct(string $targetNamespace, string $targetClass, string $targetDirectory, bool $cleanTargetDirectory = false)
+    public function __construct(string $targetNamespace, ?string $targetClass, string $targetDirectory, bool $cleanTargetDirectory = false)
     {
         $this->targetNamespace = $targetNamespace;
         $this->targetClass     = $targetClass;
@@ -46,9 +46,9 @@ class ValidatedSpecificationFilesItem
     }
 
     /**
-     * @return string
+     * @return non-empty-string|null
      */
-    public function getTargetClass(): string
+    public function getTargetClass(): ?string
     {
         return $this->targetClass;
     }
@@ -66,7 +66,7 @@ class ValidatedSpecificationFilesItem
         return $this->cleanTargetDirectory;
     }
 
-    public function withTargetClass(string $targetClass): self
+    public function withTargetClass(?string $targetClass): self
     {
         $c              = clone $this;
         $c->targetClass = $targetClass;

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -208,4 +208,36 @@ class SchemaToClassTest extends TestCase
         unlink($dir . '/Foo.php');
         rmdir($dir);
     }
+
+    public function testCliInfersClassNameFromFilename(): void
+    {
+        $schemaFile = __DIR__ . '/Fixtures/NoEnums/schema.yaml';
+
+        $dir = sys_get_temp_dir() . '/s2c_' . uniqid();
+        mkdir($dir);
+
+        $command = new GenerateCommand(
+            new SchemaLoader(),
+            new NamespaceInferrer(),
+            new SchemaToClassFactory(),
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'schema' => $schemaFile,
+            'target-dir' => $dir,
+            '--target-namespace' => 'Ns\\NoEnums',
+        ]);
+
+        $file = $dir . '/Schema.php';
+        $this->assertFileExists($file);
+        $content = file_get_contents($file);
+        $this->assertStringContainsString('namespace Ns\\NoEnums;', $content);
+        $this->assertStringContainsString('Schema', $content);
+
+        foreach (glob($dir . '/*.php') as $f) {
+            unlink($f);
+        }
+        rmdir($dir);
+    }
 }

--- a/tests/Schema2Class/Schema2ClassTest.php
+++ b/tests/Schema2Class/Schema2ClassTest.php
@@ -35,6 +35,47 @@ class Schema2ClassTest extends TestCase
         rmdir($dir);
     }
 
+    public function testGenerateFromSchemaRequiresClassNameForObjects(): void
+    {
+        $schema = [
+            'required' => ['name'],
+            'properties' => ['name' => ['type' => 'string']],
+        ];
+
+        $dir = sys_get_temp_dir() . '/s2c_' . uniqid();
+        mkdir($dir);
+
+        $generator = new Schema2Class();
+        $this->expectException(\InvalidArgumentException::class);
+        try {
+            $generator->generateFromSchema($schema, $dir, null, 'My\\Ns');
+        } finally {
+            if (is_file($dir . '/.php')) {
+                unlink($dir . '/.php');
+            }
+            rmdir($dir);
+        }
+    }
+
+    public function testGenerateFromSchemaWithoutClassForDefinitionsOnly(): void
+    {
+        $schemaFile = __DIR__ . '/../Generator/Fixtures/DefinitionsIndependet/schema.json';
+        $schema = json_decode(file_get_contents($schemaFile), true);
+
+        $dir = sys_get_temp_dir() . '/s2c_' . uniqid();
+        mkdir($dir);
+
+        $generator = new Schema2Class();
+        $generator->generateFromSchema($schema, $dir, null, 'Ns\\Defs');
+
+        $this->assertFileExists($dir . '/Foo.php');
+        $this->assertFileExists($dir . '/Bar.php');
+
+        unlink($dir . '/Foo.php');
+        unlink($dir . '/Bar.php');
+        rmdir($dir);
+    }
+
     public function testGenerateFromSpecArrayAcceptsSpecification(): void
     {
         $schemaFile = __DIR__ . '/../Generator/Fixtures/Basic/schema.yaml';

--- a/tests/Schema2Class/Schema2ClassTest.php
+++ b/tests/Schema2Class/Schema2ClassTest.php
@@ -23,7 +23,7 @@ class Schema2ClassTest extends TestCase
         mkdir($dir);
 
         $generator = new Schema2Class();
-        $generator->generateFromSchema($schema, $dir, 'Person', 'My\Ns');
+        $generator->generateFromSchema($schema, $dir, 'My\Ns', 'Person');
 
         $file = $dir . '/Person.php';
         $this->assertFileExists($file);
@@ -48,7 +48,7 @@ class Schema2ClassTest extends TestCase
         $generator = new Schema2Class();
         $this->expectException(\InvalidArgumentException::class);
         try {
-            $generator->generateFromSchema($schema, $dir, null, 'My\\Ns');
+            $generator->generateFromSchema($schema, $dir, 'My\\Ns');
         } finally {
             if (is_file($dir . '/.php')) {
                 unlink($dir . '/.php');
@@ -66,7 +66,7 @@ class Schema2ClassTest extends TestCase
         mkdir($dir);
 
         $generator = new Schema2Class();
-        $generator->generateFromSchema($schema, $dir, null, 'Ns\\Defs');
+        $generator->generateFromSchema($schema, $dir, 'Ns\\Defs');
 
         $this->assertFileExists($dir . '/Foo.php');
         $this->assertFileExists($dir . '/Bar.php');
@@ -122,7 +122,7 @@ class Schema2ClassTest extends TestCase
         file_put_contents($dir . '/Old.php', '<?php');
 
         $generator = new Schema2Class();
-        $generator->generateFromSchema($schema, $dir, 'Person', 'My\\Ns', true);
+        $generator->generateFromSchema($schema, $dir, 'My\\Ns', 'Person', true);
 
         $this->assertFileDoesNotExist($dir . '/Old.php');
 


### PR DESCRIPTION
## Summary
- allow nullable target class in specifications
- determine if the CLI should infer the class name based on the schema
- treat missing class name as `null` when generating from arrays
- document the optional nature of the class name

## Testing
- `./vendor/bin/phpunit`
- `./vendor/bin/phpstan analyse --error-format raw`

------
https://chatgpt.com/codex/tasks/task_e_685e9ff4e958832dbbf4c024d32acfef