### PR TITLE
Support multi-type union arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Now it:
 - Improves camelCase/PascalCase handling when generating identifier names.
 - Omits the default `null` value for properties listed in the `required` schema block.
 - Improves type hints and PHPDoc type generation for complex types like unions, nested arrays, etc.
+- Handles `type` arrays with multiple entries by emitting proper union properties instead of falling back to `mixed`.
 - Adds a guard against passing anything other than an array/object to `buildFromInput`, building multi-line validation error messages.
 - Skips emitting empty `__construct` or `__clone` methods.
 

--- a/src/Generator/PropertyBuilder.php
+++ b/src/Generator/PropertyBuilder.php
@@ -109,6 +109,27 @@ class PropertyBuilder
             }
         }
 
+        // Expand multi-type definitions like ["string", "object"] into a oneOf union
+        if (isset($definition['type']) && is_array($definition['type']) && count($definition['type']) > 1) {
+            $types      = $definition['type'];
+            $subSchemas = [];
+            foreach ($types as $t) {
+                $sub       = $definition;
+                $sub['type'] = $t;
+                // prune object specific fields for non-object arms
+                if ($t !== 'object') {
+                    unset($sub['properties'], $sub['required'], $sub['additionalProperties']);
+                }
+                $subSchemas[] = $sub;
+            }
+
+            $unionDef = $definition;
+            unset($unionDef['type']);
+            $unionDef['oneOf'] = $subSchemas;
+
+            return self::buildPropertyFromSchema($req, $name, $unionDef, $isRequired);
+        }
+
         // Strip out null arms from anyOf/oneOf and wrap the rest as an Optional<…>
         $unionKey = isset($definition['anyOf']) ? 'anyOf'
                 : (isset($definition['oneOf']) ? 'oneOf' : null);

--- a/src/Generator/PropertyBuilder.php
+++ b/src/Generator/PropertyBuilder.php
@@ -109,7 +109,7 @@ class PropertyBuilder
             }
         }
 
-        // Expand multi-type definitions like ["string", "object"] into a oneOf union
+        // Expand multi-type definitions like ["string", "object"] into an anyOf union
         if (isset($definition['type']) && is_array($definition['type']) && count($definition['type']) > 1) {
             $types      = $definition['type'];
             $subSchemas = [];
@@ -125,7 +125,7 @@ class PropertyBuilder
 
             $unionDef = $definition;
             unset($unionDef['type']);
-            $unionDef['oneOf'] = $subSchemas;
+            $unionDef['anyOf'] = $subSchemas;
 
             return self::buildPropertyFromSchema($req, $name, $unionDef, $isRequired);
         }

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output/Foo.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output/Foo.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\TypeArrayUnion;
+
+class Foo
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        'required' => [
+            'input',
+        ],
+        'properties' => [
+            'input' => [
+                'type' => [
+                    'string',
+                    'object',
+                ],
+                'required' => [
+                    'foo',
+                ],
+                'properties' => [
+                    'foo' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * @var string|FooInputAlternative2
+     */
+    private string|FooInputAlternative2 $input;
+
+    /**
+     * @param string|FooInputAlternative2 $input
+     */
+    public function __construct(FooInputAlternative2|string $input)
+    {
+        $this->input = $input;
+    }
+
+    /**
+     * @return string|FooInputAlternative2
+     */
+    public function getInput() : FooInputAlternative2|string
+    {
+        return $this->input;
+    }
+
+    /**
+     * @param string|FooInputAlternative2 $input
+     * @return self
+     */
+    public function withInput(FooInputAlternative2|string $input) : self
+    {
+        $clone = clone $this;
+        $clone->input = $input;
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input2 Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return Foo Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput(array|object $input2, bool $validate = true) : Foo
+    {
+        $input2 = is_array($input2) ? \JsonSchema\Validator::arrayToObjectRecursive($input2) : $input2;
+        if ($validate) {
+            static::validateInput($input2);
+        }
+
+        $input = match (true) {
+            is_string($input2->{'input'}) => $input2->{'input'},
+            FooInputAlternative2::validateInput($input2->{'input'}, true) => FooInputAlternative2::buildFromInput($input2->{'input'}, validate: $validate),
+            default => throw new \InvalidArgumentException("could not build property 'input' from JSON"),
+        };
+
+        $obj = new self($input);
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray() : array
+    {
+        $output = [];
+        $output['input'] = match (true) {
+            is_string($this->input) => $this->input,
+            $this->input instanceof FooInputAlternative2 => ($this->input)->toArray(),
+        };
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+
+    public function __clone()
+    {
+        $this->input = match (true) {
+            is_string($this->input) => $this->input,
+            $this->input instanceof FooInputAlternative2 => clone $this->input,
+        };
+    }
+}

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output/FooInputAlternative2.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output/FooInputAlternative2.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\TypeArrayUnion;
+
+class FooInputAlternative2
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        'type' => 'object',
+        'required' => [
+            'foo',
+        ],
+        'properties' => [
+            'foo' => [
+                'type' => 'string',
+            ],
+        ],
+    ];
+
+    /**
+     * @var string
+     */
+    private string $foo;
+
+    /**
+     * @param string $foo
+     */
+    public function __construct(string $foo)
+    {
+        $this->foo = $foo;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFoo() : string
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @param string $foo
+     * @return self
+     */
+    public function withFoo(string $foo) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($foo, self::$schema['properties']['foo']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->foo = $foo;
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return FooInputAlternative2 Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput(array|object $input, bool $validate = true) : FooInputAlternative2
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $foo = $input->{'foo'};
+
+        $obj = new self($foo);
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray() : array
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/TypeArrayUnion/schema.yaml
+++ b/tests/Generator/Fixtures/TypeArrayUnion/schema.yaml
@@ -1,0 +1,9 @@
+required:
+  - input
+properties:
+  input:
+    type: [string, object]
+    required: [foo]
+    properties:
+      foo:
+        type: string


### PR DESCRIPTION
## Summary
- handle arrays in `type` definitions by expanding them into union properties
- add coverage for multi-type properties
- document the new functionality in the changelog

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68604b61cd44832db8556cfc03fb30ab