### PR TITLE
Improve error context during generation

### DIFF
--- a/src/Generator/Class/ClassGenerator.php
+++ b/src/Generator/Class/ClassGenerator.php
@@ -14,7 +14,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Helmich\Schema2Class\Generator\Class\PropertyCollector;
 use Helmich\Schema2Class\Generator\Class\MethodFactory;
 use Helmich\Schema2Class\Generator\Class\ClassFileWriter;
+use Helmich\Schema2Class\Generator\GeneratorException;
 use Helmich\Schema2Class\Generator\GeneratorRequest;
+use Throwable;
 
 /**
  * Generates the `Laminas\Code` representation of a PHP class for a single schema.
@@ -207,41 +209,47 @@ class ClassGenerator
             : PropertyGenerator::FLAG_PRIVATE;
 
         foreach ($properties as $property) {
-            $schema     = $property->schema();
-            $isOptional = false;
-            $prop       = new PropertyGenerator(
-                $property->name(),
-                $property->formatValue(null),
-                $visibility
-            );
+            try {
+                $schema     = $property->schema();
+                $isOptional = false;
+                $prop       = new PropertyGenerator(
+                    $property->name(),
+                    $property->formatValue(null),
+                    $visibility
+                );
 
-            if ($property instanceof OptionalPropertyDecorator) {
-                $isOptional = true;
+                if ($property instanceof OptionalPropertyDecorator) {
+                    $isOptional = true;
+                }
+
+                $tags = [new GenericTag("var", trim($property->typeAnnotation()))];
+                if (PropertyQuery::isDeprecated($property)) {
+                    $tags[] = new GenericTag("deprecated");
+                }
+
+                $docBlock = new DocBlockGenerator(
+                    $schema["description"] ?? null,
+                    null,
+                    $tags
+                );
+                $docBlock->setWordWrap(false);
+
+                $prop->setDocBlock($docBlock);
+
+                $typeHint = $property->typeHint($this->generatorRequest->getTargetPHPVersion());
+                if ($this->generatorRequest->isAtLeastPHP("7.4") && $typeHint !== null) {
+                    $prop->setTypeHint($typeHint);
+                }
+
+                // omit default `null` for every required field, unsless default is specified in the schema
+                $prop->omitDefaultValue(!$isOptional);
+
+                $propertyGenerators[] = $prop;
+            } catch (Throwable $e) {
+                $cls = $this->generatorRequest->getTargetClass() ?? '<anonymous>';
+                $msg = "error generating property '{$property->name()}' in class '{$cls}': " . $e->getMessage();
+                throw new GeneratorException($msg, 0, $e);
             }
-
-            $tags = [new GenericTag("var", trim($property->typeAnnotation()))];
-            if (PropertyQuery::isDeprecated($property)) {
-                $tags[] = new GenericTag("deprecated");
-            }
-
-            $docBlock = new DocBlockGenerator(
-                $schema["description"] ?? null,
-                null,
-                $tags
-            );
-            $docBlock->setWordWrap(false);
-
-            $prop->setDocBlock($docBlock);
-
-            $typeHint = $property->typeHint($this->generatorRequest->getTargetPHPVersion());
-            if ($this->generatorRequest->isAtLeastPHP("7.4") && $typeHint !== null) {
-                $prop->setTypeHint($typeHint);
-            }
-
-            // omit default `null` for every required field, unsless default is specified in the schema
-            $prop->omitDefaultValue(!$isOptional);
-
-            $propertyGenerators[] = $prop;
         }
 
         return $propertyGenerators;

--- a/src/Generator/Definition/DefinitionsGenerator.php
+++ b/src/Generator/Definition/DefinitionsGenerator.php
@@ -3,8 +3,10 @@ declare(strict_types=1);
 
 namespace Helmich\Schema2Class\Generator\Definition;
 
+use Helmich\Schema2Class\Generator\GeneratorException;
 use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\SchemaToClass;
+use Throwable;
 
 /**
  * Generates PHP classes for each {@see Definition} produced by a {@see DefinitionsCollector}.
@@ -92,7 +94,12 @@ class DefinitionsGenerator
                 ->withGeneratedClassNames($generatedClasses)
                 ->withRootDefinitions($trimmedDefs);
 
-            $this->schemaToClass->schemaToClass($newRequest);
+            try {
+                $this->schemaToClass->schemaToClass($newRequest);
+            } catch (Throwable $e) {
+                $msg = "error generating definition '{$definition->classFQN}': " . $e->getMessage();
+                throw new GeneratorException($msg, 0, $e);
+            }
         }
     }
 }

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -13,6 +13,8 @@ use Helmich\Schema2Class\Generator\Property\Type\NestedObjectProperty;
 use Helmich\Schema2Class\Generator\ReferenceLookup\DefinitionsReferenceLookup;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Helmich\Schema2Class\Generator\GeneratorException;
+use Throwable;
 
 /**
  * Low-level generator that converts a prepared GeneratorRequest into PHP classes.
@@ -60,7 +62,13 @@ class SchemaToClass
         }
 
         $classGenerator = new ClassGenerator($req, $schema, $this->writer, $this->output);
-        $classGenerator->generateClass();
+        try {
+            $classGenerator->generateClass();
+        } catch (Throwable $e) {
+            $cls = $req->getTargetClass() ?? '<anonymous>';
+            $msg = "error generating class '{$cls}': " . $e->getMessage();
+            throw new GeneratorException($msg, 0, $e);
+        }
     }
 
     private function decodeReferences(array &$node): void


### PR DESCRIPTION
## Summary
- rethrow generator errors with context about class/definition/property
- catch errors when generating classes and nested definitions

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_688a77a6d4dc832d8c466b12b471e489