### PR TITLE
Fix parameter forwarding for nested buildFromInput

### DIFF
--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -16,6 +16,7 @@ use Helmich\Schema2Class\Generator\Property\ReferenceArrayProperty;
 use Helmich\Schema2Class\Generator\Property\NullablePropertyDecorator;
 use Helmich\Schema2Class\Generator\Property\PropertyDecoratorInterface;
 use Helmich\Schema2Class\Generator\Property\TypedArrayProperty;
+use Helmich\Schema2Class\Generator\Property\AbstractProperty;
 use Helmich\Schema2Class\Util\StringUtils;
 use Laminas\Code\Generator\DocBlock\Tag\GenericTag;
 use Laminas\Code\Generator\DocBlock\Tag\ParamTag;
@@ -183,6 +184,11 @@ class Generator
                 $i++;
             }
         }
+
+        AbstractProperty::setBuildFromInputParameterNames(
+            $validateParamName,
+            $hasDefaults ? $materializeParamName : null
+        );
 
         $assignments = [];
         foreach ($optionalProperties as $optionalProperty) {

--- a/src/Generator/Property/AbstractProperty.php
+++ b/src/Generator/Property/AbstractProperty.php
@@ -11,6 +11,25 @@ use Laminas\Code\Generator\PropertyValueGenerator;
 
 abstract class AbstractProperty implements PropertyInterface, RenameablePropertyInterface
 {
+    /**
+     * Name of the $validate argument in the currently generated buildFromInput method.
+     * This is set from the Generator during generation.
+     * @internal
+     */
+    protected static string $buildValidateParam = 'validate';
+
+    /**
+     * Name of the $materializeDefaults argument in the currently generated buildFromInput method
+     * (null when the argument is not generated). This is set from the Generator.
+     * @internal
+     */
+    protected static ?string $buildMaterializeParam = 'materializeDefaults';
+
+    public static function setBuildFromInputParameterNames(string $validateParam, ?string $materializeParam): void
+    {
+        self::$buildValidateParam = $validateParam;
+        self::$buildMaterializeParam = $materializeParam;
+    }
     protected string $key;
 
     protected string $name;

--- a/src/Generator/Property/IntersectProperty.php
+++ b/src/Generator/Property/IntersectProperty.php
@@ -57,10 +57,13 @@ class IntersectProperty extends AbstractProperty
 
     public function generateInputMappingExpr(string $expr, bool $asserted = false): string
     {
-        if ($this->generatorRequest->isAtLeastPHP("8.0")) {
-            return "{$this->subTypeName()}::buildFromInput({$expr}, validate: \$validate)";
+        $validateArg = '$' . AbstractProperty::$buildValidateParam;
+        $materialize = AbstractProperty::$buildMaterializeParam;
+        $args = [$expr, $validateArg];
+        if ($materialize !== null) {
+            $args[] = '$' . $materialize;
         }
-        return "{$this->subTypeName()}::buildFromInput({$expr}, \$validate)";
+        return sprintf('%s::buildFromInput(%s)', $this->subTypeName(), implode(', ', $args));
     }
 
     public function generateOutputMappingExpr(string $expr): string

--- a/src/Generator/Property/NestedObjectProperty.php
+++ b/src/Generator/Property/NestedObjectProperty.php
@@ -65,10 +65,13 @@ class NestedObjectProperty extends AbstractProperty
 
     public function generateInputMappingExpr(string $expr, bool $asserted = false): string
     {
-        if ($this->generatorRequest->isAtLeastPHP("8.0")) {
-            return "{$this->subTypeName()}::buildFromInput({$expr}, validate: \$validate)";
+        $validateArg = '$' . AbstractProperty::$buildValidateParam;
+        $materialize = AbstractProperty::$buildMaterializeParam;
+        $args = [$expr, $validateArg];
+        if ($materialize !== null) {
+            $args[] = '$' . $materialize;
         }
-        return "{$this->subTypeName()}::buildFromInput({$expr}, \$validate)";
+        return sprintf('%s::buildFromInput(%s)', $this->subTypeName(), implode(', ', $args));
     }
 
     public function generateOutputMappingExpr(string $expr): string

--- a/src/Generator/Property/ObjectArrayProperty.php
+++ b/src/Generator/Property/ObjectArrayProperty.php
@@ -12,6 +12,15 @@ class ObjectArrayProperty extends AbstractProperty
 {
     use TypeConvert;
 
+    private function buildUseClause(): string
+    {
+        $vars = ['$' . self::$buildValidateParam];
+        if (self::$buildMaterializeParam !== null) {
+            $vars[] = '$' . self::$buildMaterializeParam;
+        }
+        return implode(', ', $vars);
+    }
+
     private PropertyInterface $itemType;
     private array $itemSchema;
 
@@ -140,8 +149,19 @@ class ObjectArrayProperty extends AbstractProperty
         return match (true) {
             $this->generatorRequest->isAtLeastPHP('8.0') => "array_map(fn (array|object \$i): {$typeHint} => {$sm}, {$expr})",
             $this->generatorRequest->isAtLeastPHP('7.4') => "array_map(fn (\$i): {$typeHint} => {$sm}, {$expr})",
-            $this->generatorRequest->isAtLeastPHP('7.0') => "array_map(function(\$i): {$typeHint} use (\$validate) { return {$sm}; }, {$expr})",
-            default => "array_map(function(\$i) use (\$validate) { return {$sm}; }, {$expr})",
+            $this->generatorRequest->isAtLeastPHP('7.0') => sprintf(
+                'array_map(function($i): %s use (%s) { return %s; }, %s)',
+                $typeHint,
+                $this->buildUseClause(),
+                $sm,
+                $expr
+            ),
+            default => sprintf(
+                'array_map(function($i) use (%s) { return %s; }, %s)',
+                $this->buildUseClause(),
+                $sm,
+                $expr
+            ),
         };
     }
 

--- a/src/Generator/Property/TypedArrayProperty.php
+++ b/src/Generator/Property/TypedArrayProperty.php
@@ -89,7 +89,11 @@ class TypedArrayProperty extends AbstractProperty
         if ($this->generatorRequest->isAtLeastPHP('7.4')) {
             return "array_map(fn(\$i) => {$map}, {$expr})";
         }
-        return "array_map(function(\$i) use (\$validate) { return {$map}; }, {$expr})";
+        $use = ['$' . AbstractProperty::$buildValidateParam];
+        if (AbstractProperty::$buildMaterializeParam !== null) {
+            $use[] = '$' . AbstractProperty::$buildMaterializeParam;
+        }
+        return sprintf('array_map(function($i) use (%s) { return %s; }, %s)', implode(', ', $use), $map, $expr);
     }
 
     public function generateOutputMappingExpr(string $expr): string

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -1729,7 +1729,7 @@ class MyClass
         $obj = $_input->{'obj'};
         $materializeDefaults = $_input->{'materializeDefaults'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $validate) : null;
+        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
         $_buildFromInput_1 = $_input->{'buildFromInput'};
         $_toArray_1 = $_input->{'toArray'};
         $_validateInput_1 = $_input->{'validateInput'};

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -1731,7 +1731,7 @@ class MyClass
         $obj = $_input->{'obj'};
         $materializeDefaults = $_input->{'materializeDefaults'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $validate) : null;
+        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
         $_buildFromInput_1 = $_input->{'buildFromInput'};
         $_toArray_1 = $_input->{'toArray'};
         $_validateInput_1 = $_input->{'validateInput'};

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
@@ -1725,7 +1725,7 @@ class MyClass
         $obj = $_input->{'obj'};
         $materializeDefaults = $_input->{'materializeDefaults'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, validate: $validate) : null;
+        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
         $_buildFromInput_1 = $_input->{'buildFromInput'};
         $_toArray_1 = $_input->{'toArray'};
         $_validateInput_1 = $_input->{'validateInput'};

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -1729,7 +1729,7 @@ class MyClass
         $obj = $_input->{'obj'};
         $materializeDefaults = $_input->{'materializeDefaults'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $validate) : null;
+        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
         $_buildFromInput = $_input->{'buildFromInput'};
         $_toArray = $_input->{'toArray'};
         $_validateInput = $_input->{'validateInput'};

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -1731,7 +1731,7 @@ class MyClass
         $obj = $_input->{'obj'};
         $materializeDefaults = $_input->{'materializeDefaults'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $validate) : null;
+        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
         $_buildFromInput = $_input->{'buildFromInput'};
         $_toArray = $_input->{'toArray'};
         $_validateInput = $_input->{'validateInput'};

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
@@ -1725,7 +1725,7 @@ class MyClass
         $obj = $_input->{'obj'};
         $materializeDefaults = $_input->{'materializeDefaults'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, validate: $validate) : null;
+        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
         $_buildFromInput = $_input->{'buildFromInput'};
         $_toArray = $_input->{'toArray'};
         $_validateInput = $_input->{'validateInput'};

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
@@ -137,7 +137,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $files = isset($input->{'files'}) ? array_map(fn (array|object $i): MyClassFilesItem => MyClassFilesItem::buildFromInput($i, validate: $validate), $input->{'files'}) : null;
+        $files = isset($input->{'files'}) ? array_map(fn (array|object $i): MyClassFilesItem => MyClassFilesItem::buildFromInput($i, $validate), $input->{'files'}) : null;
         $options = isset($input->{'options'}) ? OptionsObject::buildFromInput($input->{'options'}, $validate) : null;
 
         $obj = new self();

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClass.php
@@ -518,7 +518,7 @@ class MyClass
         $quux = $input->{'quux'};
         $xyyz = isset($input->{'xyyz'}) ? $input->{'xyyz'} : null;
         $thud = $input->{'thud'};
-        $grox = property_exists($input, 'grox') ? MyClassGrox::buildFromInput($input->{'grox'}, $validate) : null;
+        $grox = property_exists($input, 'grox') ? MyClassGrox::buildFromInput($input->{'grox'}, $validate, $materializeDefaults) : null;
         if (property_exists($input, 'grox')) {
             $__explicitNulls['grox'] = true;
         }

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
@@ -514,7 +514,7 @@ class MyClass
         $quux = $input->{'quux'};
         $xyyz = isset($input->{'xyyz'}) ? $input->{'xyyz'} : null;
         $thud = $input->{'thud'};
-        $grox = property_exists($input, 'grox') ? MyClassGrox::buildFromInput($input->{'grox'}, validate: $validate) : null;
+        $grox = property_exists($input, 'grox') ? MyClassGrox::buildFromInput($input->{'grox'}, $validate, $materializeDefaults) : null;
         if (property_exists($input, 'grox')) {
             $__explicitNulls['grox'] = true;
         }

--- a/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumber.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumber.php
@@ -98,7 +98,7 @@ class MyGenericStringNumber
             static::validateInput($input);
         }
 
-        $field = MyGenericStringNumberField::buildFromInput($input->{'field'}, validate: $validate);
+        $field = MyGenericStringNumberField::buildFromInput($input->{'field'}, $validate);
 
         $obj = new self($field);
 

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-8.4/MyClass.php
@@ -83,7 +83,7 @@ class MyClass
 
         $foo = match (true) {
             is_string($input->{'foo'}) => $input->{'foo'},
-            MyClassFooAlternative2::validateInput($input->{'foo'}, true) => MyClassFooAlternative2::buildFromInput($input->{'foo'}, validate: $validate),
+            MyClassFooAlternative2::validateInput($input->{'foo'}, true) => MyClassFooAlternative2::buildFromInput($input->{'foo'}, $validate),
             default => throw new \InvalidArgumentException("could not build property 'foo' from JSON"),
         };
 

--- a/tests/Generator/Property/IntersectPropertyTest.php
+++ b/tests/Generator/Property/IntersectPropertyTest.php
@@ -53,7 +53,7 @@ class IntersectPropertyTest extends TestCase
         $result = $underTest->convertInputToType('variable');
 
         $expected = <<<'EOCODE'
-$myPropertyName = FooMyPropertyName::buildFromInput($variable['myPropertyName'], validate: $validate);
+$myPropertyName = FooMyPropertyName::buildFromInput($variable['myPropertyName'], $validate, $materializeDefaults);
 EOCODE;
 
         assertSame($expected, $result);

--- a/tests/Generator/Property/NestedObjectPropertyTest.php
+++ b/tests/Generator/Property/NestedObjectPropertyTest.php
@@ -50,7 +50,7 @@ class NestedObjectPropertyTest extends TestCase
         $result = $underTest->convertInputToType('variable');
 
         $expected = <<<'EOCODE'
-$myPropertyName = FooMyPropertyName::buildFromInput($variable['myPropertyName'], validate: $validate);
+$myPropertyName = FooMyPropertyName::buildFromInput($variable['myPropertyName'], $validate, $materializeDefaults);
 EOCODE;
 
         assertSame($expected, $result);

--- a/tests/Generator/Property/ObjectArrayPropertyTest.php
+++ b/tests/Generator/Property/ObjectArrayPropertyTest.php
@@ -65,7 +65,7 @@ class ObjectArrayPropertyTest extends TestCase
         $result = $underTest->convertInputToType('variable');
 
         $expected = <<<'EOCODE'
-$myPropertyName = array_map(fn (array|object $i): FooMyPropertyNameItem => FooMyPropertyNameItem::buildFromInput($i, validate: $validate), $variable['myPropertyName']);
+$myPropertyName = array_map(fn (array|object $i): FooMyPropertyNameItem => FooMyPropertyNameItem::buildFromInput($i, $validate, $materializeDefaults), $variable['myPropertyName']);
 EOCODE;
 
         assertSame($expected, $result);

--- a/tests/Generator/Property/UnionPropertyTest.php
+++ b/tests/Generator/Property/UnionPropertyTest.php
@@ -54,8 +54,8 @@ class UnionPropertyTest extends TestCase
 
         $expected = <<<'EOCODE'
 $myPropertyName = match (true) {
-    FooMyPropertyNameAlternative1::validateInput($variable['myPropertyName'], true) => FooMyPropertyNameAlternative1::buildFromInput($variable['myPropertyName'], validate: $validate),
-    FooMyPropertyNameAlternative2::validateInput($variable['myPropertyName'], true) => FooMyPropertyNameAlternative2::buildFromInput($variable['myPropertyName'], validate: $validate),
+    FooMyPropertyNameAlternative1::validateInput($variable['myPropertyName'], true) => FooMyPropertyNameAlternative1::buildFromInput($variable['myPropertyName'], $validate, $materializeDefaults),
+    FooMyPropertyNameAlternative2::validateInput($variable['myPropertyName'], true) => FooMyPropertyNameAlternative2::buildFromInput($variable['myPropertyName'], $validate, $materializeDefaults),
     default => throw new \InvalidArgumentException("could not build property 'myPropertyName' from JSON"),
 };
 EOCODE;


### PR DESCRIPTION
## Summary
- track variable names used for validation and defaults when generating buildFromInput
- forward these parameters when mapping nested objects and object intersections
- adjust array mapping closures
- update fixtures and property unit tests

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687b919ac930832d941e67b015da1225