### PR TITLE
Fix definition name collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Now it:
 
 - Automatically creates classes for schemas with a `definitions` block (no more `cannot generate class for types other than 'object'`).
 - Supports non-ASCII property names. Any identifier is sanitized (with a uniqueness check), including when used with the `preservePropertyNames` option.
+- Sanitization now also checks for class name collisions and appends numeric suffixes when necessary.
 - Improves camelCase/PascalCase handling when generating identifier names.
 - Omits the default `null` value for properties listed in the `required` schema block.
 - Improves type hints and PHPDoc type generation for complex types like unions, nested arrays, etc.

--- a/src/Generator/Definitions/DefinitionsCollector.php
+++ b/src/Generator/Definitions/DefinitionsCollector.php
@@ -9,8 +9,16 @@ use Helmich\Schema2Class\Generator\GeneratorRequest;
 
 class DefinitionsCollector
 {
+    /** @var array<int,string> */
+    private array $usedClassNames = [];
+
     public function __construct(private readonly GeneratorRequest $generatorRequest)
     {
+        if (($cls = $this->generatorRequest->getTargetClass()) !== null) {
+            $ns = trim($this->generatorRequest->getTargetNamespace(), '\\');
+            $fqn = $ns !== '' ? $ns . '\\' . $cls : $cls;
+            $this->usedClassNames[] = $fqn;
+        }
     }
 
     /**
@@ -59,11 +67,23 @@ class DefinitionsCollector
         $namespace = trim($this->generatorRequest->getTargetNamespace() . '\\' . implode('\\', $parts), '\\');
         $directory = rtrim($this->generatorRequest->getTargetDirectory() . '/' . implode('/', $parts), '/');
 
+        $base = $className;
+        $candidate = $base;
+        $fqn = ($namespace !== '' ? $namespace . '\\' : '') . $candidate;
+        $i = 1;
+        while (in_array($fqn, $this->usedClassNames, true)) {
+            $candidate = $base . '_' . $i;
+            $fqn = ($namespace !== '' ? $namespace . '\\' : '') . $candidate;
+            $i++;
+        }
+
+        $this->usedClassNames[] = $fqn;
+
         return new Definition(
             namespace: $namespace,
             directory: $directory,
-            classFQN: $namespace . '\\' . $className,
-            className: $className,
+            classFQN: $fqn,
+            className: $candidate,
             schema: $schema,
         );
     }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output/BarTest.php
@@ -46,23 +46,23 @@ class BarTest
     ];
 
     /**
-     * @var FooTest|null
+     * @var FooTest|FooTest_1|null
      */
-    private ?FooTest $c = null;
+    private FooTest|FooTest_1|null $c = null;
 
     /**
-     * @return FooTest|null
+     * @return FooTest|FooTest_1|null
      */
-    public function getC() : ?FooTest
+    public function getC() : FooTest|FooTest_1|null
     {
-        return $this->c ?? null;
+        return $this->c;
     }
 
     /**
-     * @param FooTest $c
+     * @param FooTest|FooTest_1 $c
      * @return self
      */
-    public function withC(FooTest $c) : self
+    public function withC(FooTest|FooTest_1 $c) : self
     {
         $clone = clone $this;
         $clone->c = $c;
@@ -98,6 +98,7 @@ class BarTest
 
         $c = isset($input->{'c'}) ? match (true) {
             FooTest::validateInput($input->{'c'}, true) => FooTest::buildFromInput($input->{'c'}, $validate),
+            FooTest_1::validateInput($input->{'c'}, true) => FooTest_1::buildFromInput($input->{'c'}, $validate),
             default => null,
         } : null;
 
@@ -116,7 +117,8 @@ class BarTest
         $output = [];
         if (isset($this->c)) {
             $output['c'] = match (true) {
-                ($this->c) instanceof FooTest => $this->c->toArray(),
+                ($this->c) instanceof FooTest,
+                ($this->c) instanceof FooTest_1 => $this->c->toArray(),
             };
         }
 
@@ -151,7 +153,8 @@ class BarTest
     {
         if (isset($this->c)) {
             $this->c = match (true) {
-                ($this->c) instanceof FooTest => $this->c,
+                ($this->c) instanceof FooTest,
+                ($this->c) instanceof FooTest_1 => $this->c,
             };
         }
     }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output/BarTest.php
@@ -14,10 +14,13 @@ class BarTest
     private static array $schema = [
         'type' => 'object',
         'properties' => [
-            'c' => [
+            'exampleProp' => [
                 'anyOf' => [
                     [
                         '$ref' => '#/definitions/Foo<Test>',
+                    ],
+                    [
+                        '$ref' => '#/definitions/МойКласс',
                     ],
                     [
                         '$ref' => '#/definitions/FooTest',
@@ -42,30 +45,38 @@ class BarTest
                     ],
                 ],
             ],
+            'МойКласс' => [
+                'type' => 'object',
+                'properties' => [
+                    'c' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
         ],
     ];
 
     /**
-     * @var FooTest|FooTest_1|null
+     * @var FooTest|MoiKlass|FooTest_1|null
      */
-    private FooTest|FooTest_1|null $c = null;
+    private FooTest|MoiKlass|FooTest_1|null $exampleProp = null;
 
     /**
-     * @return FooTest|FooTest_1|null
+     * @return FooTest|MoiKlass|FooTest_1|null
      */
-    public function getC() : FooTest|FooTest_1|null
+    public function getExampleProp() : FooTest|FooTest_1|MoiKlass|null
     {
-        return $this->c;
+        return $this->exampleProp;
     }
 
     /**
-     * @param FooTest|FooTest_1 $c
+     * @param FooTest|MoiKlass|FooTest_1 $exampleProp
      * @return self
      */
-    public function withC(FooTest|FooTest_1 $c) : self
+    public function withExampleProp(FooTest|FooTest_1|MoiKlass $exampleProp) : self
     {
         $clone = clone $this;
-        $clone->c = $c;
+        $clone->exampleProp = $exampleProp;
 
         return $clone;
     }
@@ -73,10 +84,10 @@ class BarTest
     /**
      * @return self
      */
-    public function withoutC() : self
+    public function withoutExampleProp() : self
     {
         $clone = clone $this;
-        unset($clone->c);
+        unset($clone->exampleProp);
 
         return $clone;
     }
@@ -96,14 +107,15 @@ class BarTest
             static::validateInput($input);
         }
 
-        $c = isset($input->{'c'}) ? match (true) {
-            FooTest::validateInput($input->{'c'}, true) => FooTest::buildFromInput($input->{'c'}, $validate),
-            FooTest_1::validateInput($input->{'c'}, true) => FooTest_1::buildFromInput($input->{'c'}, $validate),
+        $exampleProp = isset($input->{'exampleProp'}) ? match (true) {
+            FooTest::validateInput($input->{'exampleProp'}, true) => FooTest::buildFromInput($input->{'exampleProp'}, $validate),
+            MoiKlass::validateInput($input->{'exampleProp'}, true) => MoiKlass::buildFromInput($input->{'exampleProp'}, $validate),
+            FooTest_1::validateInput($input->{'exampleProp'}, true) => FooTest_1::buildFromInput($input->{'exampleProp'}, $validate),
             default => null,
         } : null;
 
         $obj = new self();
-        $obj->c = $c;
+        $obj->exampleProp = $exampleProp;
         return $obj;
     }
 
@@ -115,10 +127,11 @@ class BarTest
     public function toArray() : array
     {
         $output = [];
-        if (isset($this->c)) {
-            $output['c'] = match (true) {
-                ($this->c) instanceof FooTest,
-                ($this->c) instanceof FooTest_1 => $this->c->toArray(),
+        if (isset($this->exampleProp)) {
+            $output['exampleProp'] = match (true) {
+                ($this->exampleProp) instanceof FooTest,
+                ($this->exampleProp) instanceof MoiKlass,
+                ($this->exampleProp) instanceof FooTest_1 => $this->exampleProp->toArray(),
             };
         }
 
@@ -151,10 +164,11 @@ class BarTest
 
     public function __clone()
     {
-        if (isset($this->c)) {
-            $this->c = match (true) {
-                ($this->c) instanceof FooTest,
-                ($this->c) instanceof FooTest_1 => $this->c,
+        if (isset($this->exampleProp)) {
+            $this->exampleProp = match (true) {
+                ($this->exampleProp) instanceof FooTest,
+                ($this->exampleProp) instanceof MoiKlass,
+                ($this->exampleProp) instanceof FooTest_1 => $this->exampleProp,
             };
         }
     }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output/FooTest_1.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output/FooTest_1.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ns\EscapeDefinitionName;
 
-class FooTest
+class FooTest_1
 {
     /**
      * Schema used to validate input for creating instances of this class
@@ -14,7 +14,7 @@ class FooTest
     private static array $schema = [
         'type' => 'object',
         'properties' => [
-            'a' => [
+            'b' => [
                 'type' => 'string',
             ],
         ],
@@ -23,33 +23,33 @@ class FooTest
     /**
      * @var string|null
      */
-    private ?string $a = null;
+    private ?string $b = null;
 
     /**
      * @return string|null
      */
-    public function getA() : ?string
+    public function getB() : ?string
     {
-        return $this->a ?? null;
+        return $this->b ?? null;
     }
 
     /**
-     * @param string $a
+     * @param string $b
      * @return self
      * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true) : self
+    public function withB(string $b, bool $validate = true) : self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$schema['properties']['a']);
+            $validator->validate($b, self::$schema['properties']['b']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->a = $a;
+        $clone->b = $b;
 
         return $clone;
     }
@@ -57,10 +57,10 @@ class FooTest
     /**
      * @return self
      */
-    public function withoutA() : self
+    public function withoutB() : self
     {
         $clone = clone $this;
-        unset($clone->a);
+        unset($clone->b);
 
         return $clone;
     }
@@ -70,20 +70,20 @@ class FooTest
      *
      * @param array|object $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
-     * @return FooTest Created instance
+     * @return FooTest_1 Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true) : FooTest
+    public static function buildFromInput(array|object $input, bool $validate = true) : FooTest_1
     {
         $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
         if ($validate) {
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $b = isset($input->{'b'}) ? $input->{'b'} : null;
 
         $obj = new self();
-        $obj->a = $a;
+        $obj->b = $b;
         return $obj;
     }
 
@@ -95,8 +95,8 @@ class FooTest
     public function toArray() : array
     {
         $output = [];
-        if (isset($this->a)) {
-            $output['a'] = $this->a;
+        if (isset($this->b)) {
+            $output['b'] = $this->b;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output/MoiKlass.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output/MoiKlass.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\EscapeDefinitionName;
+
+class MoiKlass
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        'type' => 'object',
+        'properties' => [
+            'c' => [
+                'type' => 'string',
+            ],
+        ],
+    ];
+
+    /**
+     * @var string|null
+     */
+    private ?string $c = null;
+
+    /**
+     * @return string|null
+     */
+    public function getC() : ?string
+    {
+        return $this->c ?? null;
+    }
+
+    /**
+     * @param string $c
+     * @return self
+     * @param bool $validate
+     */
+    public function withC(string $c, bool $validate = true) : self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($c, self::$schema['properties']['c']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->c = $c;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutC() : self
+    {
+        $clone = clone $this;
+        unset($clone->c);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return MoiKlass Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput(array|object $input, bool $validate = true) : MoiKlass
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $c = isset($input->{'c'}) ? $input->{'c'} : null;
+
+        $obj = new self();
+        $obj->c = $c;
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray() : array
+    {
+        $output = [];
+        if (isset($this->c)) {
+            $output['c'] = $this->c;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/EscapeDefinitionName/schema.json
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/schema.json
@@ -13,12 +13,19 @@
         "b": { "type": "string" }
       }
     },
+    "МойКласс": {
+      "type": "object",
+      "properties": {
+        "c": { "type": "string" }
+      }
+    },
     "Bar<Test>": {
       "type": "object",
       "properties": {
-        "c": {
+        "exampleProp": {
           "anyOf": [
             { "$ref": "#/definitions/Foo<Test>" },
+            { "$ref": "#/definitions/МойКласс" },
             { "$ref": "#/definitions/FooTest" }
           ]
         }

--- a/tests/Generator/SchemaDefinitionsCollectorTest.php
+++ b/tests/Generator/SchemaDefinitionsCollectorTest.php
@@ -72,11 +72,11 @@ final class SchemaDefinitionsCollectorTest extends TestCase
         $this->assertSame('targetDirectory', $definitions['#/definitions/address']->directory);
         $this->assertSame('targetDirectory/Address/Defs', $definitions['#/definitions/address/$defs/name']->directory);
 
-        $this->assertSame('TargetNamespace\Address', $definitions['#/$defs/address']->classFQN);
+        $this->assertSame('TargetNamespace\Address_1', $definitions['#/$defs/address']->classFQN);
         $this->assertSame('TargetNamespace\Address', $definitions['#/definitions/address']->classFQN);
         $this->assertSame('TargetNamespace\Address\Defs\Name', $definitions['#/definitions/address/$defs/name']->classFQN);
 
-        $this->assertSame('Address', $definitions['#/$defs/address']->className);
+        $this->assertSame('Address_1', $definitions['#/$defs/address']->className);
         $this->assertSame('Address', $definitions['#/definitions/address']->className);
         $this->assertSame('Name', $definitions['#/definitions/address/$defs/name']->className);
     }


### PR DESCRIPTION
## Summary
- avoid overwriting classes when sanitized definition names collide
- update snapshot fixtures and tests
- document collision handling in the changelog

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68690d45f948832dab58e88e17e78d6d