### PR TITLE
Fix schema embedding after dereferencing

### DIFF
--- a/src/Generator/Property/RawObjectProperty.php
+++ b/src/Generator/Property/RawObjectProperty.php
@@ -38,4 +38,9 @@ class RawObjectProperty extends AbstractProperty
     {
         return 'is_array(' . $expr . ') || is_object(' . $expr . ')';
     }
+
+    public function generateOutputMappingExpr(string $expr): string
+    {
+        return sprintf('is_object(%1$s) ? json_decode(json_encode(%1$s), true) : %1$s', $expr);
+    }
 }

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -48,6 +48,7 @@ class SchemaToClass
     {
         // 1) start with whatever schema the request already has
         $schema = $req->getSchema();
+        $rootSchema = $schema;
 
         $decodeRefs = function (&$node) use (&$decodeRefs): void {
             if (!is_array($node)) {
@@ -63,23 +64,29 @@ class SchemaToClass
         };
         $decodeRefs($schema);
 
+        $req = $req->withSchema($schema);
+
         // 2) collect definitions and prepare lookups before dereferencing
         $this->definitionsToSchemas($req);
 
-        // 3) if the caller supplied root definitions, *always* splice them in here
-        if (($defs = $req->getRootDefinitions()) !== null && count($defs) > 0) {
-            // don't overwrite if the schema already carried its own definitions
+        // 3) dereference schemas that consist only of a reference
+        if (isset($schema['$ref'])) {
+            $schema = $req->lookupSchema($schema['$ref']);
+            // decode references in the dereferenced schema as well
+            $decodeRefs($schema);
+        }
+
+        // 4) if root definitions are present, splice them back in after dereferencing
+        $defs = $req->getRootDefinitions();
+        if ($defs === null) {
+            $defs = array_merge($rootSchema['definitions'] ?? [], $rootSchema['$defs'] ?? []);
+        }
+        if (count($defs) > 0) {
             if (!isset($schema['definitions'])) {
                 $schema['definitions'] = $defs;
             } else {
-                // merge – let local keys override, just in case
                 $schema['definitions'] = array_replace($defs, $schema['definitions']);
             }
-        }
-
-        // 4) dereference schemas that consist only of a reference
-        if (isset($schema['$ref'])) {
-            $schema = $req->lookupSchema($schema['$ref']);
         }
 
         $req = $req->withSchema($schema);

--- a/tests/Generator/Fixtures/TempTestName/Output/MyClass.php
+++ b/tests/Generator/Fixtures/TempTestName/Output/MyClass.php
@@ -17,7 +17,25 @@ class MyClass
                 '$ref' => '#/definitions/Bar',
             ],
             'encoded' => [
-                '$ref' => '#/definitions/Encoded%3CTest%3E',
+                '$ref' => '#/definitions/Encoded<Test>',
+            ],
+        ],
+        'definitions' => [
+            'Foo' => [
+                'properties' => [
+                    'foo' => [
+                        '$ref' => '#/definitions/Bar',
+                    ],
+                    'encoded' => [
+                        '$ref' => '#/definitions/Encoded%3CTest%3E',
+                    ],
+                ],
+            ],
+            'Bar' => [
+                'type' => 'object',
+            ],
+            'Encoded<Test>' => [
+                'type' => 'object',
             ],
         ],
     ];
@@ -145,10 +163,10 @@ class MyClass
     {
         $output = [];
         if (isset($this->foo)) {
-            $output['foo'] = $this->foo;
+            $output['foo'] = is_object($this->foo) ? json_decode(json_encode($this->foo), true) : $this->foo;
         }
         if (isset($this->encoded)) {
-            $output['encoded'] = $this->encoded;
+            $output['encoded'] = is_object($this->encoded) ? json_decode(json_encode($this->encoded), true) : $this->encoded;
         }
 
         return $output;


### PR DESCRIPTION
## Summary
- preserve root definitions when root schema is a $ref
- decode references again after dereferencing
- normalize output mapping for raw objects
- update TempTestName fixture

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68694ef07680832db233167f73254b6e