### PR TITLE
Add PHP syntax check for generated files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Now it:
 - Setter methods (`withX()`) now accept an optional `$validate` argument to be able skip validation, mirroring `buildFromInput()`.
 - Skips emitting empty `__construct` or `__clone` methods.
 - Prints a notice when skipping `definitions` that do not describe an object.
+- Validates written files with `php -l` to ensure generated code is syntactically correct.
 
 ### Better support for older PHP versions:
 

--- a/src/Generator/GenerationRunner.php
+++ b/src/Generator/GenerationRunner.php
@@ -52,7 +52,13 @@ class GenerationRunner
 
     private function makeWriter(OutputInterface $output, bool $dryRun): WriterInterface
     {
-        return $dryRun ? new DebugWriter($output) : new FileWriter($output);
+        $writer = $dryRun ? new DebugWriter($output) : new FileWriter($output);
+
+        if (!$dryRun) {
+            $writer = new \Helmich\Schema2Class\Writer\LintingWriter($writer);
+        }
+
+        return $writer;
     }
 
     public function cleanDirectory(string $directory, OutputInterface $output): void

--- a/src/Writer/LintingWriter.php
+++ b/src/Writer/LintingWriter.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Writer;
+
+use RuntimeException;
+
+/**
+ * Decorator writer that runs a PHP syntax check on the written file.
+ */
+class LintingWriter implements WriterInterface
+{
+    private WriterInterface $inner;
+
+    public function __construct(WriterInterface $inner)
+    {
+        $this->inner = $inner;
+    }
+
+    public function writeFile(string $filename, string $contents): void
+    {
+        $this->inner->writeFile($filename, $contents);
+
+        $output = [];
+        $result = 0;
+        exec(PHP_BINARY . ' -l ' . escapeshellarg($filename) . ' 2>&1', $output, $result);
+        if ($result !== 0) {
+            throw new RuntimeException(
+                sprintf("Generated file %s contains syntax errors:\n%s", $filename, implode("\n", $output))
+            );
+        }
+    }
+}

--- a/src/Writer/LintingWriter.php
+++ b/src/Writer/LintingWriter.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace Helmich\Schema2Class\Writer;
 
-use RuntimeException;
-
 /**
  * Decorator writer that runs a PHP syntax check on the written file.
  */
@@ -17,6 +15,9 @@ class LintingWriter implements WriterInterface
         $this->inner = $inner;
     }
 
+    /** 
+     * @throws \RuntimeException if written file contents is not valid PHP
+     */
     public function writeFile(string $filename, string $contents): void
     {
         $this->inner->writeFile($filename, $contents);
@@ -25,7 +26,7 @@ class LintingWriter implements WriterInterface
         $result = 0;
         exec(PHP_BINARY . ' -l ' . escapeshellarg($filename) . ' 2>&1', $output, $result);
         if ($result !== 0) {
-            throw new RuntimeException(
+            throw new \RuntimeException(
                 sprintf("Generated file %s contains syntax errors:\n%s", $filename, implode("\n", $output))
             );
         }

--- a/tests/Writer/LintingWriterTest.php
+++ b/tests/Writer/LintingWriterTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Writer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
+
+class LintingWriterTest extends TestCase
+{
+    public function testThrowsExceptionOnInvalidPhp(): void
+    {
+        $dir = sys_get_temp_dir() . '/s2c_' . uniqid();
+        mkdir($dir);
+        $file = $dir . '/Invalid.php';
+
+        $writer = new LintingWriter(new FileWriter(new NullOutput()));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/syntax errors/');
+
+        try {
+            $writer->writeFile($file, "<?php invalid php");
+        } finally {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+            rmdir($dir);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- run a lint check after writing each file
- add a LintingWriter decorator
- keep empty output folders for some fixtures
- document the new lint step in the changelog

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686801bc0d6c832d8da9fe25b5153578