### PR TITLE
Fix unresolved schema refs for nested objects

### DIFF
--- a/src/Generator/Property/NestedObjectProperty.php
+++ b/src/Generator/Property/NestedObjectProperty.php
@@ -29,11 +29,16 @@ class NestedObjectProperty extends AbstractProperty
      */
     public function generateSubTypes(SchemaToClass $generator): void
     {
-        $generator->schemaToClass(
-            $this->generatorRequest
-                ->withSchema($this->schema)
-                ->withClass($this->subTypeName())
-        );
+        $req = $this->generatorRequest
+            ->withSchema($this->schema)
+            ->withClass($this->subTypeName());
+
+        $rootDefs = $this->generatorRequest->getRootDefinitions();
+        if ($rootDefs !== null) {
+            $req = $req->withRootDefinitions($rootDefs);
+        }
+
+        $generator->schemaToClass($req);
     }
 
     public function typeAnnotation(): string

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -57,6 +57,13 @@ class SchemaToClass
                 $schema['definitions'] = array_replace($defs, $schema['definitions']);
             }
         }
+        // 2b) otherwise, if this schema has definitions, remember them for nested types
+        elseif (isset($schema['definitions']) || isset($schema['$defs'])) {
+            $req = $req->withRootDefinitions(array_merge(
+                $schema['definitions'] ?? [],
+                $schema['$defs'] ?? [],
+            ));
+        }
 
         // dereference schemas that consist only of a reference
         if (isset($schema['$ref'])) {

--- a/tests/Generator/Fixtures/MisteriousIssue/Output/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/MisteriousIssue/Output/MyClassFilesItem.php
@@ -20,6 +20,15 @@ class MyClassFilesItem
                 '$ref' => '#/definitions/OptionsObject',
             ],
         ],
+        'definitions' => [
+            'OptionsObject' => [
+                'properties' => [
+                    'output' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+        ],
     ];
 
     /**


### PR DESCRIPTION
## Summary
- carry root definitions to nested objects
- remember definitions from the current schema when generating nested types
- update test fixture for "MisteriousIssue"

## Testing
- `vendor/bin/phpunit --filter MisteriousIssue`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6867dcdd8a28832daaf19c17740201fc