### PR TITLE
Fix buildFromInput argument propagation

### DIFF
--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -183,8 +183,8 @@ class Generator
             }
         }
 
-        $this->generatorRequest = $this->generatorRequest->withCurrValidateArgName($validateArgName);
-        $this->generatorRequest = $this->generatorRequest->withCurrMaterializeArgName($hasDefaults ? $materializeArgName : null);
+        $this->generatorRequest->setCurrValidateArgName($validateArgName);
+        $this->generatorRequest->setCurrMaterializeArgName($hasDefaults ? $materializeArgName : null);
 
         $assignments = [];
         foreach ($optionalProperties as $optionalProperty) {

--- a/src/Generator/GeneratorRequest.php
+++ b/src/Generator/GeneratorRequest.php
@@ -339,6 +339,16 @@ class GeneratorRequest
         return $clone;
     }
 
+    public function setCurrValidateArgName(string $currValidateArgName): void
+    {
+        $this->currValidateArgName = $currValidateArgName;
+    }
+
+    public function setCurrMaterializeArgName(?string $currMaterializeArgName): void
+    {
+        $this->currMaterializeArgName = $currMaterializeArgName;
+    }
+
     public function getCurrValidateArgName(): string
     {
         return $this->currValidateArgName;

--- a/src/Generator/GeneratorRequest.php
+++ b/src/Generator/GeneratorRequest.php
@@ -325,25 +325,21 @@ class GeneratorRequest
         throw new GeneratorException("unresolvable reference: {$ref}");
     }
 
-    public function withCurrValidateArgName(string $currValidateArgName): self
-    {
-        $clone = clone $this;
-        $clone->currValidateArgName = $currValidateArgName;
-        return $clone;
-    }
-
-    public function withCurrMaterializeArgName(?string $currMaterializeArgName): self
-    {
-        $clone = clone $this;
-        $clone->currMaterializeArgName = $currMaterializeArgName;
-        return $clone;
-    }
-
+    /**
+     * This method is deliberately mutating (not `with...`) so that the active
+     * argument names can be updated for all property generators during code generation
+     * to ensure consistent variable names in nested contexts
+     */
     public function setCurrValidateArgName(string $currValidateArgName): void
     {
         $this->currValidateArgName = $currValidateArgName;
     }
 
+    /**
+     * This method is deliberately mutating (not `with...`) so that the active
+     * argument names can be updated for all property generators during code generation
+     * to ensure consistent variable names in nested contexts
+     */
     public function setCurrMaterializeArgName(?string $currMaterializeArgName): void
     {
         $this->currMaterializeArgName = $currMaterializeArgName;

--- a/src/Generator/Property/ObjectArrayProperty.php
+++ b/src/Generator/Property/ObjectArrayProperty.php
@@ -160,7 +160,7 @@ class ObjectArrayProperty extends AbstractProperty
                 => "array_map(function(\$i): {$typeHint} use ({$this->buildUseClause()}) { return {$sm}; }, {$expr})",
 
             default
-                => "array_map(function(\$i): use ({$this->buildUseClause()}) { return {$sm}; }, {$expr})",
+                => "array_map(function(\$i) use ({$this->buildUseClause()}) { return {$sm}; }, {$expr})",
         };
     }
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -1729,7 +1729,7 @@ class MyClass
         $obj = $_input->{'obj'};
         $materializeDefaults = $_input->{'materializeDefaults'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $validate, $materializeDefaults) : null;
+        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
         $_buildFromInput_1 = $_input->{'buildFromInput'};
         $_toArray_1 = $_input->{'toArray'};
         $_validateInput_1 = $_input->{'validateInput'};

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -1731,7 +1731,7 @@ class MyClass
         $obj = $_input->{'obj'};
         $materializeDefaults = $_input->{'materializeDefaults'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $validate, $materializeDefaults) : null;
+        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
         $_buildFromInput_1 = $_input->{'buildFromInput'};
         $_toArray_1 = $_input->{'toArray'};
         $_validateInput_1 = $_input->{'validateInput'};

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
@@ -1725,7 +1725,7 @@ class MyClass
         $obj = $_input->{'obj'};
         $materializeDefaults = $_input->{'materializeDefaults'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $validate, $materializeDefaults) : null;
+        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
         $_buildFromInput_1 = $_input->{'buildFromInput'};
         $_toArray_1 = $_input->{'toArray'};
         $_validateInput_1 = $_input->{'validateInput'};

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -1729,7 +1729,7 @@ class MyClass
         $obj = $_input->{'obj'};
         $materializeDefaults = $_input->{'materializeDefaults'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $validate, $materializeDefaults) : null;
+        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
         $_buildFromInput = $_input->{'buildFromInput'};
         $_toArray = $_input->{'toArray'};
         $_validateInput = $_input->{'validateInput'};

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -1731,7 +1731,7 @@ class MyClass
         $obj = $_input->{'obj'};
         $materializeDefaults = $_input->{'materializeDefaults'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $validate, $materializeDefaults) : null;
+        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
         $_buildFromInput = $_input->{'buildFromInput'};
         $_toArray = $_input->{'toArray'};
         $_validateInput = $_input->{'validateInput'};

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
@@ -1725,7 +1725,7 @@ class MyClass
         $obj = $_input->{'obj'};
         $materializeDefaults = $_input->{'materializeDefaults'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $validate, $materializeDefaults) : null;
+        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
         $_buildFromInput = $_input->{'buildFromInput'};
         $_toArray = $_input->{'toArray'};
         $_validateInput = $_input->{'validateInput'};

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
@@ -141,7 +141,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $files = isset($input->{'files'}) ? array_map(function($i): use ($validate, $materializeDefaults) { return MyClassFilesItem::buildFromInput($i, $validate, $materializeDefaults); }, $input->{'files'}) : null;
+        $files = isset($input->{'files'}) ? array_map(function($i) use ($validate) { return MyClassFilesItem::buildFromInput($i, $validate); }, $input->{'files'}) : null;
         $options = isset($input->{'options'}) ? OptionsObject::buildFromInput($input->{'options'}, $validate) : null;
 
         $obj = new self();

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
@@ -143,7 +143,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $files = isset($input->{'files'}) ? array_map(fn ($i): MyClassFilesItem => MyClassFilesItem::buildFromInput($i, $validate, $materializeDefaults), $input->{'files'}) : null;
+        $files = isset($input->{'files'}) ? array_map(fn ($i): MyClassFilesItem => MyClassFilesItem::buildFromInput($i, $validate), $input->{'files'}) : null;
         $options = isset($input->{'options'}) ? OptionsObject::buildFromInput($input->{'options'}, $validate) : null;
 
         $obj = new self();

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
@@ -137,7 +137,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $files = isset($input->{'files'}) ? array_map(fn (array|object $i): MyClassFilesItem => MyClassFilesItem::buildFromInput($i, $validate, $materializeDefaults), $input->{'files'}) : null;
+        $files = isset($input->{'files'}) ? array_map(fn (array|object $i): MyClassFilesItem => MyClassFilesItem::buildFromInput($i, $validate), $input->{'files'}) : null;
         $options = isset($input->{'options'}) ? OptionsObject::buildFromInput($input->{'options'}, $validate) : null;
 
         $obj = new self();

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Record.php
@@ -293,12 +293,12 @@ class Record
             fn($i) => Phone::buildFromInput($i, $validate),
             $input->{'dataArray'}
         ) : null;
-        $dataArrayNested = isset($input->{'dataArrayNested'}) ? array_map(function($i) use ($validate, $materializeDefaults) { return array_map(
+        $dataArrayNested = isset($input->{'dataArrayNested'}) ? array_map(function($i) use ($validate) { return array_map(
             fn($i) => Phone::buildFromInput($i, $validate),
             $i
         ); }, $input->{'dataArrayNested'}) : null;
-        $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'}) ? array_map(function($i) use ($validate, $materializeDefaults) { return (Fio::validateInput($i, true)) ? (Fio::buildFromInput($i, $validate)) : ((Phone::validateInput($i, true)) ? (Phone::buildFromInput($i, $validate)) : (null)); }, $input->{'dataArrayAnyOf'}) : null;
-        $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'}) ? array_map(function($i) use ($validate, $materializeDefaults) { return array_map(function($i) use ($validate, $materializeDefaults) { return (Fio::validateInput($i, true)) ? (Fio::buildFromInput($i, $validate)) : ((Phone::validateInput($i, true)) ? (Phone::buildFromInput($i, $validate)) : (null)); }, $i); }, $input->{'dataArrayNestedAnyOf'}) : null;
+        $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'}) ? array_map(function($i) use ($validate) { return (Fio::validateInput($i, true)) ? (Fio::buildFromInput($i, $validate)) : ((Phone::validateInput($i, true)) ? (Phone::buildFromInput($i, $validate)) : (null)); }, $input->{'dataArrayAnyOf'}) : null;
+        $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'}) ? array_map(function($i) use ($validate) { return array_map(function($i) use ($validate) { return (Fio::validateInput($i, true)) ? (Fio::buildFromInput($i, $validate)) : ((Phone::validateInput($i, true)) ? (Phone::buildFromInput($i, $validate)) : (null)); }, $i); }, $input->{'dataArrayNestedAnyOf'}) : null;
 
         $obj = new self();
         $obj->dataArray = $dataArray;

--- a/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumber.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumber.php
@@ -102,7 +102,7 @@ class MyGenericStringNumber
             static::validateInput($input);
         }
 
-        $field = MyGenericStringNumberField::buildFromInput($input->{'field'}, $validate, $materializeDefaults);
+        $field = MyGenericStringNumberField::buildFromInput($input->{'field'}, $validate);
 
         $obj = new self($field);
 

--- a/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumber.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumber.php
@@ -104,7 +104,7 @@ class MyGenericStringNumber
             static::validateInput($input);
         }
 
-        $field = MyGenericStringNumberField::buildFromInput($input->{'field'}, $validate, $materializeDefaults);
+        $field = MyGenericStringNumberField::buildFromInput($input->{'field'}, $validate);
 
         $obj = new self($field);
 

--- a/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumber.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumber.php
@@ -98,7 +98,7 @@ class MyGenericStringNumber
             static::validateInput($input);
         }
 
-        $field = MyGenericStringNumberField::buildFromInput($input->{'field'}, $validate, $materializeDefaults);
+        $field = MyGenericStringNumberField::buildFromInput($input->{'field'}, $validate);
 
         $obj = new self($field);
 

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-5.6/MyClass.php
@@ -86,7 +86,7 @@ class MyClass
         }
 
         if ((MyClassFooAlternative2::validateInput($input->{'foo'}, true))) {
-            $foo = MyClassFooAlternative2::buildFromInput($input->{'foo'}, $validate, $materializeDefaults);
+            $foo = MyClassFooAlternative2::buildFromInput($input->{'foo'}, $validate);
         } else {
             $foo = $input->{'foo'};
         }

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-7.4/MyClass.php
@@ -88,7 +88,7 @@ class MyClass
         }
 
         if ((MyClassFooAlternative2::validateInput($input->{'foo'}, true))) {
-            $foo = MyClassFooAlternative2::buildFromInput($input->{'foo'}, $validate, $materializeDefaults);
+            $foo = MyClassFooAlternative2::buildFromInput($input->{'foo'}, $validate);
         } else {
             $foo = $input->{'foo'};
         }

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-8.4/MyClass.php
@@ -83,7 +83,7 @@ class MyClass
 
         $foo = match (true) {
             is_string($input->{'foo'}) => $input->{'foo'},
-            MyClassFooAlternative2::validateInput($input->{'foo'}, true) => MyClassFooAlternative2::buildFromInput($input->{'foo'}, $validate, $materializeDefaults),
+            MyClassFooAlternative2::validateInput($input->{'foo'}, true) => MyClassFooAlternative2::buildFromInput($input->{'foo'}, $validate),
             default => throw new \InvalidArgumentException("could not build property 'foo' from JSON"),
         };
 


### PR DESCRIPTION
## Summary
- ensure `buildFromInput` parameter names propagate to property generators
- update `ObjectArrayProperty` mapping for php5.6
- regenerate fixture snapshots

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687b9ec5baa4832d9c5cdbe1e705a23c