### PR TITLE
Fix naming collisions for reserved variables

### DIFF
--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -104,14 +104,9 @@ class Generator
         $optionalProperties = $properties->filter(PropertyCollectionFilterFactory::optional());
 
         $constructorParams = [];
-        $assignments       = [];
-
+        
         foreach ($requiredProperties as $requiredProperty) {
             $constructorParams[] = '$' . $requiredProperty->name();
-        }
-
-        foreach ($optionalProperties as $optionalProperty) {
-            $assignments[] = "\$obj->{$optionalProperty->name()} = \${$optionalProperty->name()};";
         }
 
         $inputVarName = 'input';
@@ -129,8 +124,34 @@ class Generator
             $paramType = "array|object";
         }
 
+        $validateParamName = 'validate';
+        if ($properties->hasPropertyWithName($validateParamName)) {
+            $validateParamName = '_validate';
+            $i = 2;
+            while ($properties->hasPropertyWithName($validateParamName)) {
+                $validateParamName = '_validate' . $i;
+                $i++;
+            }
+        }
+
+        $objVarName = 'obj';
+        if ($properties->hasPropertyWithName($objVarName)) {
+            $objVarName = '_obj';
+            $i = 2;
+            while ($properties->hasPropertyWithName($objVarName)) {
+                $objVarName = '_obj' . $i;
+                $i++;
+            }
+        }
+
+        $assignments = [];
+        foreach ($optionalProperties as $optionalProperty) {
+            $name = $optionalProperty->name();
+            $assignments[] = sprintf('$%s->%s = $%s;', $objVarName, $name, $name);
+        }
+
         $validationParam = new ParameterGenerator(
-            name: "validate",
+            name: $validateParamName,
             type: "bool",
             defaultValue: true,
         );
@@ -140,7 +161,7 @@ class Generator
             null,
             [
                 new ParamTag($inputVarName, ["array|object"], "Input data"),
-                new ParamTag("validate", ["bool"], "Set this to false to skip validation; use at own risk"),
+                new ParamTag($validateParamName, ["bool"], "Set this to false to skip validation; use at own risk"),
                 new ReturnTag([$this->generatorRequest->getTargetClass()], "Created instance"),
                 new ThrowsTag("\\InvalidArgumentException"),
             ]
@@ -157,24 +178,28 @@ class Generator
                 "}\n\n";
         }
             
+        $aliasLine = $validateParamName !== 'validate' ? "\$validate = \${$validateParamName};\n" : '';
+
         $body = $inputGuard .
             // Conversion into object if input is array
             "\$$inputVarName = is_array(\$$inputVarName) ? \\JsonSchema\\Validator::arrayToObjectRecursive(\$$inputVarName) : \$$inputVarName;\n" .
 
             // Conditional schema validation
-            "if (\$validate) {\n" .
+            "if (\${$validateParamName}) {\n" .
             "    static::validateInput(\$$inputVarName);\n" .
             "}\n\n" .
+
+            $aliasLine .
 
             // Property‐by‐property mapping
             $properties->generateInputToTypeConversionCode($inputVarName, object: true) . "\n\n" .
 
             // Construct & assign optional props
-            '$obj = new self(' . join(", ", $constructorParams) . ');' . "\n" .
+            "\${$objVarName} = new self(" . join(", ", $constructorParams) . ");" . "\n" .
             join("\n", $assignments) . "\n" .
 
             // Return
-            'return $obj;'
+            "return \${$objVarName};"
         ;
 
         $method = new MethodGenerator(

--- a/src/Generator/Property/PropertyCollection.php
+++ b/src/Generator/Property/PropertyCollection.php
@@ -47,6 +47,17 @@ class PropertyCollection implements \Iterator
         return false;
     }
 
+    public function hasPropertyWithName(string $name): bool
+    {
+        foreach ($this->properties as $p) {
+            if ($p->name() === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function filter(PropertyCollectionFilter $filter): PropertyCollection
     {
         $matching = [];

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -206,7 +206,8 @@ class SchemaToClass
      */
     private function ensureUniquePropertyNames(PropertyCollection $properties): void
     {
-        $used = [];
+        // Reserved variable names that should never be used for properties
+        $used = ['GLOBALS', 'validate', 'obj', 'validator', 'clone'];
         foreach ($properties as $property) {
             $base = $property->name();
             $unique = $base;

--- a/tests/Generator/Fixtures/FallbackNaming/Output/Foo.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output/Foo.php
@@ -78,12 +78,12 @@ class Foo
     /**
      * @var string
      */
-    private string $validate;
+    private string $validate_1;
 
     /**
      * @var string
      */
-    private string $obj;
+    private string $obj_1;
 
     /**
      * @var string
@@ -128,17 +128,17 @@ class Foo
     /**
      * @var string
      */
-    private string $GLOBALS;
+    private string $GLOBALS_1;
 
     /**
      * @var string
      */
-    private string $GLOBALS_1;
+    private string $GLOBALS_2;
 
     /**
      * @param string $input
-     * @param string $validate
-     * @param string $obj
+     * @param string $validate_1
+     * @param string $obj_1
      * @param string $POST
      * @param string $GET
      * @param string $REQUEST
@@ -147,14 +147,14 @@ class Foo
      * @param string $SESSION
      * @param string $FILES
      * @param string $ENV
-     * @param string $GLOBALS
      * @param string $GLOBALS_1
+     * @param string $GLOBALS_2
      */
-    public function __construct(string $input, string $validate, string $obj, string $POST, string $GET, string $REQUEST, string $SERVER, string $COOKIE, string $SESSION, string $FILES, string $ENV, string $GLOBALS, string $GLOBALS_1)
+    public function __construct(string $input, string $validate_1, string $obj_1, string $POST, string $GET, string $REQUEST, string $SERVER, string $COOKIE, string $SESSION, string $FILES, string $ENV, string $GLOBALS_1, string $GLOBALS_2)
     {
         $this->input = $input;
-        $this->validate = $validate;
-        $this->obj = $obj;
+        $this->validate_1 = $validate_1;
+        $this->obj_1 = $obj_1;
         $this->POST = $POST;
         $this->GET = $GET;
         $this->REQUEST = $REQUEST;
@@ -163,8 +163,8 @@ class Foo
         $this->SESSION = $SESSION;
         $this->FILES = $FILES;
         $this->ENV = $ENV;
-        $this->GLOBALS = $GLOBALS;
         $this->GLOBALS_1 = $GLOBALS_1;
+        $this->GLOBALS_2 = $GLOBALS_2;
     }
 
     /**
@@ -178,17 +178,17 @@ class Foo
     /**
      * @return string
      */
-    public function getValidate() : string
+    public function getValidate1() : string
     {
-        return $this->validate;
+        return $this->validate_1;
     }
 
     /**
      * @return string
      */
-    public function getObj() : string
+    public function getObj1() : string
     {
-        return $this->obj;
+        return $this->obj_1;
     }
 
     /**
@@ -258,17 +258,17 @@ class Foo
     /**
      * @return string
      */
-    public function getGLOBALS() : string
+    public function getGLOBALS1() : string
     {
-        return $this->GLOBALS;
+        return $this->GLOBALS_1;
     }
 
     /**
      * @return string
      */
-    public function getGLOBALS1() : string
+    public function getGLOBALS2() : string
     {
-        return $this->GLOBALS_1;
+        return $this->GLOBALS_2;
     }
 
     /**
@@ -290,37 +290,37 @@ class Foo
     }
 
     /**
-     * @param string $validate
+     * @param string $validate_1
      * @return self
      */
-    public function withValidate(string $validate) : self
+    public function withValidate1(string $validate_1) : self
     {
         $validator = new \JsonSchema\Validator();
-        $validator->validate($validate, self::$schema['properties']['validate']);
+        $validator->validate($validate_1, self::$schema['properties']['validate']);
         if (!$validator->isValid()) {
             throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
         }
 
         $clone = clone $this;
-        $clone->validate = $validate;
+        $clone->validate_1 = $validate_1;
 
         return $clone;
     }
 
     /**
-     * @param string $obj
+     * @param string $obj_1
      * @return self
      */
-    public function withObj(string $obj) : self
+    public function withObj1(string $obj_1) : self
     {
         $validator = new \JsonSchema\Validator();
-        $validator->validate($obj, self::$schema['properties']['obj']);
+        $validator->validate($obj_1, self::$schema['properties']['obj']);
         if (!$validator->isValid()) {
             throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
         }
 
         $clone = clone $this;
-        $clone->obj = $obj;
+        $clone->obj_1 = $obj_1;
 
         return $clone;
     }
@@ -470,37 +470,37 @@ class Foo
     }
 
     /**
-     * @param string $GLOBALS
-     * @return self
-     */
-    public function withGLOBALS(string $GLOBALS) : self
-    {
-        $validator = new \JsonSchema\Validator();
-        $validator->validate($GLOBALS, self::$schema['properties']['_GLOBALS']);
-        if (!$validator->isValid()) {
-            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-        }
-
-        $clone = clone $this;
-        $clone->GLOBALS = $GLOBALS;
-
-        return $clone;
-    }
-
-    /**
      * @param string $GLOBALS_1
      * @return self
      */
     public function withGLOBALS1(string $GLOBALS_1) : self
     {
         $validator = new \JsonSchema\Validator();
-        $validator->validate($GLOBALS_1, self::$schema['properties']['GLOBALS']);
+        $validator->validate($GLOBALS_1, self::$schema['properties']['_GLOBALS']);
         if (!$validator->isValid()) {
             throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
         }
 
         $clone = clone $this;
         $clone->GLOBALS_1 = $GLOBALS_1;
+
+        return $clone;
+    }
+
+    /**
+     * @param string $GLOBALS_2
+     * @return self
+     */
+    public function withGLOBALS2(string $GLOBALS_2) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($GLOBALS_2, self::$schema['properties']['GLOBALS']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->GLOBALS_2 = $GLOBALS_2;
 
         return $clone;
     }
@@ -521,8 +521,8 @@ class Foo
         }
 
         $input = $_input->{'input'};
-        $validate = $_input->{'validate'};
-        $obj = $_input->{'obj'};
+        $validate_1 = $_input->{'validate'};
+        $obj_1 = $_input->{'obj'};
         $POST = $_input->{'_POST'};
         $GET = $_input->{'_GET'};
         $REQUEST = $_input->{'_REQUEST'};
@@ -531,10 +531,10 @@ class Foo
         $SESSION = $_input->{'_SESSION'};
         $FILES = $_input->{'_FILES'};
         $ENV = $_input->{'_ENV'};
-        $GLOBALS = $_input->{'_GLOBALS'};
-        $GLOBALS_1 = $_input->{'GLOBALS'};
+        $GLOBALS_1 = $_input->{'_GLOBALS'};
+        $GLOBALS_2 = $_input->{'GLOBALS'};
 
-        $obj = new self($input, $validate, $obj, $POST, $GET, $REQUEST, $SERVER, $COOKIE, $SESSION, $FILES, $ENV, $GLOBALS, $GLOBALS_1);
+        $obj = new self($input, $validate_1, $obj_1, $POST, $GET, $REQUEST, $SERVER, $COOKIE, $SESSION, $FILES, $ENV, $GLOBALS_1, $GLOBALS_2);
 
         return $obj;
     }
@@ -548,8 +548,8 @@ class Foo
     {
         $output = [];
         $output['input'] = $this->input;
-        $output['validate'] = $this->validate;
-        $output['obj'] = $this->obj;
+        $output['validate'] = $this->validate_1;
+        $output['obj'] = $this->obj_1;
         $output['_POST'] = $this->POST;
         $output['_GET'] = $this->GET;
         $output['_REQUEST'] = $this->REQUEST;
@@ -558,8 +558,8 @@ class Foo
         $output['_SESSION'] = $this->SESSION;
         $output['_FILES'] = $this->FILES;
         $output['_ENV'] = $this->ENV;
-        $output['_GLOBALS'] = $this->GLOBALS;
-        $output['GLOBALS'] = $this->GLOBALS_1;
+        $output['_GLOBALS'] = $this->GLOBALS_1;
+        $output['GLOBALS'] = $this->GLOBALS_2;
 
         return $output;
     }


### PR DESCRIPTION
## Summary
- avoid property names conflicting with reserved variables like `$GLOBALS`, `$validate` or `$obj`
- adjust build method to use dynamic parameter names and object variable names
- update the fallback naming fixture accordingly

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6863021f8cfc832d926d64da856c6767