### PR TITLE
Fix optional nullable union handling

### DIFF
--- a/src/Generator/PropertyBuilder.php
+++ b/src/Generator/PropertyBuilder.php
@@ -132,7 +132,7 @@ class PropertyBuilder
                 }
 
                 $decorator = new OptionalPropertyDecorator($name, $prop);  // optional
-                if (self::definitionAllowsNull($definition)) {
+                if (self::definitionAllowsNull($definition) || $property->allowsNull()) {
                     $decorator->markOptionalNullable();
                 }
 
@@ -144,13 +144,13 @@ class PropertyBuilder
             $property = new PrimitiveUnionEnumProperty($name, $definition, $req);
             if (isset($definition['default']) && $req->getOptions()->getTreatValuesWithDefaultAsOptional()) {
                 $decorator = new OptionalPropertyDecorator($name, $property);
-                if (self::definitionAllowsNull($definition)) {
+                if (self::definitionAllowsNull($definition) || $property->allowsNull()) {
                     $decorator->markOptionalNullable();
                 }
                 $property = $decorator;
             } elseif (!$isRequired) {
                 $decorator = new OptionalPropertyDecorator($name, $property);
-                if (self::definitionAllowsNull($definition)) {
+                if (self::definitionAllowsNull($definition) || $property->allowsNull()) {
                     $decorator->markOptionalNullable();
                 }
                 $property = $decorator;
@@ -165,13 +165,13 @@ class PropertyBuilder
             $property = new InferredEnumProperty($name, $definition, $req);
             if (isset($definition['default']) && $req->getOptions()->getTreatValuesWithDefaultAsOptional()) {
                 $decorator = new OptionalPropertyDecorator($name, $property);
-                if (self::definitionAllowsNull($definition)) {
+                if (self::definitionAllowsNull($definition) || $property->allowsNull()) {
                     $decorator->markOptionalNullable();
                 }
                 $property = $decorator;
             } elseif (!$isRequired) {
                 $decorator = new OptionalPropertyDecorator($name, $property);
-                if (self::definitionAllowsNull($definition)) {
+                if (self::definitionAllowsNull($definition) || $property->allowsNull()) {
                     $decorator->markOptionalNullable();
                 }
                 $property = $decorator;
@@ -251,7 +251,7 @@ class PropertyBuilder
                     }
 
                     $decorator = new OptionalPropertyDecorator($name, $inner);
-                    if (self::definitionAllowsNull($definition)) {
+                    if (self::definitionAllowsNull($definition) || $inner->allowsNull()) {
                         $decorator->markOptionalNullable();
                     }
 
@@ -272,7 +272,7 @@ class PropertyBuilder
                 }
 
                 $decorator = new OptionalPropertyDecorator($name, $unionProp);
-                if (self::definitionAllowsNull($definition)) {
+                if (self::definitionAllowsNull($definition) || $unionProp->allowsNull()) {
                     $decorator->markOptionalNullable();
                 }
 
@@ -287,13 +287,13 @@ class PropertyBuilder
 
                 if (isset($definition["default"]) && $req->getOptions()->getTreatValuesWithDefaultAsOptional()) {
                     $decorator = new OptionalPropertyDecorator($name, $property); // treat default as optional
-                    if (self::definitionAllowsNull($definition)) {
+                    if (self::definitionAllowsNull($definition) || $property->allowsNull()) {
                         $decorator->markOptionalNullable();
                     }
                     $property = $decorator;
                 } elseif (!$isRequired) {
                     $decorator = new OptionalPropertyDecorator($name, $property); // optional
-                    if (self::definitionAllowsNull($definition)) {
+                    if (self::definitionAllowsNull($definition) || $property->allowsNull()) {
                         $decorator->markOptionalNullable();
                     }
                     $property = $decorator;

--- a/src/Generator/PropertyBuilder.php
+++ b/src/Generator/PropertyBuilder.php
@@ -132,7 +132,7 @@ class PropertyBuilder
                 }
 
                 $decorator = new OptionalPropertyDecorator($name, $prop);  // optional
-                if (self::definitionAllowsNull($definition) || $property->allowsNull()) {
+                if (self::definitionAllowsNull($definition) || $prop->allowsNull()) {
                     $decorator->markOptionalNullable();
                 }
 

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -53,6 +53,13 @@ class Cat
     ];
 
     /**
+     * Map of optional nullable property names that were explicitly set to `null`
+     *
+     * @var array<string,true>
+     */
+    private array $_explicitNulls = [];
+
+    /**
      * @var bool|null|string|int|float
      */
     private null|bool|string|int|float $hasFur = null;
@@ -73,6 +80,7 @@ class Cat
     {
         $clone = clone $this;
         $clone->hasFur = $hasFur;
+        $clone->_explicitNulls['hasFur'] = true;
 
         return $clone;
     }
@@ -84,6 +92,7 @@ class Cat
     {
         $clone = clone $this;
         unset($clone->hasFur);
+        unset($clone->_explicitNulls['hasFur']);
 
         return $clone;
     }
@@ -103,6 +112,7 @@ class Cat
             static::validateInput($input);
         }
 
+        $__explicitNulls = [];
         $hasFur = property_exists($input, 'hasFur') ? match (true) {
             (($input->{'hasFur'}) === null) || (is_bool($input->{'hasFur'})) => ($input->{'hasFur'} !== null) ? ((bool)($input->{'hasFur'})) : null,
             (($input->{'hasFur'}) === null) || ((is_string($input->{'hasFur'})) || (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'}))) => ($input->{'hasFur'} !== null) ? (match (true) {
@@ -118,9 +128,13 @@ class Cat
         },
             default => null,
         } : null;
+        if (property_exists($input, 'hasFur')) {
+            $__explicitNulls['hasFur'] = true;
+        }
 
         $obj = new self();
         $obj->hasFur = $hasFur;
+        $obj->_explicitNulls = $__explicitNulls;
         return $obj;
     }
 
@@ -132,20 +146,22 @@ class Cat
     public function toArray() : array
     {
         $output = [];
-        $output['hasFur'] = match (true) {
-            (($this->hasFur) === null) || (is_bool($this->hasFur)) => ($this->hasFur !== null) ? ($this->hasFur) : null,
-            (($this->hasFur) === null) || ((is_string($this->hasFur)) || (is_int($this->hasFur) || is_float($this->hasFur))) => ($this->hasFur !== null) ? (match (true) {
-            default => null,
-            is_string($this->hasFur),
-            is_int($this->hasFur) || is_float($this->hasFur) => $this->hasFur,
-        }) : null,
-            (is_string($this->hasFur)) || (is_int($this->hasFur) || is_float($this->hasFur)) || (is_bool($this->hasFur)) => match (true) {
-            default => null,
-            is_string($this->hasFur),
-            is_int($this->hasFur) || is_float($this->hasFur),
-            is_bool($this->hasFur) => $this->hasFur,
-        },
-        };
+        if (isset($this->hasFur) || array_key_exists('hasFur', $this->_explicitNulls)) {
+            $output['hasFur'] = match (true) {
+                (($this->hasFur) === null) || (is_bool($this->hasFur)) => ($this->hasFur !== null) ? ($this->hasFur) : null,
+                (($this->hasFur) === null) || ((is_string($this->hasFur)) || (is_int($this->hasFur) || is_float($this->hasFur))) => ($this->hasFur !== null) ? (match (true) {
+                default => null,
+                is_string($this->hasFur),
+                is_int($this->hasFur) || is_float($this->hasFur) => $this->hasFur,
+            }) : null,
+                (is_string($this->hasFur)) || (is_int($this->hasFur) || is_float($this->hasFur)) || (is_bool($this->hasFur)) => match (true) {
+                default => null,
+                is_string($this->hasFur),
+                is_int($this->hasFur) || is_float($this->hasFur),
+                is_bool($this->hasFur) => $this->hasFur,
+            },
+            };
+        }
 
         return $output;
     }
@@ -187,5 +203,16 @@ class Cat
             },
             };
         }
+    }
+
+    /**
+     * Checks if an optional nullable property was explicitly set to `null`
+     *
+     * @param string $propertyName property name as appears in the schema
+     * @return bool
+     */
+    public function isExplicitNull(string $propertyName) : bool
+    {
+        return array_key_exists($propertyName, $this->_explicitNulls);
     }
 }


### PR DESCRIPTION
## Summary
- mark optional union properties as nullable when any branch allows null
- update union-with-repeated-type snapshot for explicit null tracking

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687bb7fb3b6c832d9c57f54cd52f6934