### PR TITLE
Add toObject method generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Now it:
 ### Defaults handling
 
 - Now, if the schema has a default for some property, the generated class includes the parameter `$materializeDefaults` in `buildFromInput` and `$includeDefaults` in `toArray()`.
+- Generated classes now also provide a `toObject()` method returning a `stdClass` representation.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ The generated classes offer:
 - To disable validation, pass `false` as the second argument of `buildFromInput($data, false)`. Use at your own risk.
 - If your schema has default values and you want to use them to populate the object properties that are not set in the input, pass the parameter `materializeDefaults = true` to `buildFromInput`. The parameter is generated only when the schema has default values.
 - The method `toArray()` returns a plain array ready for `json_encode()`.
+- The method `toObject()` returns a `stdClass` object similar to `json_decode()` with no flags.
 - Properties are immutable by default; use `withX()` (or `withoutX()` for optional values) to create modified copies. Pass `--mutable-setters` to generate classic `setX()` methods instead.
 
 ## Advanced programmatic usage

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -371,6 +371,60 @@ class Generator
     }
 
     /**
+     * @param PropertyCollection $properties
+     * @return MethodGenerator
+     */
+    public function generateToObjectMethod(PropertyCollection $properties, bool $hasDefaults = false): MethodGenerator
+    {
+        $tags = [];
+        if ($hasDefaults) {
+            $tags[] = new ParamTag('includeDefaults', ['bool'], 'Add defaults for missing properties');
+        }
+        $tags[] = new ReturnTag(["\\stdClass"], "Converted object");
+
+        $docBlock = new DocBlockGenerator(
+            "Converts this object back to a stdClass that can be JSON-encoded",
+            null,
+            $tags
+        );
+        $docBlock->setWordWrap(false);
+
+        $params = [];
+        if ($hasDefaults) {
+            $params[] = new ParameterGenerator('includeDefaults', 'bool', false);
+        }
+
+        $body = '$output = [];' . "\n" .
+            $properties->generateTypeToArrayConversionCode('output') . "\n";
+
+        if ($hasDefaults) {
+            $body .= "\nif (\$includeDefaults) {\n" .
+            "    foreach (self::\$_defaults as \$k => \$v) {\n" .
+            "        if (!array_key_exists(\$k, \$output)) {\n" .
+            "            \$output[\$k] = \$v;\n" .
+            "        }\n" .
+            "    }\n" .
+            "}\n";
+        }
+
+        $body .= "\nreturn \\JsonSchema\\Validator::arrayToObjectRecursive(\$output);";
+
+        $method = new MethodGenerator(
+            'toObject',
+            $params,
+            MethodGenerator::FLAG_PUBLIC,
+            $body,
+            $docBlock
+        );
+
+        if ($this->generatorRequest->isAtLeastPHP("7.0")) {
+            $method->setReturnType("\\stdClass");
+        }
+
+        return $method;
+    }
+
+    /**
      * @return MethodGenerator
      */
     public function generateValidateMethod(): MethodGenerator

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -263,6 +263,7 @@ class SchemaToClass
             ...$codeGenerator->generateSetterMethods($propertiesFromSchema),
             $codeGenerator->generateBuildMethod($propertiesFromSchema, $hasDefaults),
             $codeGenerator->generateToArrayMethod($propertiesFromSchema, $hasDefaults),
+            $codeGenerator->generateToObjectMethod($propertiesFromSchema, $hasDefaults),
             $codeGenerator->generateValidateMethod(),
             $codeGenerator->generateCloneMethod($propertiesFromSchema),
             $hasOptionalNullable ? $codeGenerator->generateIsSetMethod() : null,

--- a/tests/Generator/Fixtures/AdditionalProps/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output-5.6/MyClass.php
@@ -163,6 +163,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+        if (isset($this->params)) {
+            $output['params'] = $this->params;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AdditionalProps/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output-7.4/MyClass.php
@@ -165,6 +165,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+        if (isset($this->params)) {
+            $output['params'] = $this->params;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AdditionalProps/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output-8.4/MyClass.php
@@ -159,6 +159,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+        if (isset($this->params)) {
+            $output['params'] = $this->params;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AdditionalPropsRoot/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropsRoot/Output-5.6/MyClass.php
@@ -163,6 +163,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+        if (isset($this->params)) {
+            $output['params'] = json_decode(json_encode($this->params), true);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AdditionalPropsRoot/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropsRoot/Output-7.4/MyClass.php
@@ -165,6 +165,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+        if (isset($this->params)) {
+            $output['params'] = json_decode(json_encode($this->params), true);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AdditionalPropsRoot/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropsRoot/Output-8.4/MyClass.php
@@ -159,6 +159,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+        if (isset($this->params)) {
+            $output['params'] = json_decode(json_encode($this->params), true);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AllOfRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output-5.6/MyClass.php
@@ -189,6 +189,21 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['city'] = $this->city;
+        $output['street'] = $this->street;
+        $output['country'] = $this->country;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AllOfRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output-7.4/MyClass.php
@@ -191,6 +191,21 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['city'] = $this->city;
+        $output['street'] = $this->street;
+        $output['country'] = $this->country;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AllOfRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output-8.4/MyClass.php
@@ -185,6 +185,21 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['city'] = $this->city;
+        $output['street'] = $this->street;
+        $output['country'] = $this->country;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
@@ -139,6 +139,32 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false)
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            if ((is_string($this->foo)) || (is_int($this->foo))) {
+                $output['foo'] = $this->foo;
+            }
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
@@ -140,6 +140,33 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = match (true) {
+                is_string($this->foo),
+                is_int($this->foo) => $this->foo,
+            };
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayProperty/Output-5.6/Phone.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-5.6/Phone.php
@@ -107,6 +107,21 @@ class Phone
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayProperty/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-5.6/Record.php
@@ -125,6 +125,21 @@ class Record
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->dataArray)) {
+            $output['dataArray'] = array_map(fn(Phone $i): array => $i->toArray(), $this->dataArray);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayProperty/Output-7.4/Phone.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-7.4/Phone.php
@@ -109,6 +109,21 @@ class Phone
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayProperty/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-7.4/Record.php
@@ -127,6 +127,21 @@ class Record
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->dataArray)) {
+            $output['dataArray'] = array_map(fn(Phone $i): array => $i->toArray(), $this->dataArray);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Phone.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Phone.php
@@ -103,6 +103,21 @@ class Phone
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Record.php
@@ -121,6 +121,21 @@ class Record
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->dataArray)) {
+            $output['dataArray'] = array_map(fn(Phone $i): array => $i->toArray(), $this->dataArray);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -542,6 +542,55 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['a'] = $this->a;
+        $output['b'] = match (true) {
+            is_array($this->b),
+            is_string($this->b) => $this->b,
+        };
+        $output['c'] = $this->c;
+        $output['d'] = match (true) {
+            is_array($this->d),
+            is_string($this->d) => $this->d,
+        };
+        if (isset($this->e)) {
+            $output['e'] = $this->e;
+        }
+        if (isset($this->f)) {
+            $output['f'] = match (true) {
+                is_array($this->f),
+                is_string($this->f) => $this->f,
+            };
+        }
+        if (isset($this->g) || array_key_exists('g', $this->_providedOptionals)) {
+            if (isset($this->g)) {
+                $output['g'] = $this->g;
+            }
+        }
+        if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
+            $output['h'] = match (true) {
+                is_array($this->h),
+                is_string($this->h) => $this->h,
+            };
+        }
+        if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
+            $output['i'] = match (true) {
+                is_array($this->i),
+                is_string($this->i) => $this->i,
+                is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), true),
+            };
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Basic/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/Basic/Output-5.6/MyClass.php
@@ -156,6 +156,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        $output['foo_bar'] = $this->fooBar;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Basic/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Basic/Output-7.4/MyClass.php
@@ -158,6 +158,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        $output['foo_bar'] = $this->fooBar;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Basic/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Basic/Output-8.4/MyClass.php
@@ -152,6 +152,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        $output['foo_bar'] = $this->fooBar;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -569,6 +569,54 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+        if (isset($this->baz) || array_key_exists('baz', $this->_providedOptionals)) {
+            $output['baz'] = $this->baz;
+        }
+        if (isset($this->qux)) {
+            $output['qux'] = $this->qux;
+        }
+        if (isset($this->thud)) {
+            $output['thud'] = $this->thud;
+        }
+        if (isset($this->grox)) {
+            $output['grox'] = $this->grox;
+        }
+        if (isset($this->qwert)) {
+            $output['qwert'] = match (true) {
+                is_string($this->qwert),
+                is_int($this->qwert) || is_float($this->qwert) => $this->qwert,
+            };
+        }
+        if (isset($this->zyx)) {
+            $output['zyx'] = $this->zyx;
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-5.6/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-5.6/Address.php
@@ -158,6 +158,22 @@ class Address
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name->toArray();
+        }
+        $output['city'] = $this->city;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-5.6/Address/Defs/Name.php
+++ b/tests/Generator/Fixtures/Definitions/Output-5.6/Address/Defs/Name.php
@@ -107,6 +107,21 @@ class Name
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->first)) {
+            $output['first'] = $this->first;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-5.6/MyClass.php
@@ -178,6 +178,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['id'] = $this->id;
+        if (isset($this->address)) {
+            $output['address'] = $this->address->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/Address.php
@@ -160,6 +160,22 @@ class Address
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name->toArray();
+        }
+        $output['city'] = $this->city;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/Address/Defs/Name.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/Address/Defs/Name.php
@@ -109,6 +109,21 @@ class Name
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->first)) {
+            $output['first'] = $this->first;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/MyClass.php
@@ -180,6 +180,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['id'] = $this->id;
+        if (isset($this->address)) {
+            $output['address'] = $this->address->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/Address.php
@@ -154,6 +154,22 @@ class Address
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name->toArray();
+        }
+        $output['city'] = $this->city;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/Address/Defs/Name.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/Address/Defs/Name.php
@@ -103,6 +103,21 @@ class Name
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->first)) {
+            $output['first'] = $this->first;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/MyClass.php
@@ -174,6 +174,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['id'] = $this->id;
+        if (isset($this->address)) {
+            $output['address'] = $this->address->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-5.6/Foo.php
@@ -174,6 +174,22 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['color'] = $this->color;
+        if (isset($this->size)) {
+            $output['size'] = $this->size;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-7.4/Foo.php
@@ -176,6 +176,22 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['color'] = $this->color;
+        if (isset($this->size)) {
+            $output['size'] = $this->size;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-8.4/Foo.php
@@ -152,6 +152,22 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['color'] = $this->color->value;
+        if (isset($this->size)) {
+            $output['size'] = $this->size->value;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-5.6/Bar.php
@@ -107,6 +107,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->b)) {
+            $output['b'] = $this->b;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-5.6/Foo.php
@@ -107,6 +107,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Bar.php
@@ -109,6 +109,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->b)) {
+            $output['b'] = $this->b;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Foo.php
@@ -109,6 +109,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Bar.php
@@ -103,6 +103,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->b)) {
+            $output['b'] = $this->b;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Foo.php
@@ -103,6 +103,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-5.6/Foo.php
@@ -120,6 +120,19 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['val'] = $this->val;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-7.4/Foo.php
@@ -122,6 +122,19 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['val'] = $this->val;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-8.4/Foo.php
@@ -116,6 +116,19 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['val'] = $this->val;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Bar.php
@@ -108,6 +108,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Foo.php
@@ -107,6 +107,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Bar.php
@@ -110,6 +110,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Foo.php
@@ -109,6 +109,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Bar.php
@@ -104,6 +104,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Foo.php
@@ -103,6 +103,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-5.6/Bar.php
@@ -107,6 +107,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-5.6/Foo.php
@@ -107,6 +107,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Bar.php
@@ -109,6 +109,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Foo.php
@@ -109,6 +109,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Bar.php
@@ -103,6 +103,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Foo.php
@@ -103,6 +103,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefsRefs/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-5.6/Bar.php
@@ -107,6 +107,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefsRefs/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-5.6/Foo.php
@@ -107,6 +107,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefsRefs/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-7.4/Bar.php
@@ -109,6 +109,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefsRefs/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-7.4/Foo.php
@@ -109,6 +109,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefsRefs/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-8.4/Bar.php
@@ -103,6 +103,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefsRefs/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-8.4/Foo.php
@@ -103,6 +103,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Descriptions/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-5.6/Baz.php
@@ -116,6 +116,21 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Descriptions/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-5.6/MyClass.php
@@ -172,6 +172,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Descriptions/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-7.4/Baz.php
@@ -118,6 +118,21 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Descriptions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-7.4/MyClass.php
@@ -174,6 +174,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Descriptions/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-8.4/Baz.php
@@ -112,6 +112,21 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Descriptions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-8.4/MyClass.php
@@ -168,6 +168,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-5.6/MyClass.php
@@ -146,6 +146,20 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['foo-bar'] = $this->foo_bar;
+        $output['foo bar'] = $this->_foo_bar;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-7.4/MyClass.php
@@ -148,6 +148,20 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo-bar'] = $this->foo_bar;
+        $output['foo bar'] = $this->_foo_bar;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-8.4/MyClass.php
@@ -142,6 +142,20 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo-bar'] = $this->foo_bar;
+        $output['foo bar'] = $this->_foo_bar;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-5.6/MyClass.php
@@ -156,6 +156,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['foo-bar'] = $this->foo_bar;
+        if (isset($this->_foo_bar)) {
+            $output['foo bar'] = $this->_foo_bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-7.4/MyClass.php
@@ -158,6 +158,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo-bar'] = $this->foo_bar;
+        if (isset($this->_foo_bar)) {
+            $output['foo bar'] = $this->_foo_bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-8.4/MyClass.php
@@ -152,6 +152,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo-bar'] = $this->foo_bar;
+        if (isset($this->_foo_bar)) {
+            $output['foo bar'] = $this->_foo_bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-5.6/MyClass.php
@@ -175,6 +175,25 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->foobar)) {
+            $output['foobar'] = $this->foobar;
+        }
+        $output['fooBar'] = $this->_fooBar_1;
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-7.4/MyClass.php
@@ -177,6 +177,25 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foobar)) {
+            $output['foobar'] = $this->foobar;
+        }
+        $output['fooBar'] = $this->_fooBar_1;
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-8.4/MyClass.php
@@ -171,6 +171,25 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foobar)) {
+            $output['foobar'] = $this->foobar;
+        }
+        $output['fooBar'] = $this->_fooBar_1;
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-5.6/BarTest.php
@@ -107,6 +107,21 @@ class BarTest
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-5.6/Baz.php
@@ -204,6 +204,27 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a->toArray();
+        }
+        if (isset($this->b)) {
+            $output['b'] = $this->b->toArray();
+        }
+        if (isset($this->c)) {
+            $output['c'] = $this->c->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-5.6/FooTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-5.6/FooTest.php
@@ -107,6 +107,21 @@ class FooTest
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-7.4/BarTest.php
@@ -109,6 +109,21 @@ class BarTest
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-7.4/Baz.php
@@ -206,6 +206,27 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a->toArray();
+        }
+        if (isset($this->b)) {
+            $output['b'] = $this->b->toArray();
+        }
+        if (isset($this->c)) {
+            $output['c'] = $this->c->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-7.4/FooTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-7.4/FooTest.php
@@ -109,6 +109,21 @@ class FooTest
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-8.4/BarTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-8.4/BarTest.php
@@ -103,6 +103,21 @@ class BarTest
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-8.4/Baz.php
@@ -200,6 +200,27 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a->toArray();
+        }
+        if (isset($this->b)) {
+            $output['b'] = $this->b->toArray();
+        }
+        if (isset($this->c)) {
+            $output['c'] = $this->c->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-8.4/FooTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-8.4/FooTest.php
@@ -103,6 +103,21 @@ class FooTest
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EnumMixed/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/EnumMixed/Output-5.6/MyClass.php
@@ -361,6 +361,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        $output['bar'] = $this->bar;
+        $output['baz'] = $this->baz;
+        $output['contradiction'] = $this->contradiction;
+        $output['contradiction2'] = $this->contradiction2;
+        $output['nullable'] = $this->nullable;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EnumMixed/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/EnumMixed/Output-7.4/MyClass.php
@@ -363,6 +363,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        $output['bar'] = $this->bar;
+        $output['baz'] = $this->baz;
+        $output['contradiction'] = $this->contradiction;
+        $output['contradiction2'] = $this->contradiction2;
+        $output['nullable'] = $this->nullable;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EnumMixed/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/EnumMixed/Output-8.4/MyClass.php
@@ -348,6 +348,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        $output['bar'] = $this->bar;
+        $output['baz'] = $this->baz;
+        $output['contradiction'] = $this->contradiction;
+        $output['contradiction2'] = $this->contradiction2;
+        $output['nullable'] = ($this->nullable)->value;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
@@ -342,6 +342,31 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->floatEnum)) {
+            $output['floatEnum'] = $this->floatEnum;
+        }
+        if (isset($this->floatEnumRef)) {
+            $output['floatEnumRef'] = $this->floatEnumRef;
+        }
+        if (isset($this->boolEnum)) {
+            $output['boolEnum'] = $this->boolEnum;
+        }
+        if (isset($this->boolEnumRef)) {
+            $output['boolEnumRef'] = $this->boolEnumRef;
+        }
+        $output['requiredBoolEnumRef'] = $this->requiredBoolEnumRef;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
@@ -344,6 +344,31 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->floatEnum)) {
+            $output['floatEnum'] = $this->floatEnum;
+        }
+        if (isset($this->floatEnumRef)) {
+            $output['floatEnumRef'] = $this->floatEnumRef;
+        }
+        if (isset($this->boolEnum)) {
+            $output['boolEnum'] = $this->boolEnum;
+        }
+        if (isset($this->boolEnumRef)) {
+            $output['boolEnumRef'] = $this->boolEnumRef;
+        }
+        $output['requiredBoolEnumRef'] = $this->requiredBoolEnumRef;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
@@ -338,6 +338,31 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->floatEnum)) {
+            $output['floatEnum'] = $this->floatEnum;
+        }
+        if (isset($this->floatEnumRef)) {
+            $output['floatEnumRef'] = $this->floatEnumRef;
+        }
+        if (isset($this->boolEnum)) {
+            $output['boolEnum'] = $this->boolEnum;
+        }
+        if (isset($this->boolEnumRef)) {
+            $output['boolEnumRef'] = $this->boolEnumRef;
+        }
+        $output['requiredBoolEnumRef'] = $this->requiredBoolEnumRef;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
@@ -136,6 +136,23 @@ class BarTest
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->exampleProp)) {
+            if ((($this->exampleProp) instanceof FooTest) || (($this->exampleProp) instanceof MoiKlass) || (($this->exampleProp) instanceof FooTest_1)) {
+                $output['exampleProp'] = $this->exampleProp->toArray();
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/FooTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/FooTest.php
@@ -107,6 +107,21 @@ class FooTest
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/FooTest_1.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/FooTest_1.php
@@ -107,6 +107,21 @@ class FooTest_1
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->b)) {
+            $output['b'] = $this->b;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/MoiKlass.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/MoiKlass.php
@@ -107,6 +107,21 @@ class MoiKlass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->c)) {
+            $output['c'] = $this->c;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -138,6 +138,23 @@ class BarTest
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->exampleProp)) {
+            if ((($this->exampleProp) instanceof FooTest) || (($this->exampleProp) instanceof MoiKlass) || (($this->exampleProp) instanceof FooTest_1)) {
+                $output['exampleProp'] = $this->exampleProp->toArray();
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest.php
@@ -109,6 +109,21 @@ class FooTest
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest_1.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest_1.php
@@ -109,6 +109,21 @@ class FooTest_1
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->b)) {
+            $output['b'] = $this->b;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/MoiKlass.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/MoiKlass.php
@@ -109,6 +109,21 @@ class MoiKlass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->c)) {
+            $output['c'] = $this->c;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
@@ -139,6 +139,25 @@ class BarTest
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->exampleProp)) {
+            $output['exampleProp'] = match (true) {
+                ($this->exampleProp) instanceof FooTest,
+                ($this->exampleProp) instanceof MoiKlass,
+                ($this->exampleProp) instanceof FooTest_1 => $this->exampleProp->toArray(),
+            };
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest.php
@@ -103,6 +103,21 @@ class FooTest
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest_1.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest_1.php
@@ -103,6 +103,21 @@ class FooTest_1
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->b)) {
+            $output['b'] = $this->b;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/MoiKlass.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/MoiKlass.php
@@ -103,6 +103,21 @@ class MoiKlass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->c)) {
+            $output['c'] = $this->c;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -2063,6 +2063,87 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false)
+    {
+        $output = [];
+        $output['_GLOBALS'] = $this->_GLOBALS_1;
+        $output['GLOBALS'] = $this->_GLOBALS_2;
+        $output['GLOBALS_1'] = $this->_GLOBALS1_1;
+        $output['_SERVER'] = $this->_SERVER_1;
+        $output['_GET'] = $this->_GET_1;
+        $output['_POST'] = $this->_POST_1;
+        $output['_FILES'] = $this->_FILES_1;
+        $output['_REQUEST'] = $this->_REQUEST_1;
+        $output['_SESSION'] = $this->_SESSION_1;
+        $output['_ENV'] = $this->_ENV_1;
+        $output['_COOKIE'] = $this->_COOKIE_1;
+        $output['php_errormsg'] = $this->_phpErrormsg;
+        $output['http_response_header'] = $this->_httpResponseHeader;
+        $output['argc'] = $this->_argc;
+        $output['argv'] = $this->_argv;
+        $output['input'] = $this->input;
+        if (isset($this->validate)) {
+            $output['validate'] = $this->validate;
+        }
+        if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
+            $output['materializeDefaults'] = $this->materializeDefaults;
+        }
+        $output['obj'] = $this->obj;
+        $output['includeDefaults'] = $this->includeDefaults;
+        if (isset($this->testObj)) {
+            $output['testObj'] = ($this->testObj)->toArray();
+        }
+        $output['buildFromInput'] = $this->_buildFromInput_1;
+        $output['toArray'] = $this->_toArray_1;
+        $output['validateInput'] = $this->_validateInput_1;
+        $output['schema'] = $this->_schema;
+        $output['_defaults'] = $this->_defaults_1;
+        $output['clone'] = $this->_clone_1;
+        $output['__construct'] = $this->_construct_1;
+        $output['__destruct'] = $this->_destruct_1;
+        $output['__get'] = $this->_get_2;
+        $output['__set'] = $this->_set_1;
+        $output['__call'] = $this->_call_1;
+        $output['__isset'] = $this->_isset_1;
+        $output['__unset'] = $this->_unset_1;
+        $output['__sleep'] = $this->_sleep_1;
+        $output['__wakeup'] = $this->_wakeup_1;
+        $output['__toString'] = $this->_toString_1;
+        $output['__invoke'] = $this->_invoke_1;
+        $output['__debugInfo'] = $this->_debugInfo_1;
+        $output['__clone'] = $this->_clone_2;
+        $output['files'] = $this->files;
+        if (isset($this->ensureArgs1)) {
+            if (($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1) || ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2)) {
+                $output['ensureArgs1'] = ($this->ensureArgs1)->toArray();
+            } else if ((is_string($this->ensureArgs1))) {
+                $output['ensureArgs1'] = $this->ensureArgs1;
+            }
+        }
+        if (isset($this->ensureArgs2)) {
+            $output['ensureArgs2'] = ($this->ensureArgs2)->toArray();
+        }
+        if (isset($this->ensureArgs3)) {
+            $output['ensureArgs3'] = array_map(function(MyClassEnsureArgs3Item $i) { return $i->toArray(); }, $this->ensureArgs3);
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs1Alternative1.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs1Alternative1.php
@@ -140,6 +140,30 @@ class MyClassEnsureArgs1Alternative1
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false)
+    {
+        $output = [];
+        if (isset($this->type)) {
+            $output['type'] = $this->type;
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs1Alternative2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs1Alternative2.php
@@ -177,6 +177,29 @@ class MyClassEnsureArgs1Alternative2
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false)
+    {
+        $output = [];
+        $output['type'] = $this->type;
+        $output['accountNumber'] = $this->accountNumber;
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs2.php
@@ -178,6 +178,29 @@ class MyClassEnsureArgs2
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false)
+    {
+        $output = [];
+        $output['city'] = $this->city;
+        $output['street'] = $this->street;
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs3Item.php
@@ -137,6 +137,30 @@ class MyClassEnsureArgs3Item
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false)
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassTestObj.php
@@ -107,6 +107,21 @@ class MyClassTestObj
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -2065,6 +2065,87 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        $output['_GLOBALS'] = $this->_GLOBALS_1;
+        $output['GLOBALS'] = $this->_GLOBALS_2;
+        $output['GLOBALS_1'] = $this->_GLOBALS1_1;
+        $output['_SERVER'] = $this->_SERVER_1;
+        $output['_GET'] = $this->_GET_1;
+        $output['_POST'] = $this->_POST_1;
+        $output['_FILES'] = $this->_FILES_1;
+        $output['_REQUEST'] = $this->_REQUEST_1;
+        $output['_SESSION'] = $this->_SESSION_1;
+        $output['_ENV'] = $this->_ENV_1;
+        $output['_COOKIE'] = $this->_COOKIE_1;
+        $output['php_errormsg'] = $this->_phpErrormsg;
+        $output['http_response_header'] = $this->_httpResponseHeader;
+        $output['argc'] = $this->_argc;
+        $output['argv'] = $this->_argv;
+        $output['input'] = $this->input;
+        if (isset($this->validate)) {
+            $output['validate'] = $this->validate;
+        }
+        if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
+            $output['materializeDefaults'] = $this->materializeDefaults;
+        }
+        $output['obj'] = $this->obj;
+        $output['includeDefaults'] = $this->includeDefaults;
+        if (isset($this->testObj)) {
+            $output['testObj'] = ($this->testObj)->toArray();
+        }
+        $output['buildFromInput'] = $this->_buildFromInput_1;
+        $output['toArray'] = $this->_toArray_1;
+        $output['validateInput'] = $this->_validateInput_1;
+        $output['schema'] = $this->_schema;
+        $output['_defaults'] = $this->_defaults_1;
+        $output['clone'] = $this->_clone_1;
+        $output['__construct'] = $this->_construct_1;
+        $output['__destruct'] = $this->_destruct_1;
+        $output['__get'] = $this->_get_2;
+        $output['__set'] = $this->_set_1;
+        $output['__call'] = $this->_call_1;
+        $output['__isset'] = $this->_isset_1;
+        $output['__unset'] = $this->_unset_1;
+        $output['__sleep'] = $this->_sleep_1;
+        $output['__wakeup'] = $this->_wakeup_1;
+        $output['__toString'] = $this->_toString_1;
+        $output['__invoke'] = $this->_invoke_1;
+        $output['__debugInfo'] = $this->_debugInfo_1;
+        $output['__clone'] = $this->_clone_2;
+        $output['files'] = $this->files;
+        if (isset($this->ensureArgs1)) {
+            if (($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1) || ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2)) {
+                $output['ensureArgs1'] = ($this->ensureArgs1)->toArray();
+            } else if ((is_string($this->ensureArgs1))) {
+                $output['ensureArgs1'] = $this->ensureArgs1;
+            }
+        }
+        if (isset($this->ensureArgs2)) {
+            $output['ensureArgs2'] = ($this->ensureArgs2)->toArray();
+        }
+        if (isset($this->ensureArgs3)) {
+            $output['ensureArgs3'] = array_map(fn (MyClassEnsureArgs3Item $i) => $i->toArray(), $this->ensureArgs3);
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs1Alternative1.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs1Alternative1.php
@@ -142,6 +142,30 @@ class MyClassEnsureArgs1Alternative1
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        if (isset($this->type)) {
+            $output['type'] = $this->type;
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs1Alternative2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs1Alternative2.php
@@ -179,6 +179,29 @@ class MyClassEnsureArgs1Alternative2
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        $output['type'] = $this->type;
+        $output['accountNumber'] = $this->accountNumber;
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs2.php
@@ -180,6 +180,29 @@ class MyClassEnsureArgs2
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        $output['city'] = $this->city;
+        $output['street'] = $this->street;
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs3Item.php
@@ -139,6 +139,30 @@ class MyClassEnsureArgs3Item
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassTestObj.php
@@ -109,6 +109,21 @@ class MyClassTestObj
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
@@ -2064,6 +2064,87 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        $output['_GLOBALS'] = $this->_GLOBALS_1;
+        $output['GLOBALS'] = $this->_GLOBALS_2;
+        $output['GLOBALS_1'] = $this->_GLOBALS1_1;
+        $output['_SERVER'] = $this->_SERVER_1;
+        $output['_GET'] = $this->_GET_1;
+        $output['_POST'] = $this->_POST_1;
+        $output['_FILES'] = $this->_FILES_1;
+        $output['_REQUEST'] = $this->_REQUEST_1;
+        $output['_SESSION'] = $this->_SESSION_1;
+        $output['_ENV'] = $this->_ENV_1;
+        $output['_COOKIE'] = $this->_COOKIE_1;
+        $output['php_errormsg'] = $this->_phpErrormsg;
+        $output['http_response_header'] = $this->_httpResponseHeader;
+        $output['argc'] = $this->_argc;
+        $output['argv'] = $this->_argv;
+        $output['input'] = $this->input;
+        if (isset($this->validate)) {
+            $output['validate'] = $this->validate;
+        }
+        if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
+            $output['materializeDefaults'] = $this->materializeDefaults;
+        }
+        $output['obj'] = $this->obj;
+        $output['includeDefaults'] = $this->includeDefaults;
+        if (isset($this->testObj)) {
+            $output['testObj'] = ($this->testObj)->toArray();
+        }
+        $output['buildFromInput'] = $this->_buildFromInput_1;
+        $output['toArray'] = $this->_toArray_1;
+        $output['validateInput'] = $this->_validateInput_1;
+        $output['schema'] = $this->_schema;
+        $output['_defaults'] = $this->_defaults_1;
+        $output['clone'] = $this->_clone_1;
+        $output['__construct'] = $this->_construct_1;
+        $output['__destruct'] = $this->_destruct_1;
+        $output['__get'] = $this->_get_2;
+        $output['__set'] = $this->_set_1;
+        $output['__call'] = $this->_call_1;
+        $output['__isset'] = $this->_isset_1;
+        $output['__unset'] = $this->_unset_1;
+        $output['__sleep'] = $this->_sleep_1;
+        $output['__wakeup'] = $this->_wakeup_1;
+        $output['__toString'] = $this->_toString_1;
+        $output['__invoke'] = $this->_invoke_1;
+        $output['__debugInfo'] = $this->_debugInfo_1;
+        $output['__clone'] = $this->_clone_2;
+        $output['files'] = $this->files;
+        if (isset($this->ensureArgs1)) {
+            $output['ensureArgs1'] = match (true) {
+                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1,
+                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 => ($this->ensureArgs1)->toArray(),
+                is_string($this->ensureArgs1) => $this->ensureArgs1,
+            };
+        }
+        if (isset($this->ensureArgs2)) {
+            $output['ensureArgs2'] = ($this->ensureArgs2)->toArray();
+        }
+        if (isset($this->ensureArgs3)) {
+            $output['ensureArgs3'] = array_map(fn (MyClassEnsureArgs3Item $i) => $i->toArray(), $this->ensureArgs3);
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs1Alternative1.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs1Alternative1.php
@@ -127,6 +127,30 @@ class MyClassEnsureArgs1Alternative1
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        if (isset($this->type)) {
+            $output['type'] = ($this->type)->value;
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs1Alternative2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs1Alternative2.php
@@ -173,6 +173,29 @@ class MyClassEnsureArgs1Alternative2
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        $output['type'] = $this->type;
+        $output['accountNumber'] = $this->accountNumber;
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs2.php
@@ -174,6 +174,29 @@ class MyClassEnsureArgs2
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        $output['city'] = $this->city;
+        $output['street'] = $this->street;
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs3Item.php
@@ -133,6 +133,30 @@ class MyClassEnsureArgs3Item
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassTestObj.php
@@ -103,6 +103,21 @@ class MyClassTestObj
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-5.6/MyClass.php
@@ -212,6 +212,27 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->bound)) {
+            $output['bound'] = $this->bound;
+        }
+        if (isset($this->outbound)) {
+            $output['outbound'] = $this->outbound;
+        }
+        if (isset($this->_outbound)) {
+            $output['_outbound'] = $this->_outbound;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-7.4/MyClass.php
@@ -214,6 +214,27 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->bound)) {
+            $output['bound'] = $this->bound;
+        }
+        if (isset($this->outbound)) {
+            $output['outbound'] = $this->outbound;
+        }
+        if (isset($this->_outbound)) {
+            $output['_outbound'] = $this->_outbound;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-8.4/MyClass.php
@@ -208,6 +208,27 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->bound)) {
+            $output['bound'] = $this->bound;
+        }
+        if (isset($this->outbound)) {
+            $output['outbound'] = $this->outbound;
+        }
+        if (isset($this->_outbound)) {
+            $output['_outbound'] = $this->_outbound;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -1828,6 +1828,70 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false)
+    {
+        $output = [];
+        $output['_GLOBALS'] = $this->_GLOBALS_1;
+        $output['GLOBALS'] = $this->_GLOBALS_2;
+        $output['GLOBALS_1'] = $this->_GLOBALS_1_1;
+        $output['_SERVER'] = $this->_SERVER_1;
+        $output['_GET'] = $this->_GET_1;
+        $output['_POST'] = $this->_POST_1;
+        $output['_FILES'] = $this->_FILES_1;
+        $output['_REQUEST'] = $this->_REQUEST_1;
+        $output['_SESSION'] = $this->_SESSION_1;
+        $output['_ENV'] = $this->_ENV_1;
+        $output['_COOKIE'] = $this->_COOKIE_1;
+        $output['php_errormsg'] = $this->_php_errormsg;
+        $output['http_response_header'] = $this->_http_response_header;
+        $output['argc'] = $this->_argc;
+        $output['argv'] = $this->_argv;
+        $output['input'] = $this->input;
+        $output['validate'] = $this->validate;
+        $output['obj'] = $this->obj;
+        $output['materializeDefaults'] = $this->materializeDefaults;
+        $output['includeDefaults'] = $this->includeDefaults;
+        if (isset($this->testObj)) {
+            $output['testObj'] = ($this->testObj)->toArray();
+        }
+        $output['buildFromInput'] = $this->_buildFromInput;
+        $output['toArray'] = $this->_toArray;
+        $output['validateInput'] = $this->_validateInput;
+        $output['schema'] = $this->_schema;
+        $output['_defaults'] = $this->_defaults_1;
+        $output['clone'] = $this->_clone;
+        $output['__construct'] = $this->__construct_1;
+        $output['__destruct'] = $this->__destruct_1;
+        $output['__get'] = $this->__get_1;
+        $output['__set'] = $this->__set_1;
+        $output['__call'] = $this->__call_1;
+        $output['__isset'] = $this->__isset_1;
+        $output['__unset'] = $this->__unset_1;
+        $output['__sleep'] = $this->__sleep_1;
+        $output['__wakeup'] = $this->__wakeup_1;
+        $output['__toString'] = $this->__toString_1;
+        $output['__invoke'] = $this->__invoke_1;
+        $output['__debugInfo'] = $this->__debugInfo_1;
+        $output['__clone'] = $this->__clone_1;
+        $output['files'] = $this->files;
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClassTestObj.php
@@ -107,6 +107,21 @@ class MyClassTestObj
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -1830,6 +1830,70 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        $output['_GLOBALS'] = $this->_GLOBALS_1;
+        $output['GLOBALS'] = $this->_GLOBALS_2;
+        $output['GLOBALS_1'] = $this->_GLOBALS_1_1;
+        $output['_SERVER'] = $this->_SERVER_1;
+        $output['_GET'] = $this->_GET_1;
+        $output['_POST'] = $this->_POST_1;
+        $output['_FILES'] = $this->_FILES_1;
+        $output['_REQUEST'] = $this->_REQUEST_1;
+        $output['_SESSION'] = $this->_SESSION_1;
+        $output['_ENV'] = $this->_ENV_1;
+        $output['_COOKIE'] = $this->_COOKIE_1;
+        $output['php_errormsg'] = $this->_php_errormsg;
+        $output['http_response_header'] = $this->_http_response_header;
+        $output['argc'] = $this->_argc;
+        $output['argv'] = $this->_argv;
+        $output['input'] = $this->input;
+        $output['validate'] = $this->validate;
+        $output['obj'] = $this->obj;
+        $output['materializeDefaults'] = $this->materializeDefaults;
+        $output['includeDefaults'] = $this->includeDefaults;
+        if (isset($this->testObj)) {
+            $output['testObj'] = ($this->testObj)->toArray();
+        }
+        $output['buildFromInput'] = $this->_buildFromInput;
+        $output['toArray'] = $this->_toArray;
+        $output['validateInput'] = $this->_validateInput;
+        $output['schema'] = $this->_schema;
+        $output['_defaults'] = $this->_defaults_1;
+        $output['clone'] = $this->_clone;
+        $output['__construct'] = $this->__construct_1;
+        $output['__destruct'] = $this->__destruct_1;
+        $output['__get'] = $this->__get_1;
+        $output['__set'] = $this->__set_1;
+        $output['__call'] = $this->__call_1;
+        $output['__isset'] = $this->__isset_1;
+        $output['__unset'] = $this->__unset_1;
+        $output['__sleep'] = $this->__sleep_1;
+        $output['__wakeup'] = $this->__wakeup_1;
+        $output['__toString'] = $this->__toString_1;
+        $output['__invoke'] = $this->__invoke_1;
+        $output['__debugInfo'] = $this->__debugInfo_1;
+        $output['__clone'] = $this->__clone_1;
+        $output['files'] = $this->files;
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassTestObj.php
@@ -109,6 +109,21 @@ class MyClassTestObj
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
@@ -1824,6 +1824,70 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        $output['_GLOBALS'] = $this->_GLOBALS_1;
+        $output['GLOBALS'] = $this->_GLOBALS_2;
+        $output['GLOBALS_1'] = $this->_GLOBALS_1_1;
+        $output['_SERVER'] = $this->_SERVER_1;
+        $output['_GET'] = $this->_GET_1;
+        $output['_POST'] = $this->_POST_1;
+        $output['_FILES'] = $this->_FILES_1;
+        $output['_REQUEST'] = $this->_REQUEST_1;
+        $output['_SESSION'] = $this->_SESSION_1;
+        $output['_ENV'] = $this->_ENV_1;
+        $output['_COOKIE'] = $this->_COOKIE_1;
+        $output['php_errormsg'] = $this->_php_errormsg;
+        $output['http_response_header'] = $this->_http_response_header;
+        $output['argc'] = $this->_argc;
+        $output['argv'] = $this->_argv;
+        $output['input'] = $this->input;
+        $output['validate'] = $this->validate;
+        $output['obj'] = $this->obj;
+        $output['materializeDefaults'] = $this->materializeDefaults;
+        $output['includeDefaults'] = $this->includeDefaults;
+        if (isset($this->testObj)) {
+            $output['testObj'] = ($this->testObj)->toArray();
+        }
+        $output['buildFromInput'] = $this->_buildFromInput;
+        $output['toArray'] = $this->_toArray;
+        $output['validateInput'] = $this->_validateInput;
+        $output['schema'] = $this->_schema;
+        $output['_defaults'] = $this->_defaults_1;
+        $output['clone'] = $this->_clone;
+        $output['__construct'] = $this->__construct_1;
+        $output['__destruct'] = $this->__destruct_1;
+        $output['__get'] = $this->__get_1;
+        $output['__set'] = $this->__set_1;
+        $output['__call'] = $this->__call_1;
+        $output['__isset'] = $this->__isset_1;
+        $output['__unset'] = $this->__unset_1;
+        $output['__sleep'] = $this->__sleep_1;
+        $output['__wakeup'] = $this->__wakeup_1;
+        $output['__toString'] = $this->__toString_1;
+        $output['__invoke'] = $this->__invoke_1;
+        $output['__debugInfo'] = $this->__debugInfo_1;
+        $output['__clone'] = $this->__clone_1;
+        $output['files'] = $this->files;
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassTestObj.php
@@ -103,6 +103,21 @@ class MyClassTestObj
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/JsonFile/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/JsonFile/Output-5.6/MyClass.php
@@ -109,6 +109,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['id'] = $this->id;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/JsonFile/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/JsonFile/Output-7.4/MyClass.php
@@ -111,6 +111,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['id'] = $this->id;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/JsonFile/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/JsonFile/Output-8.4/MyClass.php
@@ -105,6 +105,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['id'] = $this->id;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -231,6 +231,32 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        $output['bar'] = ($this->bar)->toArray();
+        if (isset($this->baz)) {
+            $output['baz'] = $this->baz;
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassBar.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassBar.php
@@ -104,6 +104,19 @@ class MyClassBar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['nestedFoo'] = $this->nestedFoo;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSetters/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-5.6/Baz.php
@@ -92,6 +92,21 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSetters/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-5.6/MyClass.php
@@ -201,6 +201,25 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        $output['bar'] = $this->bar->toArray();
+        if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
+            $output['opt'] = $this->opt;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSetters/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-7.4/Baz.php
@@ -94,6 +94,21 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
@@ -203,6 +203,25 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        $output['bar'] = $this->bar->toArray();
+        if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
+            $output['opt'] = $this->opt;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSetters/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-8.4/Baz.php
@@ -88,6 +88,21 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
@@ -197,6 +197,25 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        $output['bar'] = $this->bar->toArray();
+        if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
+            $output['opt'] = $this->opt;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/Baz.php
@@ -95,6 +95,21 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/MyClass.php
@@ -212,6 +212,25 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        $output['bar'] = $this->bar->toArray();
+        if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
+            $output['opt'] = $this->opt;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/Baz.php
@@ -97,6 +97,21 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
@@ -214,6 +214,25 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        $output['bar'] = $this->bar->toArray();
+        if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
+            $output['opt'] = $this->opt;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/Baz.php
@@ -91,6 +91,21 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
@@ -208,6 +208,25 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        $output['bar'] = $this->bar->toArray();
+        if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
+            $output['opt'] = $this->opt;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
@@ -169,6 +169,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->files)) {
+            $output['files'] = array_map(function(MyClassFilesItem $i) { return $i->toArray(); }, $this->files);
+        }
+        if (isset($this->options)) {
+            $output['options'] = $this->options->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClassFilesItem.php
@@ -162,6 +162,24 @@ class MyClassFilesItem
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->input)) {
+            $output['input'] = $this->input;
+        }
+        if (isset($this->options)) {
+            $output['options'] = $this->options->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/OptionsObject.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/OptionsObject.php
@@ -106,6 +106,21 @@ class OptionsObject
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->output)) {
+            $output['output'] = $this->output;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
@@ -171,6 +171,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->files)) {
+            $output['files'] = array_map(fn (MyClassFilesItem $i) => $i->toArray(), $this->files);
+        }
+        if (isset($this->options)) {
+            $output['options'] = $this->options->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
@@ -164,6 +164,24 @@ class MyClassFilesItem
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->input)) {
+            $output['input'] = $this->input;
+        }
+        if (isset($this->options)) {
+            $output['options'] = $this->options->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/OptionsObject.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/OptionsObject.php
@@ -108,6 +108,21 @@ class OptionsObject
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->output)) {
+            $output['output'] = $this->output;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
@@ -165,6 +165,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->files)) {
+            $output['files'] = array_map(fn (MyClassFilesItem $i) => $i->toArray(), $this->files);
+        }
+        if (isset($this->options)) {
+            $output['options'] = $this->options->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
@@ -158,6 +158,24 @@ class MyClassFilesItem
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->input)) {
+            $output['input'] = $this->input;
+        }
+        if (isset($this->options)) {
+            $output['options'] = $this->options->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/OptionsObject.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/OptionsObject.php
@@ -102,6 +102,21 @@ class OptionsObject
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->output)) {
+            $output['output'] = $this->output;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Fio.php
@@ -124,6 +124,21 @@ class Fio
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->bar) || array_key_exists('bar', $this->_providedOptionals)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Phone.php
@@ -107,6 +107,21 @@ class Phone
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Record.php
@@ -333,6 +333,30 @@ class Record
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->dataArray)) {
+            $output['dataArray'] = array_map(fn(Phone $i): array => $i->toArray(), $this->dataArray);
+        }
+        if (isset($this->dataArrayNested)) {
+            $output['dataArrayNested'] = array_map(function($i) { return array_map(fn(Phone $i): array => $i->toArray(), $i); }, $this->dataArrayNested);
+        }
+        if (isset($this->dataArrayAnyOf)) {
+            $output['dataArrayAnyOf'] = array_map(function($i) { return (($i) instanceof Fio) ? ($i->toArray()) : ((($i) instanceof Phone) ? ($i->toArray()) : (null)); }, $this->dataArrayAnyOf);
+        }
+        if (isset($this->dataArrayNestedAnyOf)) {
+            $output['dataArrayNestedAnyOf'] = array_map(function($i) { return array_map(function($i) { return (($i) instanceof Fio) ? ($i->toArray()) : ((($i) instanceof Phone) ? ($i->toArray()) : (null)); }, $i); }, $this->dataArrayNestedAnyOf);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Fio.php
@@ -126,6 +126,21 @@ class Fio
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->bar) || array_key_exists('bar', $this->_providedOptionals)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Phone.php
@@ -109,6 +109,21 @@ class Phone
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Record.php
@@ -335,6 +335,30 @@ class Record
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->dataArray)) {
+            $output['dataArray'] = array_map(fn(Phone $i): array => $i->toArray(), $this->dataArray);
+        }
+        if (isset($this->dataArrayNested)) {
+            $output['dataArrayNested'] = array_map(fn($i) => array_map(fn(Phone $i): array => $i->toArray(), $i), $this->dataArrayNested);
+        }
+        if (isset($this->dataArrayAnyOf)) {
+            $output['dataArrayAnyOf'] = array_map(fn($i) => (($i) instanceof Fio) ? ($i->toArray()) : ((($i) instanceof Phone) ? ($i->toArray()) : (null)), $this->dataArrayAnyOf);
+        }
+        if (isset($this->dataArrayNestedAnyOf)) {
+            $output['dataArrayNestedAnyOf'] = array_map(fn($i) => array_map(fn($i) => (($i) instanceof Fio) ? ($i->toArray()) : ((($i) instanceof Phone) ? ($i->toArray()) : (null)), $i), $this->dataArrayNestedAnyOf);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Fio.php
@@ -120,6 +120,21 @@ class Fio
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->bar) || array_key_exists('bar', $this->_providedOptionals)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Phone.php
@@ -103,6 +103,21 @@ class Phone
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Record.php
@@ -345,6 +345,38 @@ class Record
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->dataArray)) {
+            $output['dataArray'] = array_map(fn(Phone $i): array => $i->toArray(), $this->dataArray);
+        }
+        if (isset($this->dataArrayNested)) {
+            $output['dataArrayNested'] = array_map(fn($i) => array_map(fn(Phone $i): array => $i->toArray(), $i), $this->dataArrayNested);
+        }
+        if (isset($this->dataArrayAnyOf)) {
+            $output['dataArrayAnyOf'] = array_map(fn($i) => match (true) {
+                default => null,
+                ($i) instanceof Phone,
+                ($i) instanceof Fio => $i->toArray(),
+            }, $this->dataArrayAnyOf);
+        }
+        if (isset($this->dataArrayNestedAnyOf)) {
+            $output['dataArrayNestedAnyOf'] = array_map(fn($i) => array_map(fn($i) => match (true) {
+                default => null,
+                ($i) instanceof Phone,
+                ($i) instanceof Fio => $i->toArray(),
+            }, $i), $this->dataArrayNestedAnyOf);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoEnums/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NoEnums/Output-5.6/MyClass.php
@@ -108,6 +108,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['color'] = $this->color;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoEnums/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoEnums/Output-7.4/MyClass.php
@@ -110,6 +110,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['color'] = $this->color;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoEnums/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoEnums/Output-8.4/MyClass.php
@@ -104,6 +104,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['color'] = $this->color;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoGetters/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NoGetters/Output-5.6/MyClass.php
@@ -96,6 +96,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoGetters/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoGetters/Output-7.4/MyClass.php
@@ -98,6 +98,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoGetters/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoGetters/Output-8.4/MyClass.php
@@ -92,6 +92,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoSchemaMetadata/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NoSchemaMetadata/Output-5.6/MyClass.php
@@ -167,6 +167,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoSchemaMetadata/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoSchemaMetadata/Output-7.4/MyClass.php
@@ -169,6 +169,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoSchemaMetadata/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoSchemaMetadata/Output-8.4/MyClass.php
@@ -163,6 +163,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoSetters/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NoSetters/Output-5.6/MyClass.php
@@ -104,6 +104,20 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        $output['bar'] = $this->bar;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoSetters/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoSetters/Output-7.4/MyClass.php
@@ -106,6 +106,20 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        $output['bar'] = $this->bar;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoSetters/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoSetters/Output-8.4/MyClass.php
@@ -100,6 +100,20 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        $output['bar'] = $this->bar;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonAsciiProperty/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NonAsciiProperty/Output-5.6/MyClass.php
@@ -188,6 +188,21 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['Город'] = $this->Gorod;
+        $output['название юр.лица'] = $this->nazvanieIurLitsa;
+        $output['IP-адрес'] = $this->IPAdres;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonAsciiProperty/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NonAsciiProperty/Output-7.4/MyClass.php
@@ -190,6 +190,21 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['Город'] = $this->Gorod;
+        $output['название юр.лица'] = $this->nazvanieIurLitsa;
+        $output['IP-адрес'] = $this->IPAdres;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonAsciiProperty/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NonAsciiProperty/Output-8.4/MyClass.php
@@ -184,6 +184,21 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['Город'] = $this->Gorod;
+        $output['название юр.лица'] = $this->nazvanieIurLitsa;
+        $output['IP-адрес'] = $this->IPAdres;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Bar.php
@@ -114,6 +114,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->b)) {
+            $output['b'] = $this->b;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
@@ -136,6 +136,23 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->grox)) {
+            if ((($this->grox) instanceof Foo) || (($this->grox) instanceof Bar)) {
+                $output['grox'] = $this->grox->toArray();
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Foo.php
@@ -112,6 +112,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -151,6 +151,25 @@ class Qux
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->grox)) {
+            if ((is_string($this->grox)) || (is_array($this->grox))) {
+                $output['grox'] = $this->grox;
+            } else if (((($this->grox) instanceof Foo) || (($this->grox) instanceof Bar))) {
+                $output['grox'] = (($this->grox) instanceof Bar) ? ($this->grox->toArray()) : ((($this->grox) instanceof Foo) ? ($this->grox->toArray()) : (null));
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Bar.php
@@ -116,6 +116,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->b)) {
+            $output['b'] = $this->b;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -138,6 +138,23 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->grox)) {
+            if ((($this->grox) instanceof Foo) || (($this->grox) instanceof Bar)) {
+                $output['grox'] = $this->grox->toArray();
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Foo.php
@@ -114,6 +114,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -153,6 +153,25 @@ class Qux
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->grox)) {
+            if ((is_string($this->grox)) || (is_array($this->grox))) {
+                $output['grox'] = $this->grox;
+            } else if (((($this->grox) instanceof Foo) || (($this->grox) instanceof Bar))) {
+                $output['grox'] = (($this->grox) instanceof Bar) ? ($this->grox->toArray()) : ((($this->grox) instanceof Foo) ? ($this->grox->toArray()) : (null));
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Bar.php
@@ -110,6 +110,21 @@ class Bar
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->b)) {
+            $output['b'] = $this->b;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
@@ -137,6 +137,24 @@ class Baz
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->grox)) {
+            $output['grox'] = match (true) {
+                ($this->grox) instanceof Foo,
+                ($this->grox) instanceof Bar => $this->grox->toArray(),
+            };
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Foo.php
@@ -108,6 +108,21 @@ class Foo
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
@@ -160,6 +160,29 @@ class Qux
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->grox)) {
+            $output['grox'] = match (true) {
+                is_string($this->grox),
+                is_array($this->grox) => $this->grox,
+                (($this->grox) instanceof Foo) || (($this->grox) instanceof Bar) => match (true) {
+                default => null,
+                ($this->grox) instanceof Foo,
+                ($this->grox) instanceof Bar => $this->grox->toArray(),
+            },
+            };
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass.php
@@ -158,6 +158,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->_1)) {
+            $output['1'] = $this->_1;
+        }
+        if (isset($this->_2)) {
+            $output['2'] = ($this->_2)->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass_2.php
+++ b/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass_2.php
@@ -209,6 +209,27 @@ class MyClass_2
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->_1)) {
+            $output['1'] = $this->_1;
+        }
+        if (isset($this->_2)) {
+            $output['2'] = $this->_2;
+        }
+        if (isset($this->_3)) {
+            $output['3'] = $this->_3;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-5.6/MyClass.php
@@ -156,6 +156,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = json_decode(json_encode($this->foo), true);
+        }
+        $output['bar'] = json_decode(json_encode($this->bar), true);
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-7.4/MyClass.php
@@ -158,6 +158,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = json_decode(json_encode($this->foo), true);
+        }
+        $output['bar'] = json_decode(json_encode($this->bar), true);
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
@@ -152,6 +152,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = json_decode(json_encode($this->foo), true);
+        }
+        $output['bar'] = json_decode(json_encode($this->bar), true);
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -152,6 +152,30 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if ((is_string($this->foo))) {
+            $output['foo'] = $this->foo;
+        } else if ((is_array($this->foo) || is_object($this->foo))) {
+            $output['foo'] = json_decode(json_encode($this->foo), true);
+        }
+        if (isset($this->bar)) {
+            if ((is_string($this->bar))) {
+                $output['bar'] = $this->bar;
+            } else if ((is_array($this->bar) || is_object($this->bar))) {
+                $output['bar'] = json_decode(json_encode($this->bar), true);
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -154,6 +154,30 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if ((is_string($this->foo))) {
+            $output['foo'] = $this->foo;
+        } else if ((is_array($this->foo) || is_object($this->foo))) {
+            $output['foo'] = json_decode(json_encode($this->foo), true);
+        }
+        if (isset($this->bar)) {
+            if ((is_string($this->bar))) {
+                $output['bar'] = $this->bar;
+            } else if ((is_array($this->bar) || is_object($this->bar))) {
+                $output['bar'] = json_decode(json_encode($this->bar), true);
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
@@ -154,6 +154,28 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = match (true) {
+            is_string($this->foo) => $this->foo,
+            is_array($this->foo) || is_object($this->foo) => json_decode(json_encode($this->foo), true),
+        };
+        if (isset($this->bar)) {
+            $output['bar'] = match (true) {
+                is_string($this->bar) => $this->bar,
+                is_array($this->bar) || is_object($this->bar) => json_decode(json_encode($this->bar), true),
+            };
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClass.php
@@ -575,6 +575,47 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false)
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+        if (isset($this->baz) || array_key_exists('baz', $this->_providedOptionals)) {
+            $output['baz'] = $this->baz;
+        }
+        if (isset($this->qux) || array_key_exists('qux', $this->_providedOptionals)) {
+            $output['qux'] = $this->qux;
+        }
+        $output['quux'] = $this->quux;
+        if (isset($this->xyyz)) {
+            $output['xyyz'] = $this->xyyz;
+        }
+        $output['thud'] = $this->thud;
+        if (isset($this->grox) || array_key_exists('grox', $this->_providedOptionals)) {
+            if (isset($this->grox)) {
+                $output['grox'] = ($this->grox)->toArray();
+            }
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClassGrox.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClassGrox.php
@@ -168,6 +168,24 @@ class MyClassGrox
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+        if (isset($this->b)) {
+            $output['b'] = $this->b;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
@@ -571,6 +571,47 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+        if (isset($this->baz) || array_key_exists('baz', $this->_providedOptionals)) {
+            $output['baz'] = $this->baz;
+        }
+        if (isset($this->qux) || array_key_exists('qux', $this->_providedOptionals)) {
+            $output['qux'] = $this->qux;
+        }
+        $output['quux'] = $this->quux;
+        if (isset($this->xyyz)) {
+            $output['xyyz'] = $this->xyyz;
+        }
+        $output['thud'] = $this->thud;
+        if (isset($this->grox) || array_key_exists('grox', $this->_providedOptionals)) {
+            if (isset($this->grox)) {
+                $output['grox'] = ($this->grox)->toArray();
+            }
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClassGrox.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClassGrox.php
@@ -164,6 +164,24 @@ class MyClassGrox
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+        if (isset($this->b)) {
+            $output['b'] = $this->b;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-5.6/MyClass.php
@@ -692,6 +692,33 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        $output['_foo'] = $this->_foo;
+        $output['__foo'] = $this->__foo;
+        $output['foo_'] = $this->foo_;
+        $output['foo__'] = $this->foo__;
+        $output['_foo_'] = $this->_foo_;
+        $output['__foo__'] = $this->__foo__;
+        $output['foo-bar'] = $this->foo_bar;
+        $output['foo bar'] = $this->_foo_bar;
+        $output['baz qux'] = $this->baz_qux;
+        $output['123 qwe'] = $this->_123_qwe;
+        $output['Город'] = $this->Gorod;
+        $output['название юр.лица'] = $this->nazvanie_iur_litsa;
+        $output['IP-адрес'] = $this->IP_adres;
+        $output['~~tildas~~'] = $this->_tildas;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-7.4/MyClass.php
@@ -694,6 +694,33 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        $output['_foo'] = $this->_foo;
+        $output['__foo'] = $this->__foo;
+        $output['foo_'] = $this->foo_;
+        $output['foo__'] = $this->foo__;
+        $output['_foo_'] = $this->_foo_;
+        $output['__foo__'] = $this->__foo__;
+        $output['foo-bar'] = $this->foo_bar;
+        $output['foo bar'] = $this->_foo_bar;
+        $output['baz qux'] = $this->baz_qux;
+        $output['123 qwe'] = $this->_123_qwe;
+        $output['Город'] = $this->Gorod;
+        $output['название юр.лица'] = $this->nazvanie_iur_litsa;
+        $output['IP-адрес'] = $this->IP_adres;
+        $output['~~tildas~~'] = $this->_tildas;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-8.4/MyClass.php
@@ -688,6 +688,33 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+        $output['_foo'] = $this->_foo;
+        $output['__foo'] = $this->__foo;
+        $output['foo_'] = $this->foo_;
+        $output['foo__'] = $this->foo__;
+        $output['_foo_'] = $this->_foo_;
+        $output['__foo__'] = $this->__foo__;
+        $output['foo-bar'] = $this->foo_bar;
+        $output['foo bar'] = $this->_foo_bar;
+        $output['baz qux'] = $this->baz_qux;
+        $output['123 qwe'] = $this->_123_qwe;
+        $output['Город'] = $this->Gorod;
+        $output['название юр.лица'] = $this->nazvanie_iur_litsa;
+        $output['IP-адрес'] = $this->IP_adres;
+        $output['~~tildas~~'] = $this->_tildas;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyClass.php
@@ -129,6 +129,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['value'] = $this->value->toArray();
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumber.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumber.php
@@ -123,6 +123,19 @@ class MyGenericStringNumber
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['field'] = ($this->field)->toArray();
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumberField.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumberField.php
@@ -119,6 +119,21 @@ class MyGenericStringNumberField
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->field)) {
+            $output['field'] = $this->field->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyClass.php
@@ -131,6 +131,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['value'] = $this->value->toArray();
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumber.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumber.php
@@ -125,6 +125,19 @@ class MyGenericStringNumber
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['field'] = ($this->field)->toArray();
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumberField.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumberField.php
@@ -121,6 +121,21 @@ class MyGenericStringNumberField
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->field)) {
+            $output['field'] = $this->field->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyClass.php
@@ -125,6 +125,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['value'] = $this->value->toArray();
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumber.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumber.php
@@ -119,6 +119,19 @@ class MyGenericStringNumber
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['field'] = ($this->field)->toArray();
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumberField.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumberField.php
@@ -115,6 +115,21 @@ class MyGenericStringNumberField
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->field)) {
+            $output['field'] = $this->field->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
@@ -163,6 +163,30 @@ class Cat
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
+            $output['hasFur'] = $this->hasFur;
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
@@ -161,6 +161,30 @@ class GenericPet
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toObject(bool $includeDefaults = false): \stdClass
+    {
+        $output = [];
+        if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
+            $output['hasFur'] = $this->hasFur;
+        }
+
+        if ($includeDefaults) {
+            foreach (self::$_defaults as $k => $v) {
+                if (!array_key_exists($k, $output)) {
+                    $output[$k] = $v;
+                }
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Pets.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Pets.php
@@ -166,6 +166,24 @@ class Pets
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->pet)) {
+            $output['pet'] = $this->pet->toArray();
+        }
+        if (isset($this->cat)) {
+            $output['cat'] = $this->cat->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RefList/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-5.6/MyClass.php
@@ -115,6 +115,21 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = array_map(fn(\Helmich\Schema2Class\Example\CustomerAddress $i): array => $i->toArray(), $this->foo);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RefList/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-7.4/MyClass.php
@@ -117,6 +117,21 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = array_map(fn(\Helmich\Schema2Class\Example\CustomerAddress $i): array => $i->toArray(), $this->foo);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RefList/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-8.4/MyClass.php
@@ -111,6 +111,21 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = array_map(fn(\Helmich\Schema2Class\Example\CustomerAddress $i): array => $i->toArray(), $this->foo);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
@@ -131,6 +131,27 @@ class MyObject
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if ((in_array($this->foo, array (
+          0 => 'foo',
+          1 => 'bar',
+        ), true)) || (in_array($this->foo, array (
+          0 => 'baz',
+          1 => 'quz',
+        ), true))) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
@@ -133,6 +133,27 @@ class MyObject
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if ((in_array($this->foo, array (
+          0 => 'foo',
+          1 => 'bar',
+        ), true)) || (in_array($this->foo, array (
+          0 => 'baz',
+          1 => 'quz',
+        ), true))) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
@@ -126,6 +126,22 @@ class MyObject
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = match (true) {
+            ($this->foo) instanceof A,
+            ($this->foo) instanceof B => $this->foo->value,
+        };
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SingleElemTypeArray/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/SingleElemTypeArray/Output-8.4/MyClass.php
@@ -448,6 +448,39 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = $this->foo;
+        }
+        if (isset($this->bar)) {
+            $output['bar'] = $this->bar;
+        }
+        if (isset($this->baz)) {
+            $output['baz'] = $this->baz;
+        }
+        if (isset($this->qux)) {
+            $output['qux'] = $this->qux;
+        }
+        if (isset($this->grox) || array_key_exists('grox', $this->_providedOptionals)) {
+            $output['grox'] = $this->grox;
+        }
+        if (isset($this->quux)) {
+            $output['quux'] = ($this->quux)->toArray();
+        }
+        if (isset($this->thud)) {
+            $output['thud'] = $this->thud;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SingleElemTypeArray/Output-8.4/MyClassQuux.php
+++ b/tests/Generator/Fixtures/SingleElemTypeArray/Output-8.4/MyClassQuux.php
@@ -103,6 +103,21 @@ class MyClassQuux
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->a)) {
+            $output['a'] = $this->a;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SingleLineSchema/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/SingleLineSchema/Output-5.6/MyClass.php
@@ -95,6 +95,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SingleLineSchema/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/SingleLineSchema/Output-7.4/MyClass.php
@@ -97,6 +97,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SingleLineSchema/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/SingleLineSchema/Output-8.4/MyClass.php
@@ -91,6 +91,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = $this->foo;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SuperglobalCollision/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/SuperglobalCollision/Output-5.6/MyClass.php
@@ -104,6 +104,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['files'] = $this->files;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SuperglobalCollision/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/SuperglobalCollision/Output-7.4/MyClass.php
@@ -106,6 +106,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['files'] = $this->files;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SuperglobalCollision/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/SuperglobalCollision/Output-8.4/MyClass.php
@@ -100,6 +100,19 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['files'] = $this->files;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
@@ -103,6 +103,23 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            if ((is_string($this->foo)) || (is_int($this->foo) || is_float($this->foo))) {
+                $output['foo'] = $this->foo;
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
@@ -105,6 +105,23 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            if ((is_string($this->foo)) || (is_int($this->foo) || is_float($this->foo))) {
+                $output['foo'] = $this->foo;
+            }
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
@@ -104,6 +104,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = match (true) {
+                is_string($this->foo),
+                is_int($this->foo) || is_float($this->foo) => $this->foo,
+            };
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-5.6/MyClass.php
@@ -177,6 +177,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = json_decode(json_encode($this->foo), true);
+        }
+        if (isset($this->encoded)) {
+            $output['encoded'] = json_decode(json_encode($this->encoded), true);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-7.4/MyClass.php
@@ -179,6 +179,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = json_decode(json_encode($this->foo), true);
+        }
+        if (isset($this->encoded)) {
+            $output['encoded'] = json_decode(json_encode($this->encoded), true);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
@@ -173,6 +173,24 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->foo)) {
+            $output['foo'] = json_decode(json_encode($this->foo), true);
+        }
+        if (isset($this->encoded)) {
+            $output['encoded'] = json_decode(json_encode($this->encoded), true);
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-5.6/MyClass.php
@@ -114,6 +114,23 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if ((is_string($this->foo))) {
+            $output['foo'] = $this->foo;
+        } else if (($this->foo instanceof MyClassFooAlternative2)) {
+            $output['foo'] = ($this->foo)->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-5.6/MyClassFooAlternative2.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-5.6/MyClassFooAlternative2.php
@@ -105,6 +105,19 @@ class MyClassFooAlternative2
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        $output['bar'] = $this->bar;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-7.4/MyClass.php
@@ -116,6 +116,23 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if ((is_string($this->foo))) {
+            $output['foo'] = $this->foo;
+        } else if (($this->foo instanceof MyClassFooAlternative2)) {
+            $output['foo'] = ($this->foo)->toArray();
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-7.4/MyClassFooAlternative2.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-7.4/MyClassFooAlternative2.php
@@ -107,6 +107,19 @@ class MyClassFooAlternative2
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['bar'] = $this->bar;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-8.4/MyClass.php
@@ -109,6 +109,22 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = match (true) {
+            is_string($this->foo) => $this->foo,
+            $this->foo instanceof MyClassFooAlternative2 => ($this->foo)->toArray(),
+        };
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-8.4/MyClassFooAlternative2.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-8.4/MyClassFooAlternative2.php
@@ -101,6 +101,19 @@ class MyClassFooAlternative2
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['bar'] = $this->bar;
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
@@ -106,6 +106,21 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject()
+    {
+        $output = [];
+        if ((is_string($this->foo)) || (is_string($this->foo))) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -108,6 +108,21 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if ((is_string($this->foo)) || (is_string($this->foo))) {
+            $output['foo'] = $this->foo;
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -105,6 +105,21 @@ class MyClass
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        $output['foo'] = match (true) {
+            is_string($this->foo) => $this->foo,
+        };
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -167,6 +167,34 @@ class Cat
     }
 
     /**
+     * Converts this object back to a stdClass that can be JSON-encoded
+     *
+     * @return \stdClass Converted object
+     */
+    public function toObject(): \stdClass
+    {
+        $output = [];
+        if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
+            $output['hasFur'] = match (true) {
+                (($this->hasFur) === null) || (is_bool($this->hasFur)) => ($this->hasFur !== null) ? ($this->hasFur) : null,
+                (($this->hasFur) === null) || ((is_string($this->hasFur)) || (is_int($this->hasFur) || is_float($this->hasFur))) => ($this->hasFur !== null) ? (match (true) {
+                default => null,
+                is_string($this->hasFur),
+                is_int($this->hasFur) || is_float($this->hasFur) => $this->hasFur,
+            }) : null,
+                (is_string($this->hasFur)) || (is_int($this->hasFur) || is_float($this->hasFur)) || (is_bool($this->hasFur)) => match (true) {
+                default => null,
+                is_string($this->hasFur),
+                is_int($this->hasFur) || is_float($this->hasFur),
+                is_bool($this->hasFur) => $this->hasFur,
+            },
+            };
+        }
+
+        return \JsonSchema\Validator::arrayToObjectRecursive($output);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -374,6 +374,14 @@ class SchemaToClassTest extends TestCase
                         $actualArray,
                         "Array returned from {$fqcn}->toArray() doesn't match input array from file '{$inputName}'."
                     );
+
+                    $expectedObject = \JsonSchema\Validator::arrayToObjectRecursive($expectedArray);
+                    $actualObject = $obj->toObject();
+                    $this->assertEquals(
+                        $expectedObject,
+                        $actualObject,
+                        "Object returned from {$fqcn}->toObject() doesn't match expected object for file '{$inputName}'."
+                    );
                 }
             }
         }
@@ -489,6 +497,16 @@ class SchemaToClassTest extends TestCase
                 'baz' => 'sanity-check',
             ],
             $obj->toArray(),
+        );
+
+        $expectedObject = \JsonSchema\Validator::arrayToObjectRecursive([
+            'foo' => 'some default value for foo',
+            'bar' => ['nestedFoo' => "some value inside default value for 'bar' object"],
+            'baz' => 'sanity-check',
+        ]);
+        $this->assertEquals(
+            $expectedObject,
+            $obj->toObject(),
         );
     }
 }


### PR DESCRIPTION
## Summary
- generate `toObject()` in code generator to return stdClass
- include `toObject()` in generated classes
- document the new method and mention in CHANGELOG
- update tests to check `toObject()` behaviour
- regenerate fixtures

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687d5d7e610c832d862470edb4916974