### PR TITLE
Handle optional nullable properties

### DIFF
--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -45,9 +45,28 @@ class Generator
     {
         $propertyGenerators = [];
 
+        $hasOptionalNullable = false;
+        foreach ($properties as $p) {
+            if ($p instanceof OptionalPropertyDecorator && method_exists($p, 'isOptionalNullable') && $p->isOptionalNullable()) {
+                $hasOptionalNullable = true;
+                break;
+            }
+        }
+
         $visibility = $this->generatorRequest->getNoGetters()
             ? PropertyGenerator::FLAG_PUBLIC
             : PropertyGenerator::FLAG_PRIVATE;
+
+        if ($hasOptionalNullable) {
+            $setVisibility = ($this->generatorRequest->getNoGetters() && $this->generatorRequest->getNoSetters())
+                ? PropertyGenerator::FLAG_PUBLIC
+                : PropertyGenerator::FLAG_PRIVATE;
+
+            $setProp = new PropertyGenerator('_optionalNullableSet', [] , $setVisibility);
+            $setProp->setDefaultValue([]);
+            $setProp->setDocBlock(new DocBlockGenerator(null, null, [new GenericTag('var', 'array')]));
+            $propertyGenerators[] = $setProp;
+        }
 
         foreach ($properties as $property) {
             $schema     = $property->schema();
@@ -102,6 +121,14 @@ class Generator
     {
         $requiredProperties = $properties->filter(PropertyCollectionFilterFactory::required());
         $optionalProperties = $properties->filter(PropertyCollectionFilterFactory::optional());
+
+        $hasOptionalNullable = false;
+        foreach ($properties as $p) {
+            if ($p instanceof OptionalPropertyDecorator && method_exists($p, 'isOptionalNullable') && $p->isOptionalNullable()) {
+                $hasOptionalNullable = true;
+                break;
+            }
+        }
 
         $constructorParams = [];
         
@@ -191,12 +218,15 @@ class Generator
 
             $aliasLine .
 
+            ($hasOptionalNullable ? "\$__optNullables = [];\n" : '') .
+
             // Property‐by‐property mapping
             $properties->generateInputToTypeConversionCode($inputVarName, object: true) . "\n\n" .
 
             // Construct & assign optional props
             "\${$objVarName} = new self(" . join(", ", $constructorParams) . ");" . "\n" .
             join("\n", $assignments) . "\n" .
+            ($hasOptionalNullable ? "\${$objVarName}->_optionalNullableSet = \$__optNullables;\n" : '') .
 
             // Return
             "return \${$objVarName};"
@@ -323,6 +353,29 @@ class Generator
         );
     }
 
+    public function generateIsSetMethod(): MethodGenerator
+    {
+        $doc = new DocBlockGenerator(null, null, [
+            new ParamTag('propertyName', ['string']),
+            new ReturnTag('bool'),
+        ]);
+        $doc->setWordWrap(false);
+
+        $method = new MethodGenerator(
+            'isSet',
+            [new ParameterGenerator('propertyName', 'string')],
+            MethodGenerator::FLAG_PUBLIC,
+            'return array_key_exists($propertyName, $this->_optionalNullableSet);',
+            $doc
+        );
+
+        if ($this->generatorRequest->isAtLeastPHP("7.0")) {
+            $method->setReturnType('bool');
+        }
+
+        return $method;
+    }
+
     /**
      * @param PropertyCollection $properties
      * @return MethodGenerator[]
@@ -410,6 +463,9 @@ class Generator
         foreach ($properties as $property) {
             if ($mutable !== null) {
                 $methods[] = $this->generateMutableSetterMethod($property, $mutable === 'chainable');
+                if ($property instanceof OptionalPropertyDecorator && $property->isOptionalNullable()) {
+                    $methods[] = $this->generateMutableUnsetterMethod($property, $mutable === 'chainable');
+                }
             } else {
                 $methods[] = $this->generateSetterMethod($property);
 
@@ -486,13 +542,20 @@ class Generator
             $docBlock->setWordWrap(false);
         }
 
+        $body = $setterValidation . "\$clone = clone \$this;\n" .
+            "\$clone->$name = \$$name;\n";
+
+        if ($property instanceof OptionalPropertyDecorator && $property->isOptionalNullable()) {
+            $body .= "\$clone->_optionalNullableSet['$key'] = true;\n";
+        }
+
+        $body .= "\nreturn \$clone;";
+
         $setMethod = new MethodGenerator(
             'with' . $camelCaseName,
             $parameters,
             MethodGenerator::FLAG_PUBLIC,
-            $setterValidation . "\$clone = clone \$this;\n" .
-                "\$clone->$name = \$$name;\n\n" .
-                "return \$clone;",
+            $body,
             $docBlock
         );
 
@@ -562,7 +625,10 @@ class Generator
             $docBlock->setWordWrap(false);
         }
 
-        $body = $setterValidation . "\$this->$name = \$$name;";
+        $body = $setterValidation . "\$this->{$name} = \$$name;";
+        if ($property instanceof OptionalPropertyDecorator && $property->isOptionalNullable()) {
+            $body .= "\n\$this->_optionalNullableSet['$key'] = true;";
+        }
         if ($chainable) {
             $body .= "\n\nreturn \$this;";
         }
@@ -586,6 +652,39 @@ class Generator
         return $setMethod;
     }
 
+    private function generateMutableUnsetterMethod(PropertyInterface $property, bool $chainable): MethodGenerator
+    {
+        $key  = $property->key();
+        $name = $property->name();
+        $camelCaseName = $this->generatorRequest->getOptions()->getPreservePropertyNames()
+            ? StringUtils::pascalCasePreserveOuterUnderscores($name)
+            : StringUtils::pascalCase($name);
+
+        $body = "\$this->{$name} = null;\n";
+        if ($property instanceof OptionalPropertyDecorator && $property->isOptionalNullable()) {
+            $body .= "unset(\$this->_optionalNullableSet['$key']);\n";
+        }
+        if ($chainable) {
+            $body .= "\nreturn \$this;";
+        }
+
+        $unsetMethod = new MethodGenerator(
+            'unset' . $camelCaseName,
+            [],
+            MethodGenerator::FLAG_PUBLIC,
+            $body,
+            new DocBlockGenerator(null, null, $chainable ? [new ReturnTag('self')] : [])
+        );
+
+        if ($chainable && $this->generatorRequest->isAtLeastPHP('7.0')) {
+            $unsetMethod->setReturnType('self');
+        } elseif (!$chainable && $this->generatorRequest->isAtLeastPHP('7.1')) {
+            $unsetMethod->setReturnType('void');
+        }
+
+        return $unsetMethod;
+    }
+
     /**
      * @param PropertyInterface $property
      * @return MethodGenerator
@@ -593,6 +692,7 @@ class Generator
     public function generateUnsetterMethod(PropertyInterface $property): MethodGenerator
     {
         $name = $property->name();
+        $key  = $property->key();
         if ($this->generatorRequest->getOptions()->getPreservePropertyNames()) {
             $camelCasedName = StringUtils::pascalCasePreserveOuterUnderscores($name);
         } else {
@@ -605,6 +705,10 @@ class Generator
             $body .= "\$clone->$name = " . $value . "\n";
         } else {
             $body .= "unset(\$clone->$name);\n";
+        }
+
+        if ($property instanceof OptionalPropertyDecorator && $property->isOptionalNullable()) {
+            $body .= "unset(\$clone->_optionalNullableSet['$key']);\n";
         }
 
         $body .= "\nreturn \$clone;";

--- a/src/Generator/Property/OptionalPropertyDecorator.php
+++ b/src/Generator/Property/OptionalPropertyDecorator.php
@@ -7,6 +7,38 @@ class OptionalPropertyDecorator extends NullablePropertyDecorator implements Ren
 {
     use CodeFormatting;
 
+    private bool $optionalNullable = false;
+
+    public function markOptionalNullable(): void
+    {
+        $this->optionalNullable = true;
+    }
+
+    public function isOptionalNullable(): bool
+    {
+        return $this->optionalNullable;
+    }
+
+    public function generateIssetCheckExpr(string $inputVarName = 'input', bool $object = false): string
+    {
+        $key = $this->key;
+        $accessor = $object ? "\${$inputVarName}->{'$key'}" : "\${$inputVarName}['$key']";
+
+        $default = $this->schema()['default'] ?? null;
+        $existsCheck = "isset($accessor)";
+        if ($default !== null && $this->inner->allowsNull()) {
+            $existsCheck = $object
+                ? "property_exists(\${$inputVarName}, '$key')"
+                : "array_key_exists('$key', \${$inputVarName})";
+        } elseif ($this->optionalNullable) {
+            $existsCheck = $object
+                ? "property_exists(\${$inputVarName}, '$key')"
+                : "array_key_exists('$key', \${$inputVarName})";
+        }
+
+        return $existsCheck;
+    }
+
     /**
      * @param string $inputVarName
      * @param bool $object
@@ -28,14 +60,15 @@ class OptionalPropertyDecorator extends NullablePropertyDecorator implements Ren
         $default    = isset($this->schema()["default"]) ? $this->schema()["default"] : null;
         $defaultExp = rtrim($this->formatValue($default)->generate(), ";");
 
-        $existsCheck = "isset($accessor)";
-        if ($default !== null && $this->inner->allowsNull()) {
-            $existsCheck = $object
-                ? "property_exists(\${$inputVarName}, '$key')"
-                : "array_key_exists('$key', \${$inputVarName})";
+        $existsCheck = $this->generateIssetCheckExpr($inputVarName, $object);
+
+        $code = "\${$name} = {$existsCheck} ? {$mapped} : {$defaultExp};";
+
+        if ($this->optionalNullable) {
+            $code .= "\nif ({$existsCheck}) { \$__optNullables['" . $this->key . "'] = true; }";
         }
 
-        return "\${$name} = {$existsCheck} ? {$mapped} : {$defaultExp};";
+        return $code;
     }
 
     /**
@@ -46,6 +79,11 @@ class OptionalPropertyDecorator extends NullablePropertyDecorator implements Ren
     {
         $name  = $this->inner->name();
         $inner = $this->inner->convertTypeToArray($outputVarName);
+
+        if ($this->optionalNullable) {
+            $check = "isset(\$this->{$name}) || array_key_exists('" . $this->key . "', \$this->_optionalNullableSet)";
+            return "if ({$check}) {\n" . $this->indentCode($inner, 1) . "\n}";
+        }
 
         if ($this->inner->allowsNull()) {
             return $inner;

--- a/src/Generator/PropertyBuilder.php
+++ b/src/Generator/PropertyBuilder.php
@@ -128,9 +128,16 @@ class PropertyBuilder
                     $prop = null;
             }
             if ($prop !== null) {
-                return $isRequired
-                    ? new NullablePropertyDecorator($name, $prop)   // required + nullable
-                    : new OptionalPropertyDecorator($name, $prop);  // optional
+                if ($isRequired) {
+                    return new NullablePropertyDecorator($name, $prop);   // required + nullable
+                }
+
+                $decorator = new OptionalPropertyDecorator($name, $prop);  // optional
+                if (self::definitionAllowsNull($definition)) {
+                    $decorator->markOptionalNullable();
+                }
+
+                return $decorator;
             }
         }
 
@@ -139,7 +146,11 @@ class PropertyBuilder
             if (isset($definition['default']) && $req->getOptions()->getTreatValuesWithDefaultAsOptional()) {
                 $property = new DefaultPropertyDecorator($name, $property);
             } elseif (!$isRequired) {
-                $property = new OptionalPropertyDecorator($name, $property);
+                $decorator = new OptionalPropertyDecorator($name, $property);
+                if (self::definitionAllowsNull($definition)) {
+                    $decorator->markOptionalNullable();
+                }
+                $property = $decorator;
             } elseif ($property->allowsNull()) {
                 $property = new NullablePropertyDecorator($name, $property);
             }
@@ -152,7 +163,11 @@ class PropertyBuilder
             if (isset($definition['default']) && $req->getOptions()->getTreatValuesWithDefaultAsOptional()) {
                 $property = new DefaultPropertyDecorator($name, $property);
             } elseif (!$isRequired) {
-                $property = new OptionalPropertyDecorator($name, $property);
+                $decorator = new OptionalPropertyDecorator($name, $property);
+                if (self::definitionAllowsNull($definition)) {
+                    $decorator->markOptionalNullable();
+                }
+                $property = $decorator;
             } elseif ($property->allowsNull()) {
                 $property = new NullablePropertyDecorator($name, $property);
             }
@@ -224,9 +239,16 @@ class PropertyBuilder
                         $isRequired     // pass-through
                     );
 
-                    return $isRequired
-                        ? new NullablePropertyDecorator($name, $inner)
-                        : new OptionalPropertyDecorator($name, $inner);
+                    if ($isRequired) {
+                        return new NullablePropertyDecorator($name, $inner);
+                    }
+
+                    $decorator = new OptionalPropertyDecorator($name, $inner);
+                    if (self::definitionAllowsNull($definition)) {
+                        $decorator->markOptionalNullable();
+                    }
+
+                    return $decorator;
                 }
 
                 //--------------------------------------------------------
@@ -238,9 +260,16 @@ class PropertyBuilder
                 $cleanDef[$unionKey]  = $otherArms;            // without the null arm
                 $unionProp            = new UnionProperty($name, $cleanDef, $req);
 
-                return $isRequired
-                    ? new NullablePropertyDecorator($name, $unionProp)
-                    : new OptionalPropertyDecorator($name, $unionProp);
+                if ($isRequired) {
+                    return new NullablePropertyDecorator($name, $unionProp);
+                }
+
+                $decorator = new OptionalPropertyDecorator($name, $unionProp);
+                if (self::definitionAllowsNull($definition)) {
+                    $decorator->markOptionalNullable();
+                }
+
+                return $decorator;
             }
         }
 
@@ -252,7 +281,11 @@ class PropertyBuilder
                 if (isset($definition["default"]) && $req->getOptions()->getTreatValuesWithDefaultAsOptional()) {
                     $property = new DefaultPropertyDecorator($name, $property);
                 } elseif (!$isRequired) {
-                    $property = new OptionalPropertyDecorator($name, $property); // optional
+                    $decorator = new OptionalPropertyDecorator($name, $property); // optional
+                    if (self::definitionAllowsNull($definition)) {
+                        $decorator->markOptionalNullable();
+                    }
+                    $property = $decorator;
                 } elseif ($property->allowsNull()) {
                     $property = new NullablePropertyDecorator($name, $property); // required + nullable
                 }
@@ -357,5 +390,32 @@ class PropertyBuilder
         }
 
         return $definition;
+    }
+
+    private static function definitionAllowsNull(array $definition): bool
+    {
+        if (isset($definition['enum']) && in_array(null, $definition['enum'], true)) {
+            return true;
+        }
+
+        $type = $definition['type'] ?? null;
+        if ($type === 'null') {
+            return true;
+        }
+        if (is_array($type) && in_array('null', $type, true)) {
+            return true;
+        }
+
+        foreach (['anyOf', 'oneOf'] as $k) {
+            if (isset($definition[$k]) && is_array($definition[$k])) {
+                foreach ($definition[$k] as $sub) {
+                    if (($sub['type'] ?? null) === 'null') {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -13,6 +13,7 @@ use Helmich\Schema2Class\Generator\Property\IntersectProperty;
 use Helmich\Schema2Class\Generator\Property\NestedObjectProperty;
 use Helmich\Schema2Class\Generator\Property\PropertyCollection;
 use Helmich\Schema2Class\Generator\Property\RenameablePropertyInterface;
+use Helmich\Schema2Class\Generator\Property\OptionalPropertyDecorator;
 use Helmich\Schema2Class\Util\StringUtils;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Laminas\Code\DeclareStatement;
@@ -227,6 +228,14 @@ class SchemaToClass
 
         $codeGenerator = new Generator($req);
 
+        $hasOptionalNullable = false;
+        foreach ($propertiesFromSchema as $p) {
+            if ($p instanceof OptionalPropertyDecorator && method_exists($p, 'isOptionalNullable') && $p->isOptionalNullable()) {
+                $hasOptionalNullable = true;
+                break;
+            }
+        }
+
         $properties = [
             ...$properties,
             ...$codeGenerator->generateProperties($propertiesFromSchema),
@@ -240,6 +249,7 @@ class SchemaToClass
             $codeGenerator->generateToArrayMethod($propertiesFromSchema),
             $codeGenerator->generateValidateMethod(),
             $codeGenerator->generateCloneMethod($propertiesFromSchema),
+            $hasOptionalNullable ? $codeGenerator->generateIsSetMethod() : null,
         ];
         $methods = array_values(array_filter($methods));
         $this->ensureUniqueMethodNames($methods);

--- a/tests/Generator/Fixtures/MutableSetters/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-5.6/MyClass.php
@@ -40,6 +40,13 @@ class MyClass
     ];
 
     /**
+     * @var array
+     */
+    private $_optionalNullableSet = [
+        
+    ];
+
+    /**
      * @var string|null
      */
     private $foo = null;
@@ -126,6 +133,16 @@ class MyClass
         }
 
         $this->opt = $opt;
+        $this->_optionalNullableSet['opt'] = true;
+    }
+
+    /**
+     *
+     */
+    public function unsetOpt()
+    {
+        $this->opt = null;
+        unset($this->_optionalNullableSet['opt']);
     }
 
     /**
@@ -149,13 +166,16 @@ class MyClass
             static::validateInput($input);
         }
 
+        $__optNullables = [];
         $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
         $bar = Baz::buildFromInput($input->{'bar'}, $validate);
-        $opt = isset($input->{'opt'}) ? $input->{'opt'} : null;
+        $opt = property_exists($input, 'opt') ? $input->{'opt'} : null;
+        if (property_exists($input, 'opt')) { $__optNullables['opt'] = true; }
 
         $obj = new self($bar);
         $obj->foo = $foo;
         $obj->opt = $opt;
+        $obj->_optionalNullableSet = $__optNullables;
         return $obj;
     }
 
@@ -171,7 +191,9 @@ class MyClass
             $output['foo'] = $this->foo;
         }
         $output['bar'] = $this->bar->toArray();
-        $output['opt'] = $this->opt;
+        if (isset($this->opt) || array_key_exists('opt', $this->_optionalNullableSet)) {
+            $output['opt'] = $this->opt;
+        }
 
         return $output;
     }
@@ -198,5 +220,14 @@ class MyClass
         }
 
         return $validator->isValid();
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function isSet(string $propertyName)
+    {
+        return array_key_exists($propertyName, $this->_optionalNullableSet);
     }
 }

--- a/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
@@ -42,6 +42,13 @@ class MyClass
     ];
 
     /**
+     * @var array
+     */
+    private $_optionalNullableSet = [
+        
+    ];
+
+    /**
      * @var string|null
      */
     private ?string $foo = null;
@@ -128,6 +135,16 @@ class MyClass
         }
 
         $this->opt = $opt;
+        $this->_optionalNullableSet['opt'] = true;
+    }
+
+    /**
+     *
+     */
+    public function unsetOpt() : void
+    {
+        $this->opt = null;
+        unset($this->_optionalNullableSet['opt']);
     }
 
     /**
@@ -151,13 +168,16 @@ class MyClass
             static::validateInput($input);
         }
 
+        $__optNullables = [];
         $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
         $bar = Baz::buildFromInput($input->{'bar'}, $validate);
-        $opt = isset($input->{'opt'}) ? $input->{'opt'} : null;
+        $opt = property_exists($input, 'opt') ? $input->{'opt'} : null;
+        if (property_exists($input, 'opt')) { $__optNullables['opt'] = true; }
 
         $obj = new self($bar);
         $obj->foo = $foo;
         $obj->opt = $opt;
+        $obj->_optionalNullableSet = $__optNullables;
         return $obj;
     }
 
@@ -173,7 +193,9 @@ class MyClass
             $output['foo'] = $this->foo;
         }
         $output['bar'] = $this->bar->toArray();
-        $output['opt'] = $this->opt;
+        if (isset($this->opt) || array_key_exists('opt', $this->_optionalNullableSet)) {
+            $output['opt'] = $this->opt;
+        }
 
         return $output;
     }
@@ -200,5 +222,14 @@ class MyClass
         }
 
         return $validator->isValid();
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function isSet(string $propertyName) : bool
+    {
+        return array_key_exists($propertyName, $this->_optionalNullableSet);
     }
 }

--- a/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
@@ -42,6 +42,13 @@ class MyClass
     ];
 
     /**
+     * @var array
+     */
+    private $_optionalNullableSet = [
+        
+    ];
+
+    /**
      * @var string|null
      */
     private ?string $foo = null;
@@ -128,6 +135,16 @@ class MyClass
         }
 
         $this->opt = $opt;
+        $this->_optionalNullableSet['opt'] = true;
+    }
+
+    /**
+     *
+     */
+    public function unsetOpt() : void
+    {
+        $this->opt = null;
+        unset($this->_optionalNullableSet['opt']);
     }
 
     /**
@@ -145,13 +162,16 @@ class MyClass
             static::validateInput($input);
         }
 
+        $__optNullables = [];
         $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
         $bar = Baz::buildFromInput($input->{'bar'}, $validate);
-        $opt = isset($input->{'opt'}) ? $input->{'opt'} : null;
+        $opt = property_exists($input, 'opt') ? $input->{'opt'} : null;
+        if (property_exists($input, 'opt')) { $__optNullables['opt'] = true; }
 
         $obj = new self($bar);
         $obj->foo = $foo;
         $obj->opt = $opt;
+        $obj->_optionalNullableSet = $__optNullables;
         return $obj;
     }
 
@@ -167,7 +187,9 @@ class MyClass
             $output['foo'] = $this->foo;
         }
         $output['bar'] = $this->bar->toArray();
-        $output['opt'] = $this->opt;
+        if (isset($this->opt) || array_key_exists('opt', $this->_optionalNullableSet)) {
+            $output['opt'] = $this->opt;
+        }
 
         return $output;
     }
@@ -194,5 +216,14 @@ class MyClass
         }
 
         return $validator->isValid();
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function isSet(string $propertyName) : bool
+    {
+        return array_key_exists($propertyName, $this->_optionalNullableSet);
     }
 }

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/MyClass.php
@@ -40,6 +40,13 @@ class MyClass
     ];
 
     /**
+     * @var array
+     */
+    private $_optionalNullableSet = [
+        
+    ];
+
+    /**
      * @var string|null
      */
     private $foo = null;
@@ -133,6 +140,18 @@ class MyClass
         }
 
         $this->opt = $opt;
+        $this->_optionalNullableSet['opt'] = true;
+
+        return $this;
+    }
+
+    /**
+     * @return self
+     */
+    public function unsetOpt()
+    {
+        $this->opt = null;
+        unset($this->_optionalNullableSet['opt']);
 
         return $this;
     }
@@ -158,13 +177,16 @@ class MyClass
             static::validateInput($input);
         }
 
+        $__optNullables = [];
         $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
         $bar = Baz::buildFromInput($input->{'bar'}, $validate);
-        $opt = isset($input->{'opt'}) ? $input->{'opt'} : null;
+        $opt = property_exists($input, 'opt') ? $input->{'opt'} : null;
+        if (property_exists($input, 'opt')) { $__optNullables['opt'] = true; }
 
         $obj = new self($bar);
         $obj->foo = $foo;
         $obj->opt = $opt;
+        $obj->_optionalNullableSet = $__optNullables;
         return $obj;
     }
 
@@ -180,7 +202,9 @@ class MyClass
             $output['foo'] = $this->foo;
         }
         $output['bar'] = $this->bar->toArray();
-        $output['opt'] = $this->opt;
+        if (isset($this->opt) || array_key_exists('opt', $this->_optionalNullableSet)) {
+            $output['opt'] = $this->opt;
+        }
 
         return $output;
     }
@@ -207,5 +231,14 @@ class MyClass
         }
 
         return $validator->isValid();
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function isSet(string $propertyName)
+    {
+        return array_key_exists($propertyName, $this->_optionalNullableSet);
     }
 }

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
@@ -42,6 +42,13 @@ class MyClass
     ];
 
     /**
+     * @var array
+     */
+    private $_optionalNullableSet = [
+        
+    ];
+
+    /**
      * @var string|null
      */
     private ?string $foo = null;
@@ -135,6 +142,18 @@ class MyClass
         }
 
         $this->opt = $opt;
+        $this->_optionalNullableSet['opt'] = true;
+
+        return $this;
+    }
+
+    /**
+     * @return self
+     */
+    public function unsetOpt() : self
+    {
+        $this->opt = null;
+        unset($this->_optionalNullableSet['opt']);
 
         return $this;
     }
@@ -160,13 +179,16 @@ class MyClass
             static::validateInput($input);
         }
 
+        $__optNullables = [];
         $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
         $bar = Baz::buildFromInput($input->{'bar'}, $validate);
-        $opt = isset($input->{'opt'}) ? $input->{'opt'} : null;
+        $opt = property_exists($input, 'opt') ? $input->{'opt'} : null;
+        if (property_exists($input, 'opt')) { $__optNullables['opt'] = true; }
 
         $obj = new self($bar);
         $obj->foo = $foo;
         $obj->opt = $opt;
+        $obj->_optionalNullableSet = $__optNullables;
         return $obj;
     }
 
@@ -182,7 +204,9 @@ class MyClass
             $output['foo'] = $this->foo;
         }
         $output['bar'] = $this->bar->toArray();
-        $output['opt'] = $this->opt;
+        if (isset($this->opt) || array_key_exists('opt', $this->_optionalNullableSet)) {
+            $output['opt'] = $this->opt;
+        }
 
         return $output;
     }
@@ -209,5 +233,14 @@ class MyClass
         }
 
         return $validator->isValid();
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function isSet(string $propertyName) : bool
+    {
+        return array_key_exists($propertyName, $this->_optionalNullableSet);
     }
 }

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
@@ -42,6 +42,13 @@ class MyClass
     ];
 
     /**
+     * @var array
+     */
+    private $_optionalNullableSet = [
+        
+    ];
+
+    /**
      * @var string|null
      */
     private ?string $foo = null;
@@ -135,6 +142,18 @@ class MyClass
         }
 
         $this->opt = $opt;
+        $this->_optionalNullableSet['opt'] = true;
+
+        return $this;
+    }
+
+    /**
+     * @return self
+     */
+    public function unsetOpt() : self
+    {
+        $this->opt = null;
+        unset($this->_optionalNullableSet['opt']);
 
         return $this;
     }
@@ -154,13 +173,16 @@ class MyClass
             static::validateInput($input);
         }
 
+        $__optNullables = [];
         $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
         $bar = Baz::buildFromInput($input->{'bar'}, $validate);
-        $opt = isset($input->{'opt'}) ? $input->{'opt'} : null;
+        $opt = property_exists($input, 'opt') ? $input->{'opt'} : null;
+        if (property_exists($input, 'opt')) { $__optNullables['opt'] = true; }
 
         $obj = new self($bar);
         $obj->foo = $foo;
         $obj->opt = $opt;
+        $obj->_optionalNullableSet = $__optNullables;
         return $obj;
     }
 
@@ -176,7 +198,9 @@ class MyClass
             $output['foo'] = $this->foo;
         }
         $output['bar'] = $this->bar->toArray();
-        $output['opt'] = $this->opt;
+        if (isset($this->opt) || array_key_exists('opt', $this->_optionalNullableSet)) {
+            $output['opt'] = $this->opt;
+        }
 
         return $output;
     }
@@ -203,5 +227,14 @@ class MyClass
         }
 
         return $validator->isValid();
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function isSet(string $propertyName) : bool
+    {
+        return array_key_exists($propertyName, $this->_optionalNullableSet);
     }
 }

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Fio.php
@@ -22,6 +22,13 @@ class Fio
     ];
 
     /**
+     * @var array
+     */
+    private $_optionalNullableSet = [
+        
+    ];
+
+    /**
      * @var string|null
      */
     private $bar = null;
@@ -51,6 +58,7 @@ class Fio
 
         $clone = clone $this;
         $clone->bar = $bar;
+        $clone->_optionalNullableSet['bar'] = true;
 
         return $clone;
     }
@@ -62,6 +70,7 @@ class Fio
     {
         $clone = clone $this;
         unset($clone->bar);
+        unset($clone->_optionalNullableSet['bar']);
 
         return $clone;
     }
@@ -87,10 +96,13 @@ class Fio
             static::validateInput($input);
         }
 
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+        $__optNullables = [];
+        $bar = property_exists($input, 'bar') ? $input->{'bar'} : null;
+        if (property_exists($input, 'bar')) { $__optNullables['bar'] = true; }
 
         $obj = new self();
         $obj->bar = $bar;
+        $obj->_optionalNullableSet = $__optNullables;
         return $obj;
     }
 
@@ -102,7 +114,9 @@ class Fio
     public function toArray()
     {
         $output = [];
-        $output['bar'] = $this->bar;
+        if (isset($this->bar) || array_key_exists('bar', $this->_optionalNullableSet)) {
+            $output['bar'] = $this->bar;
+        }
 
         return $output;
     }
@@ -129,5 +143,14 @@ class Fio
         }
 
         return $validator->isValid();
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function isSet(string $propertyName)
+    {
+        return array_key_exists($propertyName, $this->_optionalNullableSet);
     }
 }

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Fio.php
@@ -24,6 +24,13 @@ class Fio
     ];
 
     /**
+     * @var array
+     */
+    private $_optionalNullableSet = [
+        
+    ];
+
+    /**
      * @var string|null
      */
     private ?string $bar = null;
@@ -53,6 +60,7 @@ class Fio
 
         $clone = clone $this;
         $clone->bar = $bar;
+        $clone->_optionalNullableSet['bar'] = true;
 
         return $clone;
     }
@@ -64,6 +72,7 @@ class Fio
     {
         $clone = clone $this;
         unset($clone->bar);
+        unset($clone->_optionalNullableSet['bar']);
 
         return $clone;
     }
@@ -89,10 +98,13 @@ class Fio
             static::validateInput($input);
         }
 
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+        $__optNullables = [];
+        $bar = property_exists($input, 'bar') ? $input->{'bar'} : null;
+        if (property_exists($input, 'bar')) { $__optNullables['bar'] = true; }
 
         $obj = new self();
         $obj->bar = $bar;
+        $obj->_optionalNullableSet = $__optNullables;
         return $obj;
     }
 
@@ -104,7 +116,9 @@ class Fio
     public function toArray() : array
     {
         $output = [];
-        $output['bar'] = $this->bar;
+        if (isset($this->bar) || array_key_exists('bar', $this->_optionalNullableSet)) {
+            $output['bar'] = $this->bar;
+        }
 
         return $output;
     }
@@ -131,5 +145,14 @@ class Fio
         }
 
         return $validator->isValid();
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function isSet(string $propertyName) : bool
+    {
+        return array_key_exists($propertyName, $this->_optionalNullableSet);
     }
 }

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Fio.php
@@ -24,6 +24,13 @@ class Fio
     ];
 
     /**
+     * @var array
+     */
+    private $_optionalNullableSet = [
+        
+    ];
+
+    /**
      * @var string|null
      */
     private ?string $bar = null;
@@ -53,6 +60,7 @@ class Fio
 
         $clone = clone $this;
         $clone->bar = $bar;
+        $clone->_optionalNullableSet['bar'] = true;
 
         return $clone;
     }
@@ -64,6 +72,7 @@ class Fio
     {
         $clone = clone $this;
         unset($clone->bar);
+        unset($clone->_optionalNullableSet['bar']);
 
         return $clone;
     }
@@ -83,10 +92,13 @@ class Fio
             static::validateInput($input);
         }
 
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+        $__optNullables = [];
+        $bar = property_exists($input, 'bar') ? $input->{'bar'} : null;
+        if (property_exists($input, 'bar')) { $__optNullables['bar'] = true; }
 
         $obj = new self();
         $obj->bar = $bar;
+        $obj->_optionalNullableSet = $__optNullables;
         return $obj;
     }
 
@@ -98,7 +110,9 @@ class Fio
     public function toArray() : array
     {
         $output = [];
-        $output['bar'] = $this->bar;
+        if (isset($this->bar) || array_key_exists('bar', $this->_optionalNullableSet)) {
+            $output['bar'] = $this->bar;
+        }
 
         return $output;
     }
@@ -125,5 +139,14 @@ class Fio
         }
 
         return $validator->isValid();
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function isSet(string $propertyName) : bool
+    {
+        return array_key_exists($propertyName, $this->_optionalNullableSet);
     }
 }

--- a/tests/Generator/Fixtures/OptionalProperty/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalProperty/Output-8.4/MyClass.php
@@ -33,6 +33,13 @@ class MyClass
     ];
 
     /**
+     * @var array
+     */
+    private $_optionalNullableSet = [
+        
+    ];
+
+    /**
      * @var string
      */
     private string $foo;
@@ -149,6 +156,7 @@ class MyClass
 
         $clone = clone $this;
         $clone->baz = $baz;
+        $clone->_optionalNullableSet['baz'] = true;
 
         return $clone;
     }
@@ -160,6 +168,7 @@ class MyClass
     {
         $clone = clone $this;
         unset($clone->baz);
+        unset($clone->_optionalNullableSet['baz']);
 
         return $clone;
     }
@@ -179,13 +188,16 @@ class MyClass
             static::validateInput($input);
         }
 
+        $__optNullables = [];
         $foo = $input->{'foo'};
         $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
-        $baz = isset($input->{'baz'}) ? $input->{'baz'} : null;
+        $baz = property_exists($input, 'baz') ? $input->{'baz'} : null;
+        if (property_exists($input, 'baz')) { $__optNullables['baz'] = true; }
 
         $obj = new self($foo);
         $obj->bar = $bar;
         $obj->baz = $baz;
+        $obj->_optionalNullableSet = $__optNullables;
         return $obj;
     }
 
@@ -201,7 +213,9 @@ class MyClass
         if (isset($this->bar)) {
             $output['bar'] = $this->bar;
         }
-        $output['baz'] = $this->baz;
+        if (isset($this->baz) || array_key_exists('baz', $this->_optionalNullableSet)) {
+            $output['baz'] = $this->baz;
+        }
 
         return $output;
     }
@@ -228,5 +242,14 @@ class MyClass
         }
 
         return $validator->isValid();
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function isSet(string $propertyName) : bool
+    {
+        return array_key_exists($propertyName, $this->_optionalNullableSet);
     }
 }

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
@@ -33,6 +33,13 @@ class Cat
     ];
 
     /**
+     * @var array
+     */
+    private $_optionalNullableSet = [
+        
+    ];
+
+    /**
      * Whether the cat has fur. True by default for most cats
      *
      * @var bool|null
@@ -66,6 +73,7 @@ class Cat
 
         $clone = clone $this;
         $clone->hasFur = $hasFur;
+        $clone->_optionalNullableSet['hasFur'] = true;
 
         return $clone;
     }
@@ -77,6 +85,7 @@ class Cat
     {
         $clone = clone $this;
         $clone->hasFur = true;
+        unset($clone->_optionalNullableSet['hasFur']);
 
         return $clone;
     }
@@ -96,10 +105,13 @@ class Cat
             static::validateInput($input);
         }
 
+        $__optNullables = [];
         $hasFur = property_exists($input, 'hasFur') ? $input->{'hasFur'} : true;
+        if (property_exists($input, 'hasFur')) { $__optNullables['hasFur'] = true; }
 
         $obj = new self();
         $obj->hasFur = $hasFur;
+        $obj->_optionalNullableSet = $__optNullables;
         return $obj;
     }
 
@@ -111,7 +123,9 @@ class Cat
     public function toArray() : array
     {
         $output = [];
-        $output['hasFur'] = $this->hasFur;
+        if (isset($this->hasFur) || array_key_exists('hasFur', $this->_optionalNullableSet)) {
+            $output['hasFur'] = $this->hasFur;
+        }
 
         return $output;
     }
@@ -138,5 +152,14 @@ class Cat
         }
 
         return $validator->isValid();
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function isSet(string $propertyName) : bool
+    {
+        return array_key_exists($propertyName, $this->_optionalNullableSet);
     }
 }

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
@@ -31,6 +31,13 @@ class GenericPet
     ];
 
     /**
+     * @var array
+     */
+    private $_optionalNullableSet = [
+        
+    ];
+
+    /**
      * Whether the animal has fur (true), doesn't (false), or it's unknown or varies (null)
      *
      * @var bool|null
@@ -64,6 +71,7 @@ class GenericPet
 
         $clone = clone $this;
         $clone->hasFur = $hasFur;
+        $clone->_optionalNullableSet['hasFur'] = true;
 
         return $clone;
     }
@@ -75,6 +83,7 @@ class GenericPet
     {
         $clone = clone $this;
         $clone->hasFur = false;
+        unset($clone->_optionalNullableSet['hasFur']);
 
         return $clone;
     }
@@ -94,10 +103,13 @@ class GenericPet
             static::validateInput($input);
         }
 
+        $__optNullables = [];
         $hasFur = property_exists($input, 'hasFur') ? $input->{'hasFur'} : false;
+        if (property_exists($input, 'hasFur')) { $__optNullables['hasFur'] = true; }
 
         $obj = new self();
         $obj->hasFur = $hasFur;
+        $obj->_optionalNullableSet = $__optNullables;
         return $obj;
     }
 
@@ -109,7 +121,9 @@ class GenericPet
     public function toArray() : array
     {
         $output = [];
-        $output['hasFur'] = $this->hasFur;
+        if (isset($this->hasFur) || array_key_exists('hasFur', $this->_optionalNullableSet)) {
+            $output['hasFur'] = $this->hasFur;
+        }
 
         return $output;
     }
@@ -136,5 +150,14 @@ class GenericPet
         }
 
         return $validator->isValid();
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function isSet(string $propertyName) : bool
+    {
+        return array_key_exists($propertyName, $this->_optionalNullableSet);
     }
 }


### PR DESCRIPTION
## Summary
- track nullable optional fields with `_optionalNullableSet`
- add `isSet` helper
- generate setters/unsetters that update the new tracking array
- update generator and schema builder logic
- refresh tests

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit --filter OptionalProperty-8.4`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687974529bec832d8a62cc49f2713333