### PR TITLE
Fix null handling in unions

### DIFF
--- a/src/Generator/Property/UnionProperty.php
+++ b/src/Generator/Property/UnionProperty.php
@@ -364,6 +364,17 @@ class UnionProperty extends AbstractProperty
         return $out;
     }
 
+    public function allowsNull(): bool
+    {
+        foreach ($this->subProperties as $prop) {
+            if ($prop->allowsNull()) {
+                return true;
+            }
+        }
+
+        return parent::allowsNull();
+    }
+
     private function subTypeName(int $idx = 0): string
     {
         return $this->generatorRequest->getTargetClass() . $this->capitalizedName . "Alternative" . ($idx + 1);

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -132,22 +132,20 @@ class Cat
     public function toArray() : array
     {
         $output = [];
-        if (isset($this->hasFur)) {
-            $output['hasFur'] = match (true) {
-                (($this->hasFur) === null) || (is_bool($this->hasFur)) => ($this->hasFur !== null) ? ($this->hasFur) : null,
-                (($this->hasFur) === null) || ((is_string($this->hasFur)) || (is_int($this->hasFur) || is_float($this->hasFur))) => ($this->hasFur !== null) ? (match (true) {
-                default => null,
-                is_string($this->hasFur),
-                is_int($this->hasFur) || is_float($this->hasFur) => $this->hasFur,
-            }) : null,
-                (is_string($this->hasFur)) || (is_int($this->hasFur) || is_float($this->hasFur)) || (is_bool($this->hasFur)) => match (true) {
-                default => null,
-                is_string($this->hasFur),
-                is_int($this->hasFur) || is_float($this->hasFur),
-                is_bool($this->hasFur) => $this->hasFur,
-            },
-            };
-        }
+        $output['hasFur'] = match (true) {
+            (($this->hasFur) === null) || (is_bool($this->hasFur)) => ($this->hasFur !== null) ? ($this->hasFur) : null,
+            (($this->hasFur) === null) || ((is_string($this->hasFur)) || (is_int($this->hasFur) || is_float($this->hasFur))) => ($this->hasFur !== null) ? (match (true) {
+            default => null,
+            is_string($this->hasFur),
+            is_int($this->hasFur) || is_float($this->hasFur) => $this->hasFur,
+        }) : null,
+            (is_string($this->hasFur)) || (is_int($this->hasFur) || is_float($this->hasFur)) || (is_bool($this->hasFur)) => match (true) {
+            default => null,
+            is_string($this->hasFur),
+            is_int($this->hasFur) || is_float($this->hasFur),
+            is_bool($this->hasFur) => $this->hasFur,
+        },
+        };
 
         return $output;
     }

--- a/tests/Generator/Property/UnionPropertyTest.php
+++ b/tests/Generator/Property/UnionPropertyTest.php
@@ -14,6 +14,8 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use function PHPUnit\Framework\assertSame;
 use function PHPUnit\Framework\assertTrue;
+use Helmich\Schema2Class\Generator\Definitions\Definition;
+use Helmich\Schema2Class\Generator\DefinitionsReferenceLookup;
 
 class UnionPropertyTest extends TestCase
 {
@@ -86,6 +88,26 @@ $this->myPropertyName = match (true) {
 };
 EOCODE;
         assertSame($expected, $this->property->cloneProperty());
+    }
+
+    public function testAllowsNullIfSubPropertyAllowsNull(): void
+    {
+        $defs = [
+            '#/definitions/foo' => new Definition('Ns', '', 'Ns\\Foo', 'Foo', ['type' => ['boolean', 'null']]),
+            '#/definitions/bar' => new Definition('Ns', '', 'Ns\\Bar', 'Bar', ['type' => 'string']),
+        ];
+
+        $lookup = new DefinitionsReferenceLookup($defs);
+        $req    = $this->generatorRequest->withReferenceLookup($lookup);
+
+        $prop = new UnionProperty('myPropertyName', [
+            'anyOf' => [
+                ['$ref' => '#/definitions/foo'],
+                ['$ref' => '#/definitions/bar'],
+            ],
+        ], $req);
+
+        assertTrue($prop->allowsNull());
     }
 
     public static function dataForAnnotationAndHintWithSimpleArray(): array


### PR DESCRIPTION
## Summary
- allow UnionProperty to detect null arms in its subproperties
- update fixtures for UnionWithRepeatedType
- verify null detection through a new unit test

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6874f03818a4832d8966679e76bf6c2d