### PR TITLE
Fix URL-encoded refs

### DIFF
--- a/src/Generator/DefinitionsReferenceLookup.php
+++ b/src/Generator/DefinitionsReferenceLookup.php
@@ -22,6 +22,8 @@ class DefinitionsReferenceLookup implements ReferenceLookup
 
     private function canonicalize(string $reference): string
     {
+        $reference = rawurldecode($reference);
+
         if (isset($this->definitions[$reference])) {
             return $reference;
         }

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -49,6 +49,20 @@ class SchemaToClass
         // 1) start with whatever schema the request already has
         $schema = $req->getSchema();
 
+        $decodeRefs = function (&$node) use (&$decodeRefs): void {
+            if (!is_array($node)) {
+                return;
+            }
+            foreach ($node as $k => &$v) {
+                if ($k === '$ref' && is_string($v)) {
+                    $v = rawurldecode($v);
+                } elseif (is_array($v)) {
+                    $decodeRefs($v);
+                }
+            }
+        };
+        $decodeRefs($schema);
+
         // 2) collect definitions and prepare lookups before dereferencing
         $this->definitionsToSchemas($req);
 

--- a/tests/Generator/Fixtures/EncodedRef/Output/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output/Baz.php
@@ -15,7 +15,7 @@ class Baz
         'type' => 'object',
         'properties' => [
             'a' => [
-                '$ref' => '#/definitions/Foo%3CTest%3E',
+                '$ref' => '#/definitions/Foo<Test>',
             ],
             'b' => [
                 '$ref' => '#/definitions/Foo<Test>',
@@ -45,9 +45,9 @@ class Baz
     ];
 
     /**
-     * @var mixed|null
+     * @var FooTest|null
      */
-    private mixed $a = null;
+    private ?FooTest $a = null;
 
     /**
      * @var FooTest|null
@@ -60,11 +60,11 @@ class Baz
     private ?BarTest $c = null;
 
     /**
-     * @return mixed|null
+     * @return FooTest|null
      */
-    public function getA() : mixed
+    public function getA() : ?FooTest
     {
-        return $this->a;
+        return $this->a ?? null;
     }
 
     /**
@@ -84,10 +84,10 @@ class Baz
     }
 
     /**
-     * @param mixed $a
+     * @param FooTest $a
      * @return self
      */
-    public function withA(mixed $a) : self
+    public function withA(FooTest $a) : self
     {
         $clone = clone $this;
         $clone->a = $a;
@@ -167,7 +167,7 @@ class Baz
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? FooTest::buildFromInput($input->{'a'}, $validate) : null;
         $b = isset($input->{'b'}) ? FooTest::buildFromInput($input->{'b'}, $validate) : null;
         $c = isset($input->{'c'}) ? BarTest::buildFromInput($input->{'c'}, $validate) : null;
 
@@ -187,7 +187,7 @@ class Baz
     {
         $output = [];
         if (isset($this->a)) {
-            $output['a'] = $this->a;
+            $output['a'] = $this->a->toArray();
         }
         if (isset($this->b)) {
             $output['b'] = $this->b->toArray();


### PR DESCRIPTION
## Summary
- decode percent-encoded references when looking up definitions
- strip encoding from `$ref` values in SchemaToClass
- update EncodedRef fixture

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit --filter EncodedRef`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686935d58dd0832db3c2b29b1a2a3606