### PR TITLE
Ensure enum types are resolved consistently

### DIFF
--- a/src/Generator/EnumUtils.php
+++ b/src/Generator/EnumUtils.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Generator;
+
+use Composer\Semver\Semver;
+
+final class EnumUtils
+{
+    /**
+     * @param array<int|string|null|float|bool> $values
+     */
+    public static function typeAnnotation(array $values): string
+    {
+        $literals = array_map(static fn($v): string => var_export($v, true), $values);
+        return implode('|', $literals);
+    }
+
+    /**
+     * @param array<int|string|null|float|bool> $values
+     */
+    public static function typeHint(array $values, string $phpVersion): ?string
+    {
+        $types = [];
+        foreach ($values as $v) {
+            if ($v === null) {
+                $types['null'] = 'null';
+            } elseif (is_string($v)) {
+                $types['string'] = 'string';
+            } elseif (is_int($v)) {
+                $types['int'] = 'int';
+            } elseif (is_float($v)) {
+                $types['float'] = 'float';
+            } elseif (is_bool($v)) {
+                $types['bool'] = 'bool';
+            }
+        }
+
+        if (!Semver::satisfies($phpVersion, '>=8.0') && count($types) !== 1) {
+            return null;
+        }
+
+        if (isset($types['int']) && isset($types['float'])) {
+            $types['int'] = 'int';
+            $types['float'] = 'float';
+        }
+
+        return implode('|', array_values($types));
+    }
+
+    /**
+     * @param array<int|string|null|float|bool> $values
+     */
+    public static function assertionExpr(array $values, string $expr): string
+    {
+        $export = var_export($values, true);
+        return "in_array({$expr}, {$export}, true)";
+    }
+}

--- a/src/Generator/Property/NumberProperty.php
+++ b/src/Generator/Property/NumberProperty.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator\Property;
 
 use Composer\Semver\Semver;
+use Helmich\Schema2Class\Generator\EnumUtils;
 
 class NumberProperty extends AbstractProperty
 {
@@ -19,20 +20,32 @@ class NumberProperty extends AbstractProperty
 
     public function typeAnnotation(): string
     {
-        return "int|float";
+        if (isset($this->schema['enum'])) {
+            return EnumUtils::typeAnnotation($this->schema['enum']);
+        }
+
+        return 'int|float';
     }
 
     public function typeHint(string $phpVersion): ?string
     {
+        if (isset($this->schema['enum'])) {
+            return EnumUtils::typeHint($this->schema['enum'], $phpVersion);
+        }
+
         if (Semver::satisfies($phpVersion, "<8.0")) {
             return null;
         }
 
-        return "int|float";
+        return 'int|float';
     }
 
     public function generateTypeAssertionExpr(string $expr): string
     {
+        if (isset($this->schema['enum'])) {
+            return EnumUtils::assertionExpr($this->schema['enum'], $expr);
+        }
+
         return "is_int({$expr}) || is_float({$expr})";
     }
 

--- a/src/Generator/ReferencedTypeEnum.php
+++ b/src/Generator/ReferencedTypeEnum.php
@@ -3,6 +3,7 @@
 namespace Helmich\Schema2Class\Generator;
 
 use Helmich\Schema2Class\Generator\SchemaToEnum;
+use Helmich\Schema2Class\Generator\EnumUtils;
 
 readonly class ReferencedTypeEnum implements ReferencedType
 {
@@ -40,13 +41,7 @@ readonly class ReferencedTypeEnum implements ReferencedType
             return $this->relativeName($req);
         }
 
-        $literals = array_map(
-            static function ($v): string {
-                return var_export($v, true);
-            },
-            $this->schema['enum']
-        );
-        return implode('|', $literals);
+        return EnumUtils::typeAnnotation($this->schema['enum']);
     }
 
     public function typeHint(GeneratorRequest $req): ?string
@@ -55,31 +50,7 @@ readonly class ReferencedTypeEnum implements ReferencedType
             return $this->relativeName($req);
         }
 
-        $types = [];
-        foreach ($this->schema['enum'] as $v) {
-            if ($v === null) {
-                $types['null'] = 'null';
-            } elseif (is_string($v)) {
-                $types['string'] = 'string';
-            } elseif (is_int($v)) {
-                $types['int'] = 'int';
-            } elseif (is_float($v)) {
-                $types['float'] = 'float';
-            } elseif (is_bool($v)) {
-                $types['bool'] = 'bool';
-            }
-        }
-
-        if (!$req->isAtLeastPHP('8.0') && count($types) !== 1) {
-            return null;
-        }
-
-        if (isset($types['int']) && isset($types['float'])) {
-            $types['int'] = 'int';
-            $types['float'] = 'float';
-        }
-
-        return implode('|', array_values($types));
+        return EnumUtils::typeHint($this->schema['enum'], $req->getTargetPHPVersion());
     }
 
     function serializedInputTypeHint(GeneratorRequest $req): ?string
@@ -98,8 +69,7 @@ readonly class ReferencedTypeEnum implements ReferencedType
             return "({$expr}) instanceof " . $this->relativeName($req);
         }
 
-        $values = var_export($this->schema['enum'], true);
-        return "in_array({$expr}, {$values}, true)";
+        return EnumUtils::assertionExpr($this->schema['enum'], $expr);
     }
 
     public function inputAssertionExpr(GeneratorRequest $req, string $expr): string
@@ -108,8 +78,7 @@ readonly class ReferencedTypeEnum implements ReferencedType
             return "" . $this->relativeName($req) . "::tryFrom({$expr}) !== null";
         }
 
-        $values = var_export($this->schema['enum'], true);
-        return "in_array({$expr}, {$values}, true)";
+        return EnumUtils::assertionExpr($this->schema['enum'], $expr);
     }
 
     public function inputMappingExpr(GeneratorRequest $req, string $expr, ?string $validateExpr): string

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
@@ -60,7 +60,7 @@ class Foo
     ];
 
     /**
-     * @var int|float|null
+     * @var 0|1.5|2.5|3.5|null
      */
     private $floatEnum = null;
 
@@ -93,7 +93,7 @@ class Foo
     }
 
     /**
-     * @return int|float|null
+     * @return 0|1.5|2.5|3.5|null
      */
     public function getFloatEnum()
     {
@@ -133,7 +133,7 @@ class Foo
     }
 
     /**
-     * @param int|float $floatEnum
+     * @param 0|1.5|2.5|3.5 $floatEnum
      * @return self
      * @param bool $validate
      */

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
@@ -62,7 +62,7 @@ class Foo
     ];
 
     /**
-     * @var int|float|null
+     * @var 0|1.5|2.5|3.5|null
      */
     private $floatEnum = null;
 
@@ -95,7 +95,7 @@ class Foo
     }
 
     /**
-     * @return int|float|null
+     * @return 0|1.5|2.5|3.5|null
      */
     public function getFloatEnum()
     {
@@ -135,7 +135,7 @@ class Foo
     }
 
     /**
-     * @param int|float $floatEnum
+     * @param 0|1.5|2.5|3.5 $floatEnum
      * @return self
      * @param bool $validate
      */

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
@@ -62,7 +62,7 @@ class Foo
     ];
 
     /**
-     * @var int|float|null
+     * @var 0|1.5|2.5|3.5|null
      */
     private int|float|null $floatEnum = null;
 
@@ -95,7 +95,7 @@ class Foo
     }
 
     /**
-     * @return int|float|null
+     * @return 0|1.5|2.5|3.5|null
      */
     public function getFloatEnum(): int|float|null
     {
@@ -135,7 +135,7 @@ class Foo
     }
 
     /**
-     * @param int|float $floatEnum
+     * @param 0|1.5|2.5|3.5 $floatEnum
      * @return self
      * @param bool $validate
      */


### PR DESCRIPTION
## Summary
- add `EnumUtils` helper for generating literal enum types
- use `EnumUtils` in `ReferencedTypeEnum` and `NumberProperty`
- update EnumUnsupported snapshots with new numeric enum annotations

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse` *(fails: PHPStan process crashed due to memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_687cd80976b0832db74ce48089228f26