### PR TITLE
Always add version suffix in generated namespaces

### DIFF
--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ns\MaterializeDefaults;
+namespace Ns\MaterializeDefaults_8_4;
 
 class MyClass
 {

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassBar.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassBar.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ns\MaterializeDefaults;
+namespace Ns\MaterializeDefaults_8_4;
 
 class MyClassBar
 {

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ns\RefAnnotations;
+namespace Ns\RefAnnotations_8_4;
 
 class Cat
 {

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ns\RefAnnotations;
+namespace Ns\RefAnnotations_8_4;
 
 class GenericPet
 {

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Pets.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Pets.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ns\RefAnnotations;
+namespace Ns\RefAnnotations_8_4;
 
 class Pets
 {

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ns\UnionWithRepeatedType;
+namespace Ns\UnionWithRepeatedType_8_4;
 
 class Cat
 {

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -232,7 +232,7 @@ class SchemaToClassTest extends TestCase
                 $optsData['targetPHPVersion'] = $version;
                 $optsVersion = SpecificationOptions::buildFromInput($optsData);
 
-                $ns = $multipleVersions ? $entry . '_' . str_replace('.', '_', $version) : $entry;
+                $ns = $entry . '_' . str_replace('.', '_', $version);
                 $testCases[$entry . '-' . $version] = [$entry, $ns, $schema, $expectedFiles, $optsVersion, $inputFiles, $version];
             }
         }


### PR DESCRIPTION
## Summary
- ensure SchemaToClassTest always appends the PHP version to namespaces
- update snapshots for single-version fixtures

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687bc3246d34832d93f9f868df121e4a