### PR TITLE
Handle schemas with top-level $ref

### DIFF
--- a/src/Generator/GenerationRunner.php
+++ b/src/Generator/GenerationRunner.php
@@ -33,8 +33,34 @@ class GenerationRunner
      *
      * @param array<string,mixed> $schema
      */
+    private static function dereference(array $schema, string $ref): ?array
+    {
+        if (!str_starts_with($ref, '#/')) {
+            return null;
+        }
+
+        $segments = explode('/', substr($ref, 2));
+        $node = $schema;
+
+        foreach ($segments as $seg) {
+            if (!is_array($node) || !array_key_exists($seg, $node)) {
+                return null;
+            }
+            $node = $node[$seg];
+        }
+
+        return is_array($node) ? $node : null;
+    }
+
     private static function schemaNeedsClass(array $schema): bool
     {
+        if (isset($schema['$ref']) && is_string($schema['$ref'])) {
+            $resolved = self::dereference($schema, $schema['$ref']);
+            if (is_array($resolved)) {
+                $schema = $resolved;
+            }
+        }
+
         return IntersectProperty::canHandleSchema($schema)
             || NestedObjectProperty::canHandleSchema($schema)
             || array_key_exists('enum', $schema);
@@ -171,10 +197,12 @@ class GenerationRunner
                 $this->cleanDirectory($validated->getTargetDirectory(), $output);
             }
 
-            $baseRequest = new GeneratorRequest(
+            $baseRequest = (new GeneratorRequest(
                 $schema,
                 $validated,
                 $opts,
+            ))->withRootDefinitions(
+                array_merge($schema['definitions'] ?? [], $schema['$defs'] ?? [])
             );
 
             $this->generateFromRequest($baseRequest, $output, $dryRun);

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -49,7 +49,10 @@ class SchemaToClass
         // 1) start with whatever schema the request already has
         $schema = $req->getSchema();
 
-        // 2) if the caller supplied root definitions, *always* splice them in here
+        // 2) collect definitions and prepare lookups before dereferencing
+        $this->definitionsToSchemas($req);
+
+        // 3) if the caller supplied root definitions, *always* splice them in here
         if (($defs = $req->getRootDefinitions()) !== null && count($defs) > 0) {
             // don't overwrite if the schema already carried its own definitions
             if (!isset($schema['definitions'])) {
@@ -60,13 +63,12 @@ class SchemaToClass
             }
         }
 
-        // dereference schemas that consist only of a reference
+        // 4) dereference schemas that consist only of a reference
         if (isset($schema['$ref'])) {
             $schema = $req->lookupSchema($schema['$ref']);
         }
 
         $req = $req->withSchema($schema);
-        $this->definitionsToSchemas($req);
         $schema = $req->getSchema();
 
         if (isset($schema["enum"])) {
@@ -399,8 +401,10 @@ class SchemaToClass
             return;
         }
 
+        $rootRef = $req->getSchema()['$ref'] ?? null;
+
         $collector = new DefinitionsCollector($req);
-        $collected  = iterator_to_array($collector->collect($req->getSchema()));
+        $allDefinitions  = iterator_to_array($collector->collect($req->getSchema()));
 
         $ns = $req->getTargetNamespace();
         
@@ -410,17 +414,36 @@ class SchemaToClass
                 return substr($cls, strlen($ns) + 1);
             }
             return ltrim($cls, '\\');
-        }, $collected);
+        }, $allDefinitions);
 
         if ($req->getTargetClass() !== null) {
             $generatedClasses[] = $req->getTargetClass();
         }
 
         $req = $req
-            ->withAdditionalReferenceLookup(new DefinitionsReferenceLookup($collected))
+            ->withAdditionalReferenceLookup(new DefinitionsReferenceLookup($allDefinitions))
             ->withGeneratedClassNames($generatedClasses);
 
+        $definitionsToGenerate = $allDefinitions;
+        if (is_string($rootRef)) {
+            $canonical = $rootRef;
+            if (!isset($definitionsToGenerate[$canonical])) {
+                if (str_starts_with($rootRef, '#/definitions/')) {
+                    $alt = '#/$defs/' . substr($rootRef, 14);
+                    if (isset($definitionsToGenerate[$alt])) {
+                        $canonical = $alt;
+                    }
+                } elseif (str_starts_with($rootRef, '#/$defs/')) {
+                    $alt = '#/definitions/' . substr($rootRef, 7);
+                    if (isset($definitionsToGenerate[$alt])) {
+                        $canonical = $alt;
+                    }
+                }
+            }
+            unset($definitionsToGenerate[$canonical]);
+        }
+
         $generator = new DefinitionsGenerator($this);
-        $generator->generate($collected, $req);
+        $generator->generate($definitionsToGenerate, $req);
     }
 }

--- a/tests/Generator/Fixtures/TopLevelRef/Output/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output/MyClass.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\TopLevelRef;
+
+class MyClass
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        'properties' => [
+            'foo' => [
+                'type' => [
+                    'string',
+                    'number',
+                ],
+            ],
+        ],
+        'type' => 'object',
+    ];
+
+    /**
+     * @var string|int|float|null
+     */
+    private string|int|float|null $foo = null;
+
+    /**
+     * @return string|int|float|null
+     */
+    public function getFoo() : int|float|string|null
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @param string|int|float $foo
+     * @return self
+     */
+    public function withFoo(int|float|string $foo) : self
+    {
+        $clone = clone $this;
+        $clone->foo = $foo;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutFoo() : self
+    {
+        $clone = clone $this;
+        unset($clone->foo);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return MyClass Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput(array|object $input, bool $validate = true) : MyClass
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $foo = isset($input->{'foo'}) ? match (true) {
+            is_string($input->{'foo'}) => $input->{'foo'},
+            is_int($input->{'foo'}) || is_float($input->{'foo'}) => str_contains((string)($input->{'foo'}), '.') ? (float)($input->{'foo'}) : (int)($input->{'foo'}),
+            default => null,
+        } : null;
+
+        $obj = new self();
+        $obj->foo = $foo;
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray() : array
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = match (true) {
+                is_string($this->foo),
+                is_int($this->foo) || is_float($this->foo) => $this->foo,
+            };
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = match (true) {
+                is_string($this->foo),
+                is_int($this->foo) || is_float($this->foo) => $this->foo,
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- preserve root definitions in generation runner
- generate definitions before dereferencing
- exclude top level definition from generation
- detect references in schemaNeedsClass
- add test fixtures for empty Output directories
- add snapshot for top level reference case

## Testing
- `vendor/bin/phpunit --filter TopLevelRef`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6868f20d9e54832d9158d9fe6db6b790