### PR TITLE
Detect unresolved $refs

### DIFF
--- a/src/Generator/GeneratorRequest.php
+++ b/src/Generator/GeneratorRequest.php
@@ -279,7 +279,7 @@ class GeneratorRequest
     public function lookupReference(string $ref): ReferencedType
     {
         if (empty($this->referenceLookup)) {
-            return new ReferencedTypeUnknown();
+            throw new GeneratorException("unresolvable reference: {$ref}");
         }
 
         foreach ($this->referenceLookup as $lookup) {
@@ -289,13 +289,13 @@ class GeneratorRequest
             }
         }
 
-        return new ReferencedTypeUnknown();
+        throw new GeneratorException("unresolvable reference: {$ref}");
     }
 
     public function lookupSchema(string $ref): array
     {
         if (empty($this->referenceLookup)) {
-            return [];
+            throw new GeneratorException("unresolvable reference: {$ref}");
         }
 
         foreach ($this->referenceLookup as $lookup) {
@@ -305,6 +305,6 @@ class GeneratorRequest
             }
         }
 
-        return [];
+        throw new GeneratorException("unresolvable reference: {$ref}");
     }
 }

--- a/tests/Schema2Class/Schema2ClassTest.php
+++ b/tests/Schema2Class/Schema2ClassTest.php
@@ -159,4 +159,46 @@ class Schema2ClassTest extends TestCase
         $merged = OptionsDefaults::mergeOptions($base, $override);
         $this->assertFalse($merged->getSingleLineSchema());
     }
+
+    public function testUnresolvableRefThrows(): void
+    {
+        $schema = [
+            'definitions' => [
+                'Cat' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'hasFur' => [
+                            '$ref' => '#/definitions/schemas/furBoolean',
+                        ],
+                    ],
+                ],
+                'furBoolean' => [
+                    'type' => 'boolean',
+                ],
+            ],
+        ];
+
+        $dir = sys_get_temp_dir() . '/s2c_' . uniqid();
+        mkdir($dir);
+
+        $generator = new Schema2Class();
+
+        $this->expectException(\Helmich\Schema2Class\Generator\GeneratorException::class);
+
+        try {
+            $generator->generateFromSchema(
+                $schema,
+                'Cat',
+                [
+                    'targetDirectory' => $dir,
+                    'targetNamespace' => 'My\\Ns',
+                ]
+            );
+        } finally {
+            foreach (glob($dir . '/*.php') ?: [] as $file) {
+                unlink($file);
+            }
+            rmdir($dir);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- throw `GeneratorException` on unresolved schema references
- add regression test ensuring unresolved `$ref` triggers an exception

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse`

------
https://chatgpt.com/codex/tasks/task_e_687105de778c832dae67a80fa6762dee