### PR TITLE
Handle plain object properties with RawObjectProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@ Now it:
 - Handles `type` arrays with multiple entries by emitting proper union properties instead of falling back to `mixed`.
 - Adds a guard against passing anything other than an array/object to `buildFromInput`, building multi-line validation error messages.
 - Skips emitting empty `__construct` or `__clone` methods.
-- Treats bare `object` properties without defined fields as `mixed` instead of
-  generating empty classes.
+- Treats bare `object` properties without defined fields as `array|object` 
+  instead of `mixed`.
 
 ### Better support for older PHP versions:
 

--- a/src/Generator/Property/RawObjectProperty.php
+++ b/src/Generator/Property/RawObjectProperty.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Generator\Property;
+
+use Composer\Semver\Semver;
+
+/**
+ * Represents an object type without defined properties.
+ */
+class RawObjectProperty extends AbstractProperty
+{
+    use TypeConvert;
+
+    public static function canHandleSchema(array $schema): bool
+    {
+        $isObject = (isset($schema['type']) && $schema['type'] === 'object');
+        $hasProps = isset($schema['properties']) && is_array($schema['properties']) && count($schema['properties']) > 0;
+        $hasAdditional = isset($schema['additionalProperties']);
+
+        return $isObject && !$hasProps && !$hasAdditional;
+    }
+
+    public function typeAnnotation(): string
+    {
+        return 'array|object';
+    }
+
+    public function typeHint(string $phpVersion): ?string
+    {
+        if (Semver::satisfies($phpVersion, '>=8.0')) {
+            return 'array|object';
+        }
+        return null;
+    }
+
+    public function generateTypeAssertionExpr(string $expr): string
+    {
+        return 'is_array(' . $expr . ') || is_object(' . $expr . ')';
+    }
+}

--- a/src/Generator/PropertyBuilder.php
+++ b/src/Generator/PropertyBuilder.php
@@ -22,6 +22,7 @@ use Helmich\Schema2Class\Generator\Property\PrimitiveUnionEnumProperty;
 use Helmich\Schema2Class\Generator\Property\PropertyInterface;
 use Helmich\Schema2Class\Generator\Property\ReferenceArrayProperty;
 use Helmich\Schema2Class\Generator\Property\ReferenceProperty;
+use Helmich\Schema2Class\Generator\Property\RawObjectProperty;
 use Helmich\Schema2Class\Generator\Property\StringEnumProperty;
 use Helmich\Schema2Class\Generator\Property\StringProperty;
 use Helmich\Schema2Class\Generator\Property\UnionProperty;
@@ -46,6 +47,7 @@ class PropertyBuilder
         PrimitiveArrayProperty::class,
         BooleanProperty::class,
         ReferenceProperty::class,
+        RawObjectProperty::class,
         MixedProperty::class,
     ];
 

--- a/src/Spec/SpecificationFilesItem.php
+++ b/src/Spec/SpecificationFilesItem.php
@@ -14,9 +14,9 @@ class SpecificationFilesItem
     private static array $schema = ['properties' => ['input' => ['type' => ['string', 'object']], 'className' => ['type' => 'string'], 'options' => ['$ref' => '#/definitions/SpecificationOptions']], 'additionalProperties' => false, 'required' => ['input'], 'definitions' => ['SpecificationOptions' => ['additionalProperties' => false, 'properties' => ['targetDirectory' => ['type' => 'string'], 'targetNamespace' => ['type' => 'string'], 'targetPHPVersion' => ['oneOf' => [['type' => 'integer', 'enum' => [5, 7, 8]], ['type' => 'string']]], 'cleanTargetDirectory' => ['type' => 'boolean'], 'disableStrictTypes' => ['type' => 'boolean'], 'treatValuesWithDefaultAsOptional' => ['type' => 'boolean'], 'inlineAllofReferences' => ['type' => 'boolean'], 'newValidatorClassExpr' => ['type' => 'string'], 'preservePropertyNames' => ['type' => 'boolean'], 'noGetters' => ['type' => 'boolean'], 'noSetters' => ['type' => 'boolean'], 'noDescriptionsInSchema' => ['type' => 'boolean'], 'singleLineSchema' => ['type' => 'boolean'], 'noEnums' => ['type' => 'boolean']]]]];
 
     /**
-     * @var string|mixed
+     * @var string|array|object
      */
-    private $input;
+    private string|array|object $input;
 
     /**
      * @var string|null
@@ -29,17 +29,17 @@ class SpecificationFilesItem
     private ?SpecificationOptions $options = null;
 
     /**
-     * @param string|mixed $input
+     * @param string|array|object $input
      */
-    public function __construct($input)
+    public function __construct(string|array|object $input)
     {
         $this->input = $input;
     }
 
     /**
-     * @return string|mixed
+     * @return string|array|object
      */
-    public function getInput()
+    public function getInput() : string|array|object
     {
         return $this->input;
     }
@@ -61,10 +61,10 @@ class SpecificationFilesItem
     }
 
     /**
-     * @param string|mixed $input
+     * @param string|array|object $input
      * @return self
      */
-    public function withInput($input) : self
+    public function withInput(string|array|object $input) : self
     {
         $clone = clone $this;
         $clone->input = $input;
@@ -140,7 +140,7 @@ class SpecificationFilesItem
         }
 
         $input = match (true) {
-            is_string($input2->{'input'}), true => $input2->{'input'},
+            is_string($input2->{'input'}), is_array($input2->{'input'}) || is_object($input2->{'input'}) => $input2->{'input'},
             default => throw new \InvalidArgumentException("could not build property 'input' from JSON"),
         };
         $className = isset($input2->{'className'}) ? $input2->{'className'} : null;
@@ -161,7 +161,7 @@ class SpecificationFilesItem
     {
         $output = [];
         $output['input'] = match (true) {
-            is_string($this->input), true => $this->input,
+            is_string($this->input), is_array($this->input) || is_object($this->input) => $this->input,
         };
         if (isset($this->className)) {
             $output['className'] = $this->className;
@@ -200,7 +200,7 @@ class SpecificationFilesItem
     public function __clone()
     {
         $this->input = match (true) {
-            is_string($this->input), true => $this->input,
+            is_string($this->input), is_array($this->input) || is_object($this->input) => $this->input,
         };
     }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output/Foo.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output/Foo.php
@@ -26,9 +26,9 @@ class Foo
     ];
 
     /**
-     * @var mixed
+     * @var array|object
      */
-    private $foo;
+    private array|object $foo;
 
     /**
      * @var string|null
@@ -36,17 +36,17 @@ class Foo
     private ?string $bar = null;
 
     /**
-     * @param mixed $foo
+     * @param array|object $foo
      */
-    public function __construct($foo)
+    public function __construct(array|object $foo)
     {
         $this->foo = $foo;
     }
 
     /**
-     * @return mixed
+     * @return array|object
      */
-    public function getFoo()
+    public function getFoo() : array|object
     {
         return $this->foo;
     }
@@ -60,10 +60,10 @@ class Foo
     }
 
     /**
-     * @param mixed $foo
+     * @param array|object $foo
      * @return self
      */
-    public function withFoo($foo) : self
+    public function withFoo(array|object $foo) : self
     {
         $validator = new \JsonSchema\Validator();
         $validator->validate($foo, self::$schema['properties']['foo']);

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output/Foo.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output/Foo.php
@@ -29,9 +29,9 @@ class Foo
     ];
 
     /**
-     * @var string|mixed
+     * @var string|array|object
      */
-    private $foo;
+    private string|array|object $foo;
 
     /**
      * @var string|null
@@ -39,17 +39,17 @@ class Foo
     private ?string $bar = null;
 
     /**
-     * @param string|mixed $foo
+     * @param string|array|object $foo
      */
-    public function __construct($foo)
+    public function __construct(string|array|object $foo)
     {
         $this->foo = $foo;
     }
 
     /**
-     * @return string|mixed
+     * @return string|array|object
      */
-    public function getFoo()
+    public function getFoo() : string|array|object
     {
         return $this->foo;
     }
@@ -63,10 +63,10 @@ class Foo
     }
 
     /**
-     * @param string|mixed $foo
+     * @param string|array|object $foo
      * @return self
      */
-    public function withFoo($foo) : self
+    public function withFoo(string|array|object $foo) : self
     {
         $clone = clone $this;
         $clone->foo = $foo;
@@ -119,7 +119,7 @@ class Foo
         }
 
         $foo = match (true) {
-            is_string($input->{'foo'}), true => $input->{'foo'},
+            is_string($input->{'foo'}), is_array($input->{'foo'}) || is_object($input->{'foo'}) => $input->{'foo'},
             default => throw new \InvalidArgumentException("could not build property 'foo' from JSON"),
         };
         $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
@@ -138,7 +138,7 @@ class Foo
     {
         $output = [];
         $output['foo'] = match (true) {
-            is_string($this->foo), true => $this->foo,
+            is_string($this->foo), is_array($this->foo) || is_object($this->foo) => $this->foo,
         };
         if (isset($this->bar)) {
             $output['bar'] = $this->bar;
@@ -174,7 +174,7 @@ class Foo
     public function __clone()
     {
         $this->foo = match (true) {
-            is_string($this->foo), true => $this->foo,
+            is_string($this->foo), is_array($this->foo) || is_object($this->foo) => $this->foo,
         };
     }
 }


### PR DESCRIPTION
## Summary
- add `RawObjectProperty` for `object` schemas without fields
- register new property type in `PropertyBuilder`
- update fixtures for `ObjectWithoutProps` and `ObjectWithoutPropsUnion`
- document change in CHANGELOG

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68605d8c30e0832d88f8e38261c5d6bd