### PR TITLE
Handle mixed int/string enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Now it:
 ### Enums
 
 - Laminas's immutable EnumGenerator replaced with own mutable implementation PhpParserEnumGenerator built on nikic/php-parser which allows modifications via the hook system.
+- Mixed int/string enum values are now skipped instead of raising an error.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Now it:
 ### Enums
 
 - Laminas's immutable EnumGenerator replaced with own mutable implementation PhpParserEnumGenerator built on nikic/php-parser which allows modifications via the hook system.
-- Mixed int/string enum values are now skipped instead of raising an error.
+- Mixed int/string enum values are now skipped with fallback to type hints instead of raising an error.
 
 ### Documentation
 

--- a/src/Generator/ReferencedTypeEnum.php
+++ b/src/Generator/ReferencedTypeEnum.php
@@ -2,6 +2,8 @@
 
 namespace Helmich\Schema2Class\Generator;
 
+use Helmich\Schema2Class\Generator\SchemaToEnum;
+
 readonly class ReferencedTypeEnum implements ReferencedType
 {
     /**
@@ -14,7 +16,7 @@ readonly class ReferencedTypeEnum implements ReferencedType
 
     private function useNativeEnum(GeneratorRequest $req): bool
     {
-        return $req->isAtLeastPHP('8.1') && !$req->getNoEnums();
+        return SchemaToEnum::canGenerateEnum($this->schema, $req);
     }
 
     private function relativeName(GeneratorRequest $req): string
@@ -48,7 +50,18 @@ readonly class ReferencedTypeEnum implements ReferencedType
             return $this->relativeName($req);
         }
 
-        return is_int($this->schema['enum'][0]) ? 'int' : 'string';
+        $hasInt = false;
+        $hasString = false;
+        foreach ($this->schema['enum'] as $v) {
+            $hasInt = $hasInt || is_int($v);
+            $hasString = $hasString || is_string($v);
+        }
+
+        if ($hasInt && $hasString) {
+            return $req->isAtLeastPHP('8.0') ? 'int|string' : null;
+        }
+
+        return $hasInt ? 'int' : 'string';
     }
 
     function serializedInputTypeHint(GeneratorRequest $req): ?string

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -8,6 +8,7 @@ use Helmich\Schema2Class\Codegen\PropertyGenerator;
 use Helmich\Schema2Class\Generator\Definitions\DefinitionsCollector;
 use Helmich\Schema2Class\Generator\Definitions\DefinitionsGenerator;
 use Helmich\Schema2Class\Generator\DefinitionsReferenceLookup;
+use Helmich\Schema2Class\Generator\SchemaToEnum;
 use Helmich\Schema2Class\Generator\Property\IntersectProperty;
 use Helmich\Schema2Class\Generator\Property\NestedObjectProperty;
 use Helmich\Schema2Class\Generator\Property\PropertyCollection;
@@ -67,8 +68,10 @@ class SchemaToClass
         $this->definitionsToSchemas($req);
         $schema = $req->getSchema();
 
-        if (isset($schema["enum"]) && $req->isAtLeastPHP("8.1") && !$req->getNoEnums()) {
-            $this->enumGenerator->schemaToEnum($req);
+        if (isset($schema["enum"])) {
+            if (SchemaToEnum::canGenerateEnum($schema, $req)) {
+                $this->enumGenerator->schemaToEnum($req);
+            }
             return;
         }
 

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -72,6 +72,12 @@ class SchemaToClass
             if (SchemaToEnum::canGenerateEnum($schema, $req)) {
                 $this->enumGenerator->schemaToEnum($req);
             }
+
+            $class = $req->getTargetClass();
+            if ($class !== null) {
+                $this->output->writeln("skipping generation of enum <comment>{$class}</comment>");
+            }
+
             return;
         }
 
@@ -81,7 +87,7 @@ class SchemaToClass
             // If the schema does not describe an object we only generate definitions
             $class = $req->getTargetClass();
             if ($class !== null) {
-                $this->output->writeln("skipping definition <comment>{$class}</comment>: not an object");
+                $this->output->writeln("skipping generation of <comment>{$class}</comment>");
             }
             return;
         }

--- a/src/Generator/SchemaToEnum.php
+++ b/src/Generator/SchemaToEnum.php
@@ -15,10 +15,38 @@ class SchemaToEnum
         $this->writer = $writer;
     }
 
+    /**
+     * Checks if a schema can be represented as a native PHP enum.
+     *
+     * @param array $schema
+     */
+    public static function canGenerateEnum(array $schema, GeneratorRequest $req): bool
+    {
+        if (!$req->isAtLeastPHP('8.1') || $req->getNoEnums()) {
+            return false;
+        }
+
+        $hasInt = false;
+        $hasString = false;
+        foreach ($schema['enum'] as $case) {
+            if (!is_int($case) && !is_string($case)) {
+                return false;
+            }
+            $hasInt = $hasInt || is_int($case);
+            $hasString = $hasString || is_string($case);
+        }
+
+        return !($hasInt && $hasString);
+    }
+
     public function schemaToEnum(GeneratorRequest $req): void
     {
-        if (!$req->isAtLeastPHP("8.1")) {
-            throw new GeneratorException("cannot generate enum classes for PHP versions < 8.1");
+        if (!$req->isAtLeastPHP('8.1')) {
+            throw new GeneratorException('cannot generate enum classes for PHP versions < 8.1');
+        }
+
+        if (!self::canGenerateEnum($req->getSchema(), $req)) {
+            throw new GeneratorException("cannot generate enum classes for mixed int/string enum values");
         }
 
         /** @var array<non-empty-string, string|int> $cases */
@@ -44,10 +72,6 @@ class SchemaToEnum
             }
 
             $cases[$name] = $case;
-        }
-
-        if ($hasInt && $hasString) {
-            throw new GeneratorException("cannot generate enum classes for mixed int/string enum values");
         }
 
         $cases = self::makeCaseNamesConsistent($cases);

--- a/src/Generator/SchemaToEnum.php
+++ b/src/Generator/SchemaToEnum.php
@@ -22,12 +22,14 @@ class SchemaToEnum
      */
     public static function canGenerateEnum(array $schema, GeneratorRequest $req): bool
     {
-        if (!$req->isAtLeastPHP('8.1') || $req->getNoEnums()) {
-            return false;
-        }
+        return !self::areEnumsDisabled($req) && !self::isMixedEnum($schema);
+    }
 
+    static public function isMixedEnum(array $schema): bool
+    {
         $hasInt = false;
         $hasString = false;
+
         foreach ($schema['enum'] as $case) {
             if (!is_int($case) && !is_string($case)) {
                 return false;
@@ -36,7 +38,12 @@ class SchemaToEnum
             $hasString = $hasString || is_string($case);
         }
 
-        return !($hasInt && $hasString);
+        return $hasInt && $hasString;
+    }
+
+    public static function areEnumsDisabled(GeneratorRequest $req): bool
+    {
+        return !$req->isAtLeastPHP('8.1') || $req->getNoEnums();
     }
 
     public function schemaToEnum(GeneratorRequest $req): void

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output/Foo.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\DefinitionsMixedEnum;
+
+class Foo
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        'type' => 'object',
+        'additionalProperties' => false,
+        'properties' => [
+            'val' => [
+                '$ref' => '#/definitions/Mixed',
+            ],
+        ],
+        'required' => [
+            'val',
+        ],
+        'definitions' => [
+            'Mixed' => [
+                'enum' => [
+                    5,
+                    6,
+                    '5',
+                    '6',
+                ],
+                'type' => [
+                    'integer',
+                    'string',
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * @var 5|6|'5'|'6'
+     */
+    private int|string $val;
+
+    /**
+     * @param 5|6|'5'|'6' $val
+     */
+    public function __construct(int|string $val)
+    {
+        $this->val = $val;
+    }
+
+    /**
+     * @return 5|6|'5'|'6'
+     */
+    public function getVal() : int|string
+    {
+        return $this->val;
+    }
+
+    /**
+     * @param 5|6|'5'|'6' $val
+     * @return self
+     * @param bool $validate
+     */
+    public function withVal(int|string $val, bool $validate = true) : self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($val, self::$schema['properties']['val']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->val = $val;
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return Foo Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $val = $input->{'val'};
+
+        $obj = new self($val);
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray() : array
+    {
+        $output = [];
+        $output['val'] = $this->val;
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}
+

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output/Foo.php
@@ -139,4 +139,3 @@ class Foo
         return $validator->isValid();
     }
 }
-

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/schema.yaml
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/schema.yaml
@@ -1,0 +1,11 @@
+definitions:
+  Mixed:
+    enum: [5, 6, "5", "6"]
+    type: [integer, string]
+  Foo:
+    type: object
+    additionalProperties: false
+    properties:
+      val:
+        $ref: '#/definitions/Mixed'
+    required: [val]

--- a/tests/Generator/Fixtures/MixedEnum/schema.yaml
+++ b/tests/Generator/Fixtures/MixedEnum/schema.yaml
@@ -1,0 +1,6 @@
+enum:
+  - 5
+  - 6
+  - "5"
+  - "6"
+type: [integer, string]

--- a/tests/Generator/Fixtures/RootNotObject/schema.yaml
+++ b/tests/Generator/Fixtures/RootNotObject/schema.yaml
@@ -1,0 +1,1 @@
+type: string

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -289,6 +289,6 @@ class SchemaToClassTest extends TestCase
 
         $factory->build($writer, $output)->schemaToClass($req);
 
-        $this->assertStringContainsString('skipping definition SkippedDef5', $output->fetch());
+        $this->assertStringContainsString('skipping generation of SkippedDef5', $output->fetch());
     }
 }

--- a/tests/Generator/SchemaToEnumTest.php
+++ b/tests/Generator/SchemaToEnumTest.php
@@ -12,7 +12,7 @@ use function PHPUnit\Framework\assertStringContainsString;
 
 class SchemaToEnumTest extends TestCase
 {
-    public function testMixedEnumTypesThrows(): void
+    public function testMixedEnumTypesAreSkipped(): void
     {
         $schema = [
             'enum' => [1, '1', 2, 'two'],
@@ -28,8 +28,8 @@ class SchemaToEnumTest extends TestCase
         $writer = new DebugWriter(new NullOutput());
         $generator = new SchemaToClassFactory();
 
-        $this->expectException(GeneratorException::class);
         $generator->build($writer, new NullOutput())->schemaToClass($req);
+        $this->assertCount(0, $writer->getWrittenFiles());
     }
 
     public function testEnumCustomizationHook(): void


### PR DESCRIPTION
## Summary
- support enums that mix int and string values by disabling enum generation
- adjust generator to check for mixed enum values
- use union type hints for mixed enums referenced in properties
- add tests & fixtures for mixed enums
- update changelog

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6867e91493bc832d9f09070da45bf781