### PR TITLE
Fix enum fallback and docblocks

### DIFF
--- a/src/Generator/Property/BooleanProperty.php
+++ b/src/Generator/Property/BooleanProperty.php
@@ -20,6 +20,13 @@ class BooleanProperty extends AbstractProperty
 
     public function typeAnnotation(): string
     {
+        if (isset($this->schema['enum']) && count($this->schema['enum']) === 1) {
+            $v = $this->schema['enum'][0];
+            if ($v === true || $v === false) {
+                return $v ? 'true' : 'false';
+            }
+        }
+
         return "bool";
     }
 

--- a/src/Generator/ReferencedTypeEnum.php
+++ b/src/Generator/ReferencedTypeEnum.php
@@ -40,7 +40,12 @@ readonly class ReferencedTypeEnum implements ReferencedType
             return $this->relativeName($req);
         }
 
-        $literals = array_map(fn(string|int $v) => var_export($v, true), $this->schema['enum']);
+        $literals = array_map(
+            static function ($v): string {
+                return var_export($v, true);
+            },
+            $this->schema['enum']
+        );
         return implode('|', $literals);
     }
 
@@ -50,18 +55,31 @@ readonly class ReferencedTypeEnum implements ReferencedType
             return $this->relativeName($req);
         }
 
-        $hasInt = false;
-        $hasString = false;
+        $types = [];
         foreach ($this->schema['enum'] as $v) {
-            $hasInt = $hasInt || is_int($v);
-            $hasString = $hasString || is_string($v);
+            if ($v === null) {
+                $types['null'] = 'null';
+            } elseif (is_string($v)) {
+                $types['string'] = 'string';
+            } elseif (is_int($v)) {
+                $types['int'] = 'int';
+            } elseif (is_float($v)) {
+                $types['float'] = 'float';
+            } elseif (is_bool($v)) {
+                $types['bool'] = 'bool';
+            }
         }
 
-        if ($hasInt && $hasString) {
-            return $req->isAtLeastPHP('8.0') ? 'int|string' : null;
+        if (!$req->isAtLeastPHP('8.0') && count($types) !== 1) {
+            return null;
         }
 
-        return $hasInt ? 'int' : 'string';
+        if (isset($types['int']) && isset($types['float'])) {
+            $types['int'] = 'int';
+            $types['float'] = 'float';
+        }
+
+        return implode('|', array_values($types));
     }
 
     function serializedInputTypeHint(GeneratorRequest $req): ?string

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -128,15 +128,13 @@ class SchemaToClass
         if (isset($schema["enum"])) {
             if (SchemaToEnum::canGenerateEnum($schema, $req)) {
                 $this->enumGenerator->schemaToEnum($req);
-            } else {
-                $class = $req->getTargetClass();
-                if ($class !== null) {
-                    $this->output->writeln("skipping generation of enum <comment>{$class}</comment>");
-                }
+                return;
             }
 
-
-            return;
+            $class = $req->getTargetClass();
+            if ($class !== null) {
+                $this->output->writeln("skipping generation of enum <comment>{$class}</comment>");
+            }
         }
 
         if (IntersectProperty::canHandleSchema($schema)) {

--- a/src/Generator/SchemaToEnum.php
+++ b/src/Generator/SchemaToEnum.php
@@ -22,7 +22,21 @@ class SchemaToEnum
      */
     public static function canGenerateEnum(array $schema, GeneratorRequest $req): bool
     {
-        return !self::areEnumsDisabled($req) && !self::isMixedEnum($schema);
+        if (self::areEnumsDisabled($req)) {
+            return false;
+        }
+
+        if (self::isMixedEnum($schema)) {
+            return false;
+        }
+
+        foreach ($schema['enum'] as $case) {
+            if (!is_string($case) && !is_int($case)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     static public function isMixedEnum(array $schema): bool

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
@@ -67,29 +67,29 @@ class Foo
     private $floatEnum = null;
 
     /**
-     * @var 0|1|2|3|null
+     * @var 0|1.5|2.5|3.5|null
      */
-    private ?int $floatEnumRef = null;
+    private $floatEnumRef = null;
 
     /**
-     * @var bool|null
+     * @var false|null
      */
     private ?bool $boolEnum = null;
 
     /**
-     * @var 0|null
+     * @var false|null
      */
-    private ?string $boolEnumRef = null;
+    private ?bool $boolEnumRef = null;
 
     /**
-     * @var
+     * @var false
      */
-    private string $requiredBoolEnumRef;
+    private bool $requiredBoolEnumRef;
 
     /**
-     * @param 0 $requiredBoolEnumRef
+     * @param false $requiredBoolEnumRef
      */
-    public function __construct(string $requiredBoolEnumRef)
+    public function __construct(bool $requiredBoolEnumRef)
     {
         $this->requiredBoolEnumRef = $requiredBoolEnumRef;
     }
@@ -103,15 +103,15 @@ class Foo
     }
 
     /**
-     * @return 0|1|2|3|null
+     * @return 0|1.5|2.5|3.5|null
      */
-    public function getFloatEnumRef() : ?int
+    public function getFloatEnumRef()
     {
-        return $this->floatEnumRef ?? null;
+        return $this->floatEnumRef;
     }
 
     /**
-     * @return bool|null
+     * @return false|null
      */
     public function getBoolEnum() : ?bool
     {
@@ -119,17 +119,17 @@ class Foo
     }
 
     /**
-     * @return 0|null
+     * @return false|null
      */
-    public function getBoolEnumRef() : ?string
+    public function getBoolEnumRef() : ?bool
     {
         return $this->boolEnumRef ?? null;
     }
 
     /**
-     * @return
+     * @return false
      */
-    public function getRequiredBoolEnumRef() : string
+    public function getRequiredBoolEnumRef() : bool
     {
         return $this->requiredBoolEnumRef;
     }
@@ -167,11 +167,11 @@ class Foo
     }
 
     /**
-     * @param 0|1|2|3 $floatEnumRef
+     * @param 0|1.5|2.5|3.5 $floatEnumRef
      * @return self
      * @param bool $validate
      */
-    public function withFloatEnumRef(int $floatEnumRef, bool $validate = true) : self
+    public function withFloatEnumRef($floatEnumRef, bool $validate = true) : self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -199,7 +199,7 @@ class Foo
     }
 
     /**
-     * @param bool $boolEnum
+     * @param false $boolEnum
      * @return self
      * @param bool $validate
      */
@@ -231,11 +231,11 @@ class Foo
     }
 
     /**
-     * @param 0 $boolEnumRef
+     * @param false $boolEnumRef
      * @return self
      * @param bool $validate
      */
-    public function withBoolEnumRef(string $boolEnumRef, bool $validate = true) : self
+    public function withBoolEnumRef(bool $boolEnumRef, bool $validate = true) : self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -263,11 +263,11 @@ class Foo
     }
 
     /**
-     * @param 0 $requiredBoolEnumRef
+     * @param false $requiredBoolEnumRef
      * @return self
      * @param bool $validate
      */
-    public function withRequiredBoolEnumRef(string $requiredBoolEnumRef, bool $validate = true) : self
+    public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef, bool $validate = true) : self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Ns\EnumUnsupported_5_6;
+declare(strict_types=1);
+
+namespace Ns\EnumUnsupported_8_4;
 
 class Foo
 {
@@ -9,7 +11,7 @@ class Foo
      *
      * @var array
      */
-    private static $schema = [
+    private static array $schema = [
         'type' => 'object',
         'properties' => [
             'floatEnum' => [
@@ -62,27 +64,27 @@ class Foo
     /**
      * @var int|float|null
      */
-    private $floatEnum = null;
+    private int|float|null $floatEnum = null;
 
     /**
      * @var 0|1.5|2.5|3.5|null
      */
-    private $floatEnumRef = null;
+    private int|float|null $floatEnumRef = null;
 
     /**
      * @var false|null
      */
-    private $boolEnum = null;
+    private ?bool $boolEnum = null;
 
     /**
      * @var false|null
      */
-    private $boolEnumRef = null;
+    private ?bool $boolEnumRef = null;
 
     /**
      * @var false
      */
-    private $requiredBoolEnumRef;
+    private bool $requiredBoolEnumRef;
 
     /**
      * @param false $requiredBoolEnumRef
@@ -95,7 +97,7 @@ class Foo
     /**
      * @return int|float|null
      */
-    public function getFloatEnum()
+    public function getFloatEnum() : int|float|null
     {
         return $this->floatEnum;
     }
@@ -103,7 +105,7 @@ class Foo
     /**
      * @return 0|1.5|2.5|3.5|null
      */
-    public function getFloatEnumRef()
+    public function getFloatEnumRef() : int|float|null
     {
         return $this->floatEnumRef;
     }
@@ -111,23 +113,23 @@ class Foo
     /**
      * @return false|null
      */
-    public function getBoolEnum()
+    public function getBoolEnum() : ?bool
     {
-        return $this->boolEnum;
+        return $this->boolEnum ?? null;
     }
 
     /**
      * @return false|null
      */
-    public function getBoolEnumRef()
+    public function getBoolEnumRef() : ?bool
     {
-        return $this->boolEnumRef;
+        return $this->boolEnumRef ?? null;
     }
 
     /**
      * @return false
      */
-    public function getRequiredBoolEnumRef()
+    public function getRequiredBoolEnumRef() : bool
     {
         return $this->requiredBoolEnumRef;
     }
@@ -137,7 +139,7 @@ class Foo
      * @return self
      * @param bool $validate
      */
-    public function withFloatEnum($floatEnum, bool $validate = true)
+    public function withFloatEnum(int|float $floatEnum, bool $validate = true) : self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -156,7 +158,7 @@ class Foo
     /**
      * @return self
      */
-    public function withoutFloatEnum()
+    public function withoutFloatEnum() : self
     {
         $clone = clone $this;
         unset($clone->floatEnum);
@@ -169,7 +171,7 @@ class Foo
      * @return self
      * @param bool $validate
      */
-    public function withFloatEnumRef($floatEnumRef, bool $validate = true)
+    public function withFloatEnumRef(int|float $floatEnumRef, bool $validate = true) : self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -188,7 +190,7 @@ class Foo
     /**
      * @return self
      */
-    public function withoutFloatEnumRef()
+    public function withoutFloatEnumRef() : self
     {
         $clone = clone $this;
         unset($clone->floatEnumRef);
@@ -201,7 +203,7 @@ class Foo
      * @return self
      * @param bool $validate
      */
-    public function withBoolEnum($boolEnum, bool $validate = true)
+    public function withBoolEnum(bool $boolEnum, bool $validate = true) : self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -220,7 +222,7 @@ class Foo
     /**
      * @return self
      */
-    public function withoutBoolEnum()
+    public function withoutBoolEnum() : self
     {
         $clone = clone $this;
         unset($clone->boolEnum);
@@ -233,7 +235,7 @@ class Foo
      * @return self
      * @param bool $validate
      */
-    public function withBoolEnumRef(bool $boolEnumRef, bool $validate = true)
+    public function withBoolEnumRef(bool $boolEnumRef, bool $validate = true) : self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -252,7 +254,7 @@ class Foo
     /**
      * @return self
      */
-    public function withoutBoolEnumRef()
+    public function withoutBoolEnumRef() : self
     {
         $clone = clone $this;
         unset($clone->boolEnumRef);
@@ -265,7 +267,7 @@ class Foo
      * @return self
      * @param bool $validate
      */
-    public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef, bool $validate = true)
+    public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef, bool $validate = true) : self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -289,14 +291,8 @@ class Foo
      * @return Foo Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput($input, bool $validate = true)
+    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
     {
-        if (!is_array($input) && !is_object($input)) {
-            throw new \InvalidArgumentException(
-                'Input to buildFromInput must be array or object, got ' . gettype($input)
-            );
-        }
-
         $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
         if ($validate) {
             static::validateInput($input);
@@ -321,7 +317,7 @@ class Foo
      *
      * @return array Converted array
      */
-    public function toArray()
+    public function toArray() : array
     {
         $output = [];
         if (isset($this->floatEnum)) {
@@ -349,14 +345,14 @@ class Foo
      * @return bool Validation result
      * @throws \InvalidArgumentException
      */
-    public static function validateInput($input, $return = false)
+    public static function validateInput(array|object $input, bool $return = false) : bool
     {
         $validator = new \JsonSchema\Validator();
         $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
         $validator->validate($input, self::$schema);
 
         if (!$validator->isValid() && !$return) {
-            $errors = array_map(function($e) {
+            $errors = array_map(function(array $e): string {
                 return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
             }, $validator->getErrors());
             throw new \InvalidArgumentException(join(".\n", $errors));


### PR DESCRIPTION
## Summary
- support fallback when enum values aren't string/int
- improve typing for referenced enums
- narrow bool enum PHPDoc output
- update EnumUnsupported snapshots

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6873dd2d67d0832d8611187aec47ad7e