### PR TITLE
Handle defaults from refs and null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,12 @@ Now it:
 
 ### Enums
 
-- Laminas's immutable EnumGenerator replaced with own mutable implementation PhpParserEnumGenerator built on nikic/php-parser which allows modifications via the hook system.
-- Mixed int/string enum values are now skipped with fallback to type hints instead of raising an error.
+- Laminas's immutable `EnumGenerator` replaced with own mutable implementation `PhpParserEnumGenerator` built on `nikic/php-parser` which allows modifications via the hook system.
+- Unsupported enum types are now skipped with fallback to type hints instead of raising an error.
+
+### Defaults handling
+
+- Now, if the schema has a default for some property, the generated class includes the parameter `$materializeDefaults` in `buildFromInput` and `$includeDefaults` in `toArray()`.
 
 ### Documentation
 
@@ -73,7 +77,9 @@ Now it:
   - New dependencies: `voku/portable-ascii`, `nikic/php-parser`
   - Bumped PHPUnit to 12 and Psalm to 6
 
-### Breaking changes?
+### Breaking changes
+
+- The `toJson` method of the generated class was renamed to `toArray` to reflect its purpose.
 
 - Configuration layout has been simplified: there are now only two top-level keys, `options` and `files`. Each `files` item has three keys: `input`, an optional `className`, and `options`, where the `options` object can override any setting from the top-level `options`.
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ The generated classes offer:
 - `oneOf`/`anyOf` alternatives are suffixed with "AlternativeX", where _X_ is an incrementing integer. See [`Example\Advanced\User::$payment`](examples/advanced/generated/User.php#L188).
 - The static method `buildFromInput(array $data[, bool $validate = true])` accepts an array (for example the result of `json_decode(..., true)`), validates it against the schema, and creates the full object graph. No additional mapping is required.
   **Note:** Do not instantiate the class directly; always use `buildFromInput(...)`.
-- To disable validation, pass `false` as the second argument: `buildFromInput($data, false)`. Use at your own risk.
+- To disable validation, pass `false` as the second argument of `buildFromInput($data, false)`. Use at your own risk.
+- If your schema has default values and you want to use them to populate the object properties that are not set in the input, pass the parameter `materializeDefaults = true` to `buildFromInput`. The parameter is generated only when the schema has default values.
 - The method `toArray()` returns a plain array ready for `json_encode()`.
 - Properties are immutable by default; use `withX()` (or `withoutX()` for optional values) to create modified copies. Pass `--mutable-setters` to generate classic `setX()` methods instead.
 

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -543,8 +543,9 @@ class SchemaToClass
         }
 
         foreach ($schema['properties'] as $key => $def) {
-            $d = $this->extractDefault($def, $req);
-            if ($d !== null) {
+            $found = false;
+            $d = $this->extractDefault($def, $req, $found);
+            if ($found) {
                 $defaults[$key] = $d;
             }
         }
@@ -552,10 +553,21 @@ class SchemaToClass
         return $defaults;
     }
 
-    private function extractDefault(array $def, GeneratorRequest $req): mixed
+    private function extractDefault(array $def, GeneratorRequest $req, bool &$found = false): mixed
     {
         if (array_key_exists('default', $def)) {
+            $found = true;
             return $def['default'];
+        }
+
+        if (isset($def['$ref'])) {
+            $schema = $req->lookupSchema($def['$ref']);
+            if (is_array($schema)) {
+                $d = $this->extractDefault($schema, $req, $found);
+                if ($found) {
+                    return $d;
+                }
+            }
         }
 
         foreach (['anyOf', 'oneOf', 'allOf'] as $k) {
@@ -565,8 +577,8 @@ class SchemaToClass
                         $sub = $req->lookupSchema($sub['$ref']);
                     }
                     if (is_array($sub)) {
-                        $d = $this->extractDefault($sub, $req);
-                        if ($d !== null) {
+                        $d = $this->extractDefault($sub, $req, $found);
+                        if ($found) {
                             return $d;
                         }
                     }
@@ -574,6 +586,7 @@ class SchemaToClass
             }
         }
 
+        $found = false;
         return null;
     }
 }

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -63,6 +63,8 @@ class MyClass
     private static array $_defaults = [
         'foo' => 0,
         'bar' => 'xyz',
+        'baz' => null,
+        'qux' => 'default from the referenced definition',
         'thud' => 'more specific default near the $ref',
         'grox' => 'default near the $ref',
     ];

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -37,20 +37,36 @@ class MyClass
             ],
             'thud' => [
                 '$ref' => '#/definitions/Def1',
-                'default' => 'more specific default near the $ref',
+                'default' => 'more specific default near the "$ref"',
             ],
             'grox' => [
                 '$ref' => '#/definitions/Def2',
-                'default' => 'default near the $ref',
+                'default' => 'default near the "$ref"',
+            ],
+            'qwert' => [
+                'anyOf' => [
+                    [
+                        '$ref' => '#/definitions/Def2',
+                    ],
+                    [
+                        '$ref' => '#/definitions/Def1',
+                    ],
+                    [
+                        'type' => 'number',
+                        'default' => 42,
+                    ],
+                ],
             ],
         ],
         'definitions' => [
             'Def1' => [
                 'type' => 'string',
+                'description' => 'Description of Def1 (string) which has default value',
                 'default' => 'default from the referenced definition',
             ],
             'Def2' => [
                 'type' => 'string',
+                'description' => 'Description of Def2 (string) which doesn\'t have default value',
             ],
         ],
     ];
@@ -65,8 +81,9 @@ class MyClass
         'bar' => 'xyz',
         'baz' => null,
         'qux' => 'default from the referenced definition',
-        'thud' => 'more specific default near the $ref',
-        'grox' => 'default near the $ref',
+        'thud' => 'more specific default near the "$ref"',
+        'grox' => 'default near the "$ref"',
+        'qwert' => 'default from the referenced definition',
     ];
 
     /**
@@ -92,19 +109,30 @@ class MyClass
     private ?int $baz = null;
 
     /**
+     * Description of Def1 (string) which has default value
+     *
      * @var string|null
      */
     private ?string $qux = null;
 
     /**
+     * Description of Def1 (string) which has default value
+     *
      * @var string|null
      */
     private ?string $thud = null;
 
     /**
+     * Description of Def2 (string) which doesn't have default value
+     *
      * @var string|null
      */
     private ?string $grox = null;
+
+    /**
+     * @var string|int|float|null
+     */
+    private string|int|float|null $qwert = null;
 
     /**
      * @return int|null
@@ -131,6 +159,8 @@ class MyClass
     }
 
     /**
+     * Description of Def1 (string) which has default value
+     *
      * @return string|null
      */
     public function getQux(): ?string
@@ -139,6 +169,8 @@ class MyClass
     }
 
     /**
+     * Description of Def1 (string) which has default value
+     *
      * @return string|null
      */
     public function getThud(): ?string
@@ -147,11 +179,21 @@ class MyClass
     }
 
     /**
+     * Description of Def2 (string) which doesn't have default value
+     *
      * @return string|null
      */
     public function getGrox(): ?string
     {
         return $this->grox ?? null;
+    }
+
+    /**
+     * @return string|int|float|null
+     */
+    public function getQwert(): int|float|string|null
+    {
+        return $this->qwert;
     }
 
     /**
@@ -349,6 +391,29 @@ class MyClass
     }
 
     /**
+     * @param string|int|float $qwert
+     * @return self
+     */
+    public function withQwert(int|float|string $qwert): self
+    {
+        $clone = clone $this;
+        $clone->qwert = $qwert;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutQwert(): self
+    {
+        $clone = clone $this;
+        unset($clone->qwert);
+
+        return $clone;
+    }
+
+    /**
      * Builds a new instance from an input array
      *
      * @param array|object $input Input data
@@ -385,6 +450,11 @@ class MyClass
         $qux = isset($input->{'qux'}) ? $input->{'qux'} : null;
         $thud = isset($input->{'thud'}) ? $input->{'thud'} : null;
         $grox = isset($input->{'grox'}) ? $input->{'grox'} : null;
+        $qwert = isset($input->{'qwert'}) ? match (true) {
+            is_string($input->{'qwert'}) => $input->{'qwert'},
+            is_int($input->{'qwert'}) || is_float($input->{'qwert'}) => str_contains((string)($input->{'qwert'}), '.') ? (float)($input->{'qwert'}) : (int)($input->{'qwert'}),
+            default => null,
+        } : null;
 
         $obj = new self();
         $obj->foo = $foo;
@@ -393,6 +463,7 @@ class MyClass
         $obj->qux = $qux;
         $obj->thud = $thud;
         $obj->grox = $grox;
+        $obj->qwert = $qwert;
         $obj->_explicitNulls = $__explicitNulls;
         return $obj;
     }
@@ -423,6 +494,12 @@ class MyClass
         }
         if (isset($this->grox)) {
             $output['grox'] = $this->grox;
+        }
+        if (isset($this->qwert)) {
+            $output['qwert'] = match (true) {
+                is_string($this->qwert),
+                is_int($this->qwert) || is_float($this->qwert) => $this->qwert,
+            };
         }
 
         if ($includeDefaults) {
@@ -458,6 +535,16 @@ class MyClass
         }
 
         return $validator->isValid();
+    }
+
+    public function __clone()
+    {
+        if (isset($this->qwert)) {
+            $this->qwert = match (true) {
+                is_string($this->qwert),
+                is_int($this->qwert) || is_float($this->qwert) => $this->qwert,
+            };
+        }
     }
 
     /**

--- a/tests/Generator/Fixtures/DefaultValue/schema.yaml
+++ b/tests/Generator/Fixtures/DefaultValue/schema.yaml
@@ -14,13 +14,22 @@ properties:
     $ref: '#/definitions/Def1'
   thud:
     $ref: '#/definitions/Def1'
-    default: 'more specific default near the $ref'
+    default: 'more specific default near the "$ref"'
   grox:
     $ref: '#/definitions/Def2'
-    default: 'default near the $ref'
+    default: 'default near the "$ref"'
+  qwert:
+    anyOf:
+      - $ref: '#/definitions/Def2'
+      - $ref: '#/definitions/Def1'
+      -
+        type: number
+        default: 42
 definitions:
   Def1:
     type: string
+    description: Description of Def1 (string) which has default value
     default: 'default from the referenced definition'
   Def2:
     type: string
+    description: Description of Def2 (string) which doesn't have default value

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
@@ -31,6 +31,15 @@ class GenericPet
     ];
 
     /**
+     * Default values from the schema
+     *
+     * @var array
+     */
+    private static array $_defaults = [
+        'hasFur' => false,
+    ];
+
+    /**
      * Map of optional nullable property names that were explicitly set to `null`
      *
      * @var array<string,true>
@@ -93,12 +102,24 @@ class GenericPet
      *
      * @param array|object $input Input data
      * @param bool $validate Set this to false to skip validation; use at own risk
+     * @param bool $materializeDefaults Apply defaults defined in schema when missing
      * @return GenericPet Created instance
      * @throws \InvalidArgumentException
      */
-    public static function buildFromInput(array|object $input, bool $validate = true): GenericPet
+    public static function buildFromInput(array|object $input, bool $validate = true, bool $materializeDefaults = false): GenericPet
     {
-        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $input = is_array($input)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($input)
+            : ($materializeDefaults ? clone $input : $input);
+
+        if ($materializeDefaults) {
+            foreach (self::$_defaults as $__k => $__v) {
+                if (!property_exists($input, $__k)) {
+                    $input->{$__k} = is_array($__v) ? \JsonSchema\Validator::arrayToObjectRecursive($__v) : $__v;
+                }
+            }
+        }
+
         if ($validate) {
             static::validateInput($input);
         }
@@ -118,13 +139,22 @@ class GenericPet
     /**
      * Converts this object back to a simple array that can be JSON-serialized
      *
+     * @param bool $includeDefaults Add defaults for missing properties
      * @return array Converted array
      */
-    public function toArray(): array
+    public function toArray(bool $includeDefaults = false): array
     {
         $output = [];
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_explicitNulls)) {
             $output['hasFur'] = $this->hasFur;
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
         }
 
         return $output;


### PR DESCRIPTION
## Summary
- collect defaults defined on `$ref` schemas
- preserve `null` defaults when collecting property defaults
- update generated test fixtures

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687ce3518150832d9a155820dbd67ef8