### PR TITLE
Improve notice for skipped non-object definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Now it:
 - Adds a guard against passing anything other than an array/object to `buildFromInput`, building multi-line validation error messages.
 - Setter methods (`withX()`) now accept an optional `$validate` argument to be able skip validation, mirroring `buildFromInput()`.
 - Skips emitting empty `__construct` or `__clone` methods.
+- Prints a notice when skipping `definitions` that do not describe an object.
 
 ### Better support for older PHP versions:
 

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -29,6 +29,7 @@ class SchemaToClass
 {
     private WriterInterface $writer;
     private SchemaToEnum $enumGenerator;
+    private OutputInterface $output;
 
     /**
      * @phpstan-ignore constructor.unusedParameter (kept for backwards compatibility)
@@ -37,6 +38,7 @@ class SchemaToClass
     {
         $this->writer = $writer;
         $this->enumGenerator = new SchemaToEnum($writer);
+        $this->output = $output;
     }
 
     /**
@@ -77,6 +79,10 @@ class SchemaToClass
             $schema = (new IntersectProperty($req->getTargetClass(), $schema, $req))->buildSchemaIntersect();
         } elseif (!NestedObjectProperty::canHandleSchema($schema)) {
             // If the schema does not describe an object we only generate definitions
+            $class = $req->getTargetClass();
+            if ($class !== null) {
+                $this->output->writeln("skipping <comment>{$class}</comment> – definition is not an object");
+            }
             return;
         }
 

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -7,6 +7,7 @@ use Helmich\Schema2Class\Example\CustomerAddress; // ← necessary for 'RefList'
 use Helmich\Schema2Class\Loader\SchemaLoader;
 use Helmich\Schema2Class\Command\GenerateCommand;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Helmich\Schema2Class\Generator\SchemaToClassFactory;
 use Helmich\Schema2Class\Spec\SpecificationOptions;
 use Helmich\Schema2Class\Spec\ValidatedSpecificationFilesItem;
@@ -230,5 +231,25 @@ class SchemaToClassTest extends TestCase
             unlink($f);
         }
         rmdir($dir);
+    }
+
+    public function testSkipsNonObjectDefinitionsWithNotice(): void
+    {
+        $schemaFile = __DIR__ . '/Fixtures/NonObjectDefs/schema.json';
+        $schema = (new SchemaLoader())->loadSchema($schemaFile);
+
+        $req = new GeneratorRequest(
+            $schema,
+            new ValidatedSpecificationFilesItem('Ns\\NonObjectDefs', null, __DIR__),
+            (new SpecificationOptions())->withTargetPHPVersion('8.2'),
+        );
+
+        $output = new BufferedOutput();
+        $writer = new DebugWriter($output);
+        $factory = new SchemaToClassFactory();
+
+        $factory->build($writer, $output)->schemaToClass($req);
+
+        $this->assertStringContainsString('skipping SkippedDef5', $output->fetch());
     }
 }


### PR DESCRIPTION
## Summary
- store OutputInterface in `SchemaToClass`
- print a notice when skipping definitions that are not objects
- cover the new behaviour with a unit test
- document the change in CHANGELOG

## Testing
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6867bf8c5d2c832d99611717a13895e3