### PR TITLE
Clean outdated version snapshots

### DIFF
--- a/tests/Generator/Fixtures/Basic/Output/MyClass.php
+++ b/tests/Generator/Fixtures/Basic/Output/MyClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ns\Basic;
+namespace Ns\Basic_8_4;
 
 class MyClass
 {

--- a/tests/Generator/Fixtures/Enum/Output/MyClass.php
+++ b/tests/Generator/Fixtures/Enum/Output/MyClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ns\Enum;
+namespace Ns\Enum_8_4;
 
 enum MyClass: string {
     case FOO = 'Foo';

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -26,6 +26,37 @@ class SchemaToClassTest extends TestCase
     {
     }
 
+    private static function cleanUnusedOutputDirs(string $fixtureDir, array $versions): void
+    {
+        $existing = [];
+        if (is_dir($fixtureDir . '/Output')) {
+            $existing[GeneratorRequest::DEFAULT_PHP8_VERSION] = $fixtureDir . '/Output';
+        }
+
+        foreach (scandir($fixtureDir) as $entry) {
+            if (preg_match('/^Output-(.+)$/', $entry, $m)) {
+                $existing[$m[1]] = $fixtureDir . DIRECTORY_SEPARATOR . $entry;
+            }
+        }
+
+        foreach ($existing as $version => $dir) {
+            if (!in_array($version, $versions, true)) {
+                $iterator = new \RecursiveIteratorIterator(
+                    new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+                    \RecursiveIteratorIterator::CHILD_FIRST,
+                );
+                foreach ($iterator as $fileInfo) {
+                    if ($fileInfo->isFile()) {
+                        unlink($fileInfo->getPathname());
+                    } else {
+                        @rmdir($fileInfo->getPathname());
+                    }
+                }
+                @rmdir($dir);
+            }
+        }
+    }
+
     public static function loadCodeGenerationTestCases(): array
     {
         $testCases   = [];
@@ -104,6 +135,8 @@ class SchemaToClassTest extends TestCase
                         $versions = [GeneratorRequest::DEFAULT_PHP5_VERSION, GeneratorRequest::DEFAULT_PHP7_VERSION, GeneratorRequest::DEFAULT_PHP8_VERSION];
                     }
                 }
+
+                self::cleanUnusedOutputDirs($fixtureDir, $versions);
             } else {
                 if (is_dir($fixtureDir . '/Output')) {
                     $versions[] = GeneratorRequest::DEFAULT_PHP8_VERSION;


### PR DESCRIPTION
## Summary
- automatically purge obsolete `Output-*` directories when regenerating fixtures
- update snapshots for PHP 8.4

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6870013f4174832dafd8bcabe3369c4d