### PR TITLE
Consolidate duplicate class generator tests

### DIFF
--- a/tests/Generator/Class/ClassGeneratorTest.php
+++ b/tests/Generator/Class/ClassGeneratorTest.php
@@ -14,160 +14,6 @@ use Symfony\Component\Yaml\Yaml;
 
 class ClassGeneratorTest extends TestCase
 {
-    // SET 1
-    
-    public function testDefaultsAndProvidedOptionalsProperties(): void
-    {
-        $schema = [
-            'properties' => [
-                'foo' => ['type' => 'string', 'default' => 'x'],
-                'bar' => ['type' => ['null', 'string']],
-            ],
-        ];
-
-        $req = new GeneratorRequest(
-            $schema,
-            new ValidatedSpecificationFilesItem('Ns', 'MyClass', ''),
-            (new SpecificationOptions())->withTargetPHPVersion(GeneratorRequest::DEFAULT_PHP8_VERSION),
-        );
-        $writer = new DebugWriter(new NullOutput());
-
-        $generator = new ClassGenerator($req, $schema, $writer, new NullOutput());
-        $generator->generateClass();
-
-        $files = $writer->getWrittenFiles();
-        $code  = reset($files);
-
-        $this->assertStringContainsString('private static array $_defaults', $code);
-        $this->assertStringContainsString('private array $_providedOptionals', $code);
-    }
-
-    public function testMethodNamesAreUnique(): void
-    {
-        $schema = [
-            'properties' => [
-                'foo_bar' => ['type' => 'string'],
-                'foo-bar' => ['type' => 'string'],
-            ],
-        ];
-
-        $req = new GeneratorRequest(
-            $schema,
-            new ValidatedSpecificationFilesItem('Ns', 'MyClass', ''),
-            (new SpecificationOptions())->withTargetPHPVersion(GeneratorRequest::DEFAULT_PHP8_VERSION),
-        );
-        $writer = new DebugWriter(new NullOutput());
-
-        $generator = new ClassGenerator($req, $schema, $writer, new NullOutput());
-        $generator->generateClass();
-
-        $files = $writer->getWrittenFiles();
-        $code  = reset($files);
-
-        $this->assertStringContainsString('function getFooBar():', $code);
-        $this->assertStringContainsString('function getFooBar1():', $code);
-        $this->assertStringContainsString('function withFooBar1(', $code);
-        $this->assertStringContainsString('function withoutFooBar1(', $code);
-    }
-
-    public function testGeneratedMethodsMatchSnapshot(): void
-    {
-        $schema = Yaml::parseFile(__DIR__ . '/../Fixtures/Basic/schema.yaml');
-
-        $req = new GeneratorRequest(
-            $schema,
-            new ValidatedSpecificationFilesItem('Ns\\Basic_8_4', 'MyClass', ''),
-            (new SpecificationOptions())->withTargetPHPVersion(GeneratorRequest::DEFAULT_PHP8_VERSION),
-        );
-        $writer = new DebugWriter(new NullOutput());
-
-        $generator = new ClassGenerator($req, $schema, $writer, new NullOutput());
-        $generator->generateClass();
-
-        $files = $writer->getWrittenFiles();
-        $generated = trim(reset($files));
-        $expected = trim(file_get_contents(__DIR__ . '/../Fixtures/Basic/Output-8.4/MyClass.php'));
-
-        $this->assertSame($expected, $generated);
-    }
-
-    // SET 2
-
-     public function testDefaultsAndProvidedOptionalsPropertiesGenerated(): void
-    {
-        $schema = [
-            'properties' => [
-                'a' => ['type' => 'string', 'default' => 'x'],
-                'b' => ['type' => ['string', 'null']],
-            ],
-            'required' => ['a'],
-        ];
-
-        $req = new GeneratorRequest(
-            $schema,
-            new ValidatedSpecificationFilesItem('Ns', 'MyClass', sys_get_temp_dir()),
-            (new SpecificationOptions())->withTargetPHPVersion(GeneratorRequest::DEFAULT_PHP8_VERSION),
-        );
-
-        $writer = new DebugWriter(new NullOutput());
-        $generator = new ClassGenerator($req, $schema, $writer, new NullOutput());
-        $generator->generateClass();
-
-        $file = $writer->getWrittenFiles()[sys_get_temp_dir() . '/MyClass.php'];
-
-        $this->assertStringContainsString('private static array $_defaults', $file);
-        $this->assertStringContainsString('private array $_providedOptionals', $file);
-    }
-
-    public function testUniqueGetterAndSetterNames(): void
-    {
-        $schema = [
-            'required' => ['fooBar'],
-            'properties' => [
-                'fooBar' => ['type' => 'string'],
-                'foo-bar' => ['type' => 'string'],
-            ],
-        ];
-
-        $req = new GeneratorRequest(
-            $schema,
-            new ValidatedSpecificationFilesItem('Ns', 'MyClass', sys_get_temp_dir()),
-            (new SpecificationOptions())->withTargetPHPVersion(GeneratorRequest::DEFAULT_PHP8_VERSION),
-        );
-
-        $writer = new DebugWriter(new NullOutput());
-        $generator = new ClassGenerator($req, $schema, $writer, new NullOutput());
-        $generator->generateClass();
-
-        $file = $writer->getWrittenFiles()[sys_get_temp_dir() . '/MyClass.php'];
-
-        $this->assertMatchesRegularExpression('/function getFooBar\(/', $file);
-        $this->assertMatchesRegularExpression('/function getFooBar1\(/', $file);
-        $this->assertMatchesRegularExpression('/function withFooBar1\(/', $file);
-        $this->assertMatchesRegularExpression('/function withoutFooBar1\(/', $file);
-    }
-
-    public function testOutputMatchesFixture(): void
-    {
-        $schema = Yaml::parseFile(__DIR__ . '/../Fixtures/Basic/schema.yaml');
-
-        $req = new GeneratorRequest(
-            $schema,
-            new ValidatedSpecificationFilesItem('Ns\\Basic_8_4', 'MyClass', sys_get_temp_dir()),
-            (new SpecificationOptions())->withTargetPHPVersion(GeneratorRequest::DEFAULT_PHP8_VERSION),
-        );
-
-        $writer = new DebugWriter(new NullOutput());
-        $generator = new ClassGenerator($req, $schema, $writer, new NullOutput());
-        $generator->generateClass();
-
-        $file = $writer->getWrittenFiles()[sys_get_temp_dir() . '/MyClass.php'];
-        $expected = trim(file_get_contents(__DIR__ . '/../Fixtures/Basic/Output-8.4/MyClass.php'));
-        $this->assertSame($expected, trim($file));
-    }
-
-    // SET 3
-
     public function testIncludesDefaultsAndProvidedOptionalsProperties(): void
     {
         $schema = [
@@ -179,26 +25,26 @@ class ClassGeneratorTest extends TestCase
 
         $req = new GeneratorRequest(
             $schema,
-            new ValidatedSpecificationFilesItem('Ns', 'MyClass', sys_get_temp_dir()),
+            new ValidatedSpecificationFilesItem('Ns', 'MyClass', ''),
             (new SpecificationOptions())->withTargetPHPVersion(GeneratorRequest::DEFAULT_PHP8_VERSION),
         );
-
         $writer = new DebugWriter(new NullOutput());
-        $gen = new ClassGenerator($req, $schema, $writer, new NullOutput());
-        $gen->generateClass();
+
+        $generator = new ClassGenerator($req, $schema, $writer, new NullOutput());
+        $generator->generateClass();
 
         $files = $writer->getWrittenFiles();
-        $this->assertCount(1, $files);
-        $code = current($files);
+        $code  = reset($files);
         $this->assertStringContainsString('private static array $_defaults', $code);
         $this->assertStringContainsString('private array $_providedOptionals', $code);
     }
 
-    public function testGetterSetterNamesAreUniqueForConflictingProperties(): void
+    public function testConflictingGetterSetterNamesAreUnique(): void
     {
         $schema = [
-            'required' => ['foo-bar', 'foo bar'],
+            'required' => ['foo_bar', 'foo-bar', 'foo bar'],
             'properties' => [
+                'foo_bar' => ['type' => 'string'],
                 'foo-bar' => ['type' => 'string'],
                 'foo bar' => ['type' => 'string'],
             ],
@@ -206,19 +52,22 @@ class ClassGeneratorTest extends TestCase
 
         $req = new GeneratorRequest(
             $schema,
-            new ValidatedSpecificationFilesItem('Ns', 'MyClass', sys_get_temp_dir()),
+            new ValidatedSpecificationFilesItem('Ns', 'MyClass', ''),
             (new SpecificationOptions())->withTargetPHPVersion(GeneratorRequest::DEFAULT_PHP8_VERSION),
         );
-
         $writer = new DebugWriter(new NullOutput());
-        $gen = new ClassGenerator($req, $schema, $writer, new NullOutput());
-        $gen->generateClass();
 
-        $code = current($writer->getWrittenFiles());
+        $generator = new ClassGenerator($req, $schema, $writer, new NullOutput());
+        $generator->generateClass();
+
+        $files = $writer->getWrittenFiles();
+        $code  = reset($files);
         $this->assertStringContainsString('function getFooBar()', $code);
         $this->assertStringContainsString('function getFooBar1()', $code);
+        $this->assertStringContainsString('function getFooBar2()', $code);
         $this->assertStringContainsString('function withFooBar(', $code);
         $this->assertStringContainsString('function withFooBar1(', $code);
+        $this->assertStringContainsString('function withFooBar2(', $code);
     }
 
     public function testGeneratedCodeMatchesFixture(): void
@@ -232,10 +81,10 @@ class ClassGeneratorTest extends TestCase
             new ValidatedSpecificationFilesItem('Ns\\Basic_8_4', 'MyClass', __DIR__),
             (new SpecificationOptions())->withTargetPHPVersion(GeneratorRequest::DEFAULT_PHP8_VERSION),
         );
-
         $writer = new DebugWriter(new NullOutput());
-        $gen = new ClassGenerator($req, $schema, $writer, new NullOutput());
-        $gen->generateClass();
+
+        $generator = new ClassGenerator($req, $schema, $writer, new NullOutput());
+        $generator->generateClass();
 
         $files = $writer->getWrittenFiles();
         $this->assertCount(1, $files);


### PR DESCRIPTION
## Summary
- simplify ClassGeneratorTest by merging repeated test sets

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --no-progress --memory-limit=512M`

------
https://chatgpt.com/codex/tasks/task_e_688a7746be4c832db2ec733ed6b07157