### PR TITLE
Fix validation schema references for nested types

### DIFF
--- a/src/Generator/Property/IntersectProperty.php
+++ b/src/Generator/Property/IntersectProperty.php
@@ -28,10 +28,16 @@ class IntersectProperty extends AbstractProperty
         $propertyTypeName = $this->subTypeName();
         $combined = $this->buildSchemaIntersect();
 
+        $rootDefs = $this->generatorRequest->getRootDefinitions();
+        if ($rootDefs === null) {
+            $rootDefs = $this->generatorRequest->getSchema()['definitions'] ?? [];
+        }
+
         $generator->schemaToClass(
             $this->generatorRequest
                 ->withSchema($combined)
                 ->withClass($propertyTypeName)
+                ->withRootDefinitions($rootDefs)
         );
     }
 

--- a/src/Generator/Property/NestedObjectProperty.php
+++ b/src/Generator/Property/NestedObjectProperty.php
@@ -29,10 +29,16 @@ class NestedObjectProperty extends AbstractProperty
      */
     public function generateSubTypes(SchemaToClass $generator): void
     {
+        $rootDefs = $this->generatorRequest->getRootDefinitions();
+        if ($rootDefs === null) {
+            $rootDefs = $this->generatorRequest->getSchema()['definitions'] ?? [];
+        }
+
         $generator->schemaToClass(
             $this->generatorRequest
                 ->withSchema($this->schema)
                 ->withClass($this->subTypeName())
+                ->withRootDefinitions($rootDefs)
         );
     }
 

--- a/src/Generator/Property/ObjectArrayProperty.php
+++ b/src/Generator/Property/ObjectArrayProperty.php
@@ -87,8 +87,16 @@ class ObjectArrayProperty extends AbstractProperty
             return;
         }
 
+        $rootDefs = $this->generatorRequest->getRootDefinitions();
+        if ($rootDefs === null) {
+            $rootDefs = $this->generatorRequest->getSchema()['definitions'] ?? [];
+        }
+
         $generator->schemaToClass(
-            $this->generatorRequest->withSchema($this->itemSchema)->withClass($this->subTypeName())
+            $this->generatorRequest
+                ->withSchema($this->itemSchema)
+                ->withClass($this->subTypeName())
+                ->withRootDefinitions($rootDefs)
         );
     }
 

--- a/src/Generator/Property/UnionProperty.php
+++ b/src/Generator/Property/UnionProperty.php
@@ -209,10 +209,16 @@ class UnionProperty extends AbstractProperty
             $isEnum   = isset($subDef["enum"]);
 
             if ($isObject || $isEnum) {
+                $rootDefs = $this->generatorRequest->getRootDefinitions();
+                if ($rootDefs === null) {
+                    $rootDefs = $this->generatorRequest->getSchema()['definitions'] ?? [];
+                }
+
                 $generator->schemaToClass(
                     $this->generatorRequest
                         ->withSchema($subDef)
                         ->withClass($propertyTypeName)
+                        ->withRootDefinitions($rootDefs)
                 );
             }
         }

--- a/tests/Generator/Fixtures/MisteriousIssue/Output/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/MisteriousIssue/Output/MyClassFilesItem.php
@@ -20,6 +20,15 @@ class MyClassFilesItem
                 '$ref' => '#/definitions/OptionsObject',
             ],
         ],
+        'definitions' => [
+            'OptionsObject' => [
+                'properties' => [
+                    'output' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+        ],
     ];
 
     /**


### PR DESCRIPTION
## Summary
- embed root `definitions` when generating nested object types
- regenerate snapshot for `MisteriousIssue`

## Testing
- `vendor/bin/phpunit --filter MisteriousIssue`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6867dcdd8a28832daaf19c17740201fc