### PR TITLE
Add PHPCompatibility checks for fixture outputs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,9 @@
         "phpstan/phpstan": "^2.1.2",
         "phpspec/prophecy": "^1.17",
         "phpspec/prophecy-phpunit": "^2.0",
-        "cweagans/composer-patches": "^1.7"
+        "cweagans/composer-patches": "^1.7",
+        "squizlabs/php_codesniffer": "^3.7",
+        "phpcompatibility/php-compatibility": "^9.3"
     },
 	"extra": {
 		"patches": {

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -45,6 +45,23 @@ class SchemaToClassTest extends TestCase
         @rmdir($dir);
     }
 
+    private function checkCompatibility(string $dir, string $version): void
+    {
+        $phpcs = dirname(__DIR__, 2) . '/vendor/bin/phpcs';
+        $cmd = escapeshellcmd($phpcs)
+            . ' --standard=PHPCompatibility'
+            . ' --runtime-set testVersion ' . escapeshellarg($version)
+            . ' --extensions=php '
+            . escapeshellarg($dir);
+
+        exec($cmd, $output, $exitCode);
+        $this->assertSame(
+            0,
+            $exitCode,
+            "PHPCompatibility check failed for PHP {$version} in {$dir}:\n" . implode(PHP_EOL, $output),
+        );
+    }
+
     protected function setUp(): void
     {
     }
@@ -300,6 +317,9 @@ class SchemaToClassTest extends TestCase
 
         $writtenFiles = $writer->getWrittenFiles();
 
+        $dirName  = 'Output-' . $version;
+        $outputDir = join(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', $fixture, $dirName]);
+
         if (getenv('UPDATE_SNAPSHOTS') !== '1') {
             $this->assertCount(
                 expectedCount: count($expectedOutput),
@@ -317,8 +337,6 @@ class SchemaToClassTest extends TestCase
                 assertThat($actualContent, equalTo($content));
             }
         } else {
-            $dirName = 'Output-' . $version;
-            $outputDir = join(DIRECTORY_SEPARATOR, [__DIR__, 'Fixtures', $fixture, $dirName]);
             if (is_dir($outputDir)) {
                 $iterator = new \RecursiveIteratorIterator(
                     new \RecursiveDirectoryIterator($outputDir, \FilesystemIterator::SKIP_DOTS),
@@ -346,6 +364,8 @@ class SchemaToClassTest extends TestCase
 
             $this->addToAssertionCount(1);
         }
+
+        $this->checkCompatibility($outputDir, $version);
 
         if (getenv('SKIP_EVAL') !== '1') {
             // load classes in memory by evaluating the generated code


### PR DESCRIPTION
## Summary
- check generated fixture code against the declared PHP version
- add PHP_CodeSniffer + PHPCompatibility for dev

## Testing
- `composer update squizlabs/php_codesniffer phpcompatibility/php-compatibility --no-interaction`
- `vendor/bin/phpunit` *(fails: PHPCompatibility check failed for multiple fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_687e14dad0b4832d9f64cf08af18483a