### PR TITLE
Add stdClass output support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Now it:
 ### Breaking changes
 
 - The `toJson` method of the generated class was renamed to `toArray` to reflect its purpose.
+- Added a new `toStdClass` method to get an `stdClass` representation (similar to `json_decode()` without flags).
 
 - The `treatValuesWithDefaultAsOptional` option was removed in favor of the runtime options `$materializeDefaults` in `buildFromInput()` and `$includeDefaults` in `toArray()`.
 

--- a/README.md
+++ b/README.md
@@ -209,8 +209,9 @@ $updatedUser = $user->withStatus("customer");
 echo "Old status: " . $user->getStatus();      // not mutated
 echo "New status: " . $updatedUser->getStatus(); // 'customer'
 
-// Finally, convert the updated user back to a simple PHP array:
+// Finally, convert the updated user back to a simple PHP array or stdClass:
 $userAsArray = $updatedUser->toArray();
+$userAsObject = $updatedUser->toStdClass();
 ```
 
 ## Compatibility
@@ -246,6 +247,7 @@ The generated classes offer:
 - To disable validation, pass `false` as the second argument of `buildFromInput($data, false)`. Use at your own risk.
 - If your schema has default values and you want to use them to populate the object properties that are not set in the input, pass the parameter `materializeDefaults = true` to `buildFromInput`. The parameter is generated only when the schema has default values.
 - The method `toArray()` returns a plain array ready for `json_encode()`.
+- The method `toStdClass()` returns an object (`stdClass`) similar to `json_decode()` without the associative option.
 - Properties are immutable by default; use `withX()` (or `withoutX()` for optional values) to create modified copies. Pass `--mutable-setters` to generate classic `setX()` methods instead.
 
 ## Advanced programmatic usage

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -371,6 +371,50 @@ class Generator
     }
 
     /**
+     * @param PropertyCollection $properties
+     * @return MethodGenerator
+     */
+    public function generateToStdClassMethod(PropertyCollection $properties, bool $hasDefaults = false): MethodGenerator
+    {
+        $tags = [];
+        if ($hasDefaults) {
+            $tags[] = new ParamTag('includeDefaults', ['bool'], 'Add defaults for missing properties');
+        }
+        $tags[] = new ReturnTag(['\\stdClass'], 'Converted object');
+
+        $docBlock = new DocBlockGenerator(
+            'Converts this object back to an stdClass that can be JSON-serialized',
+            null,
+            $tags
+        );
+        $docBlock->setWordWrap(false);
+
+        $params = [];
+        $call = '';
+        if ($hasDefaults) {
+            $params[] = new ParameterGenerator('includeDefaults', 'bool', false);
+            $call = '$includeDefaults';
+        }
+
+        $body = '$array = $this->toArray(' . $call . ');' . "\n" .
+            'return json_decode(json_encode($array));';
+
+        $method = new MethodGenerator(
+            'toStdClass',
+            $params,
+            MethodGenerator::FLAG_PUBLIC,
+            $body,
+            $docBlock
+        );
+
+        if ($this->generatorRequest->isAtLeastPHP("7.0")) {
+            $method->setReturnType("\\stdClass");
+        }
+
+        return $method;
+    }
+
+    /**
      * @return MethodGenerator
      */
     public function generateValidateMethod(): MethodGenerator

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -263,6 +263,7 @@ class SchemaToClass
             ...$codeGenerator->generateSetterMethods($propertiesFromSchema),
             $codeGenerator->generateBuildMethod($propertiesFromSchema, $hasDefaults),
             $codeGenerator->generateToArrayMethod($propertiesFromSchema, $hasDefaults),
+            $codeGenerator->generateToStdClassMethod($propertiesFromSchema, $hasDefaults),
             $codeGenerator->generateValidateMethod(),
             $codeGenerator->generateCloneMethod($propertiesFromSchema),
             $hasOptionalNullable ? $codeGenerator->generateIsSetMethod() : null,
@@ -352,6 +353,7 @@ class SchemaToClass
         $reservedMethodNames = [
             'buildFromInput',
             'toArray',
+            'toStdClass',
             'validateInput',
             'clone',
             '__construct',
@@ -427,6 +429,7 @@ class SchemaToClass
         $reservedMethodNames = [
             'buildFromInput',
             'toArray',
+            'toStdClass',
             'validateInput',
             'clone',
             '__construct',

--- a/tests/Generator/Fixtures/AdditionalProps/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output-5.6/MyClass.php
@@ -163,6 +163,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AdditionalProps/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output-7.4/MyClass.php
@@ -165,6 +165,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AdditionalProps/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output-8.4/MyClass.php
@@ -159,6 +159,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AdditionalPropsRoot/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropsRoot/Output-5.6/MyClass.php
@@ -163,6 +163,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AdditionalPropsRoot/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropsRoot/Output-7.4/MyClass.php
@@ -165,6 +165,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AdditionalPropsRoot/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropsRoot/Output-8.4/MyClass.php
@@ -159,6 +159,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AllOfRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output-5.6/MyClass.php
@@ -189,6 +189,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AllOfRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output-7.4/MyClass.php
@@ -191,6 +191,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AllOfRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output-8.4/MyClass.php
@@ -185,6 +185,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
@@ -139,6 +139,18 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false)
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
@@ -140,6 +140,18 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayProperty/Output-5.6/Phone.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-5.6/Phone.php
@@ -107,6 +107,17 @@ class Phone
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayProperty/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-5.6/Record.php
@@ -125,6 +125,17 @@ class Record
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayProperty/Output-7.4/Phone.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-7.4/Phone.php
@@ -109,6 +109,17 @@ class Phone
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayProperty/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-7.4/Record.php
@@ -127,6 +127,17 @@ class Record
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Phone.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Phone.php
@@ -103,6 +103,17 @@ class Phone
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Record.php
@@ -121,6 +121,17 @@ class Record
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -542,6 +542,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Basic/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/Basic/Output-5.6/MyClass.php
@@ -156,6 +156,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Basic/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Basic/Output-7.4/MyClass.php
@@ -158,6 +158,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Basic/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Basic/Output-8.4/MyClass.php
@@ -152,6 +152,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -569,6 +569,18 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-5.6/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-5.6/Address.php
@@ -158,6 +158,17 @@ class Address
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-5.6/Address/Defs/Name.php
+++ b/tests/Generator/Fixtures/Definitions/Output-5.6/Address/Defs/Name.php
@@ -107,6 +107,17 @@ class Name
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-5.6/MyClass.php
@@ -178,6 +178,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/Address.php
@@ -160,6 +160,17 @@ class Address
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/Address/Defs/Name.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/Address/Defs/Name.php
@@ -109,6 +109,17 @@ class Name
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/MyClass.php
@@ -180,6 +180,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/Address.php
@@ -154,6 +154,17 @@ class Address
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/Address/Defs/Name.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/Address/Defs/Name.php
@@ -103,6 +103,17 @@ class Name
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/MyClass.php
@@ -174,6 +174,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-5.6/Foo.php
@@ -174,6 +174,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-7.4/Foo.php
@@ -176,6 +176,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-8.4/Foo.php
@@ -152,6 +152,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-5.6/Bar.php
@@ -107,6 +107,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-5.6/Foo.php
@@ -107,6 +107,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Bar.php
@@ -109,6 +109,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Foo.php
@@ -109,6 +109,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Bar.php
@@ -103,6 +103,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Foo.php
@@ -103,6 +103,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-5.6/Foo.php
@@ -120,6 +120,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-7.4/Foo.php
@@ -122,6 +122,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-8.4/Foo.php
@@ -116,6 +116,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Bar.php
@@ -108,6 +108,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Foo.php
@@ -107,6 +107,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Bar.php
@@ -110,6 +110,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Foo.php
@@ -109,6 +109,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Bar.php
@@ -104,6 +104,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Foo.php
@@ -103,6 +103,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-5.6/Bar.php
@@ -107,6 +107,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-5.6/Foo.php
@@ -107,6 +107,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Bar.php
@@ -109,6 +109,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Foo.php
@@ -109,6 +109,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Bar.php
@@ -103,6 +103,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Foo.php
@@ -103,6 +103,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefsRefs/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-5.6/Bar.php
@@ -107,6 +107,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefsRefs/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-5.6/Foo.php
@@ -107,6 +107,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefsRefs/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-7.4/Bar.php
@@ -109,6 +109,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefsRefs/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-7.4/Foo.php
@@ -109,6 +109,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefsRefs/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-8.4/Bar.php
@@ -103,6 +103,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DefsRefs/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-8.4/Foo.php
@@ -103,6 +103,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Descriptions/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-5.6/Baz.php
@@ -116,6 +116,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Descriptions/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-5.6/MyClass.php
@@ -172,6 +172,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Descriptions/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-7.4/Baz.php
@@ -118,6 +118,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Descriptions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-7.4/MyClass.php
@@ -174,6 +174,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Descriptions/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-8.4/Baz.php
@@ -112,6 +112,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/Descriptions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-8.4/MyClass.php
@@ -168,6 +168,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-5.6/MyClass.php
@@ -146,6 +146,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-7.4/MyClass.php
@@ -148,6 +148,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-8.4/MyClass.php
@@ -142,6 +142,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-5.6/MyClass.php
@@ -156,6 +156,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-7.4/MyClass.php
@@ -158,6 +158,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-8.4/MyClass.php
@@ -152,6 +152,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-5.6/MyClass.php
@@ -175,6 +175,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-7.4/MyClass.php
@@ -177,6 +177,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-8.4/MyClass.php
@@ -171,6 +171,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-5.6/BarTest.php
@@ -107,6 +107,17 @@ class BarTest
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-5.6/Baz.php
@@ -204,6 +204,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-5.6/FooTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-5.6/FooTest.php
@@ -107,6 +107,17 @@ class FooTest
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-7.4/BarTest.php
@@ -109,6 +109,17 @@ class BarTest
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-7.4/Baz.php
@@ -206,6 +206,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-7.4/FooTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-7.4/FooTest.php
@@ -109,6 +109,17 @@ class FooTest
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-8.4/BarTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-8.4/BarTest.php
@@ -103,6 +103,17 @@ class BarTest
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-8.4/Baz.php
@@ -200,6 +200,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EncodedRef/Output-8.4/FooTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-8.4/FooTest.php
@@ -103,6 +103,17 @@ class FooTest
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EnumMixed/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/EnumMixed/Output-5.6/MyClass.php
@@ -361,6 +361,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EnumMixed/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/EnumMixed/Output-7.4/MyClass.php
@@ -363,6 +363,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EnumMixed/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/EnumMixed/Output-8.4/MyClass.php
@@ -348,6 +348,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
@@ -342,6 +342,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
@@ -344,6 +344,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
@@ -338,6 +338,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
@@ -136,6 +136,17 @@ class BarTest
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/FooTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/FooTest.php
@@ -107,6 +107,17 @@ class FooTest
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/FooTest_1.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/FooTest_1.php
@@ -107,6 +107,17 @@ class FooTest_1
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/MoiKlass.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/MoiKlass.php
@@ -107,6 +107,17 @@ class MoiKlass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -138,6 +138,17 @@ class BarTest
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest.php
@@ -109,6 +109,17 @@ class FooTest
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest_1.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest_1.php
@@ -109,6 +109,17 @@ class FooTest_1
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/MoiKlass.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/MoiKlass.php
@@ -109,6 +109,17 @@ class MoiKlass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
@@ -139,6 +139,17 @@ class BarTest
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest.php
@@ -103,6 +103,17 @@ class FooTest
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest_1.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest_1.php
@@ -103,6 +103,17 @@ class FooTest_1
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/MoiKlass.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/MoiKlass.php
@@ -103,6 +103,17 @@ class MoiKlass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -2063,6 +2063,18 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false)
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs1Alternative1.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs1Alternative1.php
@@ -140,6 +140,18 @@ class MyClassEnsureArgs1Alternative1
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false)
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs1Alternative2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs1Alternative2.php
@@ -177,6 +177,18 @@ class MyClassEnsureArgs1Alternative2
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false)
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs2.php
@@ -178,6 +178,18 @@ class MyClassEnsureArgs2
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false)
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs3Item.php
@@ -137,6 +137,18 @@ class MyClassEnsureArgs3Item
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false)
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassTestObj.php
@@ -107,6 +107,17 @@ class MyClassTestObj
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -2065,6 +2065,18 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs1Alternative1.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs1Alternative1.php
@@ -142,6 +142,18 @@ class MyClassEnsureArgs1Alternative1
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs1Alternative2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs1Alternative2.php
@@ -179,6 +179,18 @@ class MyClassEnsureArgs1Alternative2
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs2.php
@@ -180,6 +180,18 @@ class MyClassEnsureArgs2
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs3Item.php
@@ -139,6 +139,18 @@ class MyClassEnsureArgs3Item
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassTestObj.php
@@ -109,6 +109,17 @@ class MyClassTestObj
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
@@ -2064,6 +2064,18 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs1Alternative1.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs1Alternative1.php
@@ -127,6 +127,18 @@ class MyClassEnsureArgs1Alternative1
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs1Alternative2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs1Alternative2.php
@@ -173,6 +173,18 @@ class MyClassEnsureArgs1Alternative2
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs2.php
@@ -174,6 +174,18 @@ class MyClassEnsureArgs2
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs3Item.php
@@ -133,6 +133,18 @@ class MyClassEnsureArgs3Item
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassTestObj.php
@@ -103,6 +103,17 @@ class MyClassTestObj
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-5.6/MyClass.php
@@ -212,6 +212,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-7.4/MyClass.php
@@ -214,6 +214,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-8.4/MyClass.php
@@ -208,6 +208,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -1828,6 +1828,18 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false)
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClassTestObj.php
@@ -107,6 +107,17 @@ class MyClassTestObj
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -1830,6 +1830,18 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassTestObj.php
@@ -109,6 +109,17 @@ class MyClassTestObj
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
@@ -1824,6 +1824,18 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassTestObj.php
@@ -103,6 +103,17 @@ class MyClassTestObj
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/JsonFile/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/JsonFile/Output-5.6/MyClass.php
@@ -109,6 +109,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/JsonFile/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/JsonFile/Output-7.4/MyClass.php
@@ -111,6 +111,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/JsonFile/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/JsonFile/Output-8.4/MyClass.php
@@ -105,6 +105,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -231,6 +231,18 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassBar.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassBar.php
@@ -104,6 +104,17 @@ class MyClassBar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSetters/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-5.6/Baz.php
@@ -92,6 +92,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSetters/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-5.6/MyClass.php
@@ -201,6 +201,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSetters/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-7.4/Baz.php
@@ -94,6 +94,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
@@ -203,6 +203,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSetters/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-8.4/Baz.php
@@ -88,6 +88,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
@@ -197,6 +197,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/Baz.php
@@ -95,6 +95,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/MyClass.php
@@ -212,6 +212,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/Baz.php
@@ -97,6 +97,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
@@ -214,6 +214,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/Baz.php
@@ -91,6 +91,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
@@ -208,6 +208,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
@@ -169,6 +169,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClassFilesItem.php
@@ -162,6 +162,17 @@ class MyClassFilesItem
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/OptionsObject.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/OptionsObject.php
@@ -106,6 +106,17 @@ class OptionsObject
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
@@ -171,6 +171,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
@@ -164,6 +164,17 @@ class MyClassFilesItem
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/OptionsObject.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/OptionsObject.php
@@ -108,6 +108,17 @@ class OptionsObject
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
@@ -165,6 +165,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
@@ -158,6 +158,17 @@ class MyClassFilesItem
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/OptionsObject.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/OptionsObject.php
@@ -102,6 +102,17 @@ class OptionsObject
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Fio.php
@@ -124,6 +124,17 @@ class Fio
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Phone.php
@@ -107,6 +107,17 @@ class Phone
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Record.php
@@ -333,6 +333,17 @@ class Record
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Fio.php
@@ -126,6 +126,17 @@ class Fio
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Phone.php
@@ -109,6 +109,17 @@ class Phone
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Record.php
@@ -335,6 +335,17 @@ class Record
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Fio.php
@@ -120,6 +120,17 @@ class Fio
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Phone.php
@@ -103,6 +103,17 @@ class Phone
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Record.php
@@ -345,6 +345,17 @@ class Record
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoEnums/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NoEnums/Output-5.6/MyClass.php
@@ -108,6 +108,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoEnums/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoEnums/Output-7.4/MyClass.php
@@ -110,6 +110,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoEnums/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoEnums/Output-8.4/MyClass.php
@@ -104,6 +104,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoGetters/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NoGetters/Output-5.6/MyClass.php
@@ -96,6 +96,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoGetters/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoGetters/Output-7.4/MyClass.php
@@ -98,6 +98,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoGetters/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoGetters/Output-8.4/MyClass.php
@@ -92,6 +92,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoSchemaMetadata/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NoSchemaMetadata/Output-5.6/MyClass.php
@@ -167,6 +167,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoSchemaMetadata/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoSchemaMetadata/Output-7.4/MyClass.php
@@ -169,6 +169,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoSchemaMetadata/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoSchemaMetadata/Output-8.4/MyClass.php
@@ -163,6 +163,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoSetters/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NoSetters/Output-5.6/MyClass.php
@@ -104,6 +104,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoSetters/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoSetters/Output-7.4/MyClass.php
@@ -106,6 +106,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NoSetters/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoSetters/Output-8.4/MyClass.php
@@ -100,6 +100,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonAsciiProperty/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NonAsciiProperty/Output-5.6/MyClass.php
@@ -188,6 +188,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonAsciiProperty/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NonAsciiProperty/Output-7.4/MyClass.php
@@ -190,6 +190,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonAsciiProperty/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NonAsciiProperty/Output-8.4/MyClass.php
@@ -184,6 +184,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Bar.php
@@ -114,6 +114,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
@@ -136,6 +136,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Foo.php
@@ -112,6 +112,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -151,6 +151,17 @@ class Qux
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Bar.php
@@ -116,6 +116,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -138,6 +138,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Foo.php
@@ -114,6 +114,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -153,6 +153,17 @@ class Qux
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Bar.php
@@ -110,6 +110,17 @@ class Bar
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
@@ -137,6 +137,17 @@ class Baz
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Foo.php
@@ -108,6 +108,17 @@ class Foo
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
@@ -160,6 +160,17 @@ class Qux
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass.php
@@ -158,6 +158,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass_2.php
+++ b/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass_2.php
@@ -209,6 +209,17 @@ class MyClass_2
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-5.6/MyClass.php
@@ -156,6 +156,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-7.4/MyClass.php
@@ -158,6 +158,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
@@ -152,6 +152,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -152,6 +152,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -154,6 +154,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
@@ -154,6 +154,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClass.php
@@ -575,6 +575,18 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false)
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClassGrox.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClassGrox.php
@@ -168,6 +168,17 @@ class MyClassGrox
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
@@ -571,6 +571,18 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClassGrox.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClassGrox.php
@@ -164,6 +164,17 @@ class MyClassGrox
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-5.6/MyClass.php
@@ -692,6 +692,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-7.4/MyClass.php
@@ -694,6 +694,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-8.4/MyClass.php
@@ -688,6 +688,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyClass.php
@@ -129,6 +129,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumber.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumber.php
@@ -123,6 +123,17 @@ class MyGenericStringNumber
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumberField.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumberField.php
@@ -119,6 +119,17 @@ class MyGenericStringNumberField
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyClass.php
@@ -131,6 +131,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumber.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumber.php
@@ -125,6 +125,17 @@ class MyGenericStringNumber
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumberField.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumberField.php
@@ -121,6 +121,17 @@ class MyGenericStringNumberField
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyClass.php
@@ -125,6 +125,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumber.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumber.php
@@ -119,6 +119,17 @@ class MyGenericStringNumber
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumberField.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumberField.php
@@ -115,6 +115,17 @@ class MyGenericStringNumberField
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
@@ -163,6 +163,18 @@ class Cat
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
@@ -161,6 +161,18 @@ class GenericPet
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @param bool $includeDefaults Add defaults for missing properties
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(bool $includeDefaults = false): \stdClass
+    {
+        $array = $this->toArray($includeDefaults);
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Pets.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Pets.php
@@ -166,6 +166,17 @@ class Pets
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RefList/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-5.6/MyClass.php
@@ -115,6 +115,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RefList/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-7.4/MyClass.php
@@ -117,6 +117,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/RefList/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-8.4/MyClass.php
@@ -111,6 +111,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
@@ -131,6 +131,17 @@ class MyObject
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
@@ -133,6 +133,17 @@ class MyObject
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
@@ -126,6 +126,17 @@ class MyObject
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SingleElemTypeArray/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/SingleElemTypeArray/Output-8.4/MyClass.php
@@ -448,6 +448,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SingleElemTypeArray/Output-8.4/MyClassQuux.php
+++ b/tests/Generator/Fixtures/SingleElemTypeArray/Output-8.4/MyClassQuux.php
@@ -103,6 +103,17 @@ class MyClassQuux
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SingleLineSchema/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/SingleLineSchema/Output-5.6/MyClass.php
@@ -95,6 +95,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SingleLineSchema/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/SingleLineSchema/Output-7.4/MyClass.php
@@ -97,6 +97,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SingleLineSchema/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/SingleLineSchema/Output-8.4/MyClass.php
@@ -91,6 +91,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SuperglobalCollision/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/SuperglobalCollision/Output-5.6/MyClass.php
@@ -104,6 +104,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SuperglobalCollision/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/SuperglobalCollision/Output-7.4/MyClass.php
@@ -106,6 +106,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/SuperglobalCollision/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/SuperglobalCollision/Output-8.4/MyClass.php
@@ -100,6 +100,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
@@ -103,6 +103,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
@@ -105,6 +105,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
@@ -104,6 +104,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-5.6/MyClass.php
@@ -177,6 +177,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-7.4/MyClass.php
@@ -179,6 +179,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
@@ -173,6 +173,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-5.6/MyClass.php
@@ -114,6 +114,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-5.6/MyClassFooAlternative2.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-5.6/MyClassFooAlternative2.php
@@ -105,6 +105,17 @@ class MyClassFooAlternative2
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-7.4/MyClass.php
@@ -116,6 +116,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-7.4/MyClassFooAlternative2.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-7.4/MyClassFooAlternative2.php
@@ -107,6 +107,17 @@ class MyClassFooAlternative2
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-8.4/MyClass.php
@@ -109,6 +109,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/TypeArrayUnion/Output-8.4/MyClassFooAlternative2.php
+++ b/tests/Generator/Fixtures/TypeArrayUnion/Output-8.4/MyClassFooAlternative2.php
@@ -101,6 +101,17 @@ class MyClassFooAlternative2
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
@@ -106,6 +106,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -108,6 +108,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -105,6 +105,17 @@ class MyClass
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -167,6 +167,17 @@ class Cat
     }
 
     /**
+     * Converts this object back to an stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $array = $this->toArray();
+        return json_decode(json_encode($array));
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data


### PR DESCRIPTION
## Summary
- generate `toStdClass` method alongside `toArray`
- call the new generator method and reserve its name
- document the new method in README
- mention the new method in changelog
- update test fixtures

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687d5d7e610c832d862470edb4916974