### PR TITLE
Fix optional nullable enum generation

### DIFF
--- a/src/Generator/Property/Decorator/OptionalPropertyDecorator.php
+++ b/src/Generator/Property/Decorator/OptionalPropertyDecorator.php
@@ -56,12 +56,19 @@ class OptionalPropertyDecorator extends NullablePropertyDecorator implements Ren
             ? "\${$inputVarName}->{{$keyStr}}"
             : "\${$inputVarName}[{$keyStr}]";
 
-        // Single mapping expression (with null-guard if the property is nullable)
-        $mapped   = $this->generateInputMappingExpr($accessor, true);
+        // Build mapping expression. Nullable optionals must keep null values
+        // intact; if the wrapped property already allows null it will handle the
+        // guard itself.
+        if ($this->optionalNullable) {
+            $innerMap = $this->inner->generateInputMappingExpr($accessor, true);
+            $mapped   = "({$accessor} !== null) ? ({$innerMap}) : null";
+        } else {
+            $mapped = $this->generateInputMappingExpr($accessor, true);
+        }
 
         $existsCheck = $this->generateIssetCheckExpr($inputVarName, $object);
 
-        $code = "\${$name} = {$existsCheck} ? {$mapped} : null;";
+        $code = "\${$name} = {$existsCheck} ? ({$mapped}) : null;";
 
         if ($this->optionalNullable) {
             $code .= "\nif ({$existsCheck}) {\n    \$__providedOptionals['{$this->key}'] = true;\n}";
@@ -77,12 +84,16 @@ class OptionalPropertyDecorator extends NullablePropertyDecorator implements Ren
     public function convertTypeToArray(string $outputVarName = 'output'): string
     {
         $name  = $this->inner->name();
-        $inner = $this->inner->convertTypeToArray($outputVarName);
 
         if ($this->optionalNullable) {
             $check = "isset(\$this->{$name}) || array_key_exists('{$this->key}', \$this->_providedOptionals)";
+            $keyStr = var_export($this->key, true);
+            $map = $this->generateOutputMappingExpr("\$this->{$name}");
+            $inner = "\${$outputVarName}[{$keyStr}] = {$map};";
             return "if ({$check}) {\n" . StringUtils::indentCode($inner, 1) . "\n}";
         }
+
+        $inner = $this->inner->convertTypeToArray($outputVarName);
 
         if ($this->inner->allowsNull()) {
             return $inner;
@@ -94,12 +105,16 @@ class OptionalPropertyDecorator extends NullablePropertyDecorator implements Ren
     public function convertTypeToStdClass(string $outputVarName = 'output'): string
     {
         $name  = $this->inner->name();
-        $inner = $this->inner->convertTypeToStdClass($outputVarName);
 
         if ($this->optionalNullable) {
             $check = "isset(\$this->{$name}) || array_key_exists('{$this->key}', \$this->_providedOptionals)";
+            $keyStr = var_export($this->key, true);
+            $map = $this->generateOutputMappingExprStdClass("\$this->{$name}");
+            $inner = "\${$outputVarName}->{{$keyStr}} = {$map};";
             return "if ({$check}) {\n" . StringUtils::indentCode($inner, 1) . "\n}";
         }
+
+        $inner = $this->inner->convertTypeToStdClass($outputVarName);
 
         if ($this->inner->allowsNull()) {
             return $inner;

--- a/tests/Generator/Fixtures/AdditionalProps/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output-5.6/MyClass.php
@@ -135,8 +135,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
-        $params = isset($input->{'params'}) ? (array)$input->{'params'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
+        $params = isset($input->{'params'}) ? ((array)$input->{'params'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/AdditionalProps/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output-7.4/MyClass.php
@@ -137,8 +137,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
-        $params = isset($input->{'params'}) ? (array)$input->{'params'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
+        $params = isset($input->{'params'}) ? ((array)$input->{'params'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/AdditionalProps/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output-8.4/MyClass.php
@@ -131,8 +131,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
-        $params = isset($input->{'params'}) ? (array)$input->{'params'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
+        $params = isset($input->{'params'}) ? ((array)$input->{'params'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/AdditionalPropsRoot/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropsRoot/Output-5.6/MyClass.php
@@ -135,8 +135,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
-        $params = isset($input->{'params'}) ? $input->{'params'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
+        $params = isset($input->{'params'}) ? ($input->{'params'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/AdditionalPropsRoot/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropsRoot/Output-7.4/MyClass.php
@@ -137,8 +137,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
-        $params = isset($input->{'params'}) ? $input->{'params'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
+        $params = isset($input->{'params'}) ? ($input->{'params'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/AdditionalPropsRoot/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropsRoot/Output-8.4/MyClass.php
@@ -131,8 +131,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
-        $params = isset($input->{'params'}) ? $input->{'params'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
+        $params = isset($input->{'params'}) ? ($input->{'params'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
@@ -109,7 +109,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? (is_int($input->{'foo'})) ? ((int)($input->{'foo'})) : ((is_string($input->{'foo'})) ? ($input->{'foo'}) : (null)) : null;
+        $foo = isset($input->{'foo'}) ? ((is_int($input->{'foo'})) ? ((int)($input->{'foo'})) : ((is_string($input->{'foo'})) ? ($input->{'foo'}) : (null))) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
@@ -105,11 +105,11 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? match (true) {
+        $foo = isset($input->{'foo'}) ? (match (true) {
             is_string($input->{'foo'}) => $input->{'foo'},
             is_int($input->{'foo'}) => (int)($input->{'foo'}),
             default => null,
-        } : null;
+        }) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Phone.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Phone.php
@@ -80,7 +80,7 @@ class Phone
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Record.php
@@ -95,10 +95,10 @@ class Record
             static::validateInput($input);
         }
 
-        $dataArray = isset($input->{'dataArray'}) ? array_map(
+        $dataArray = isset($input->{'dataArray'}) ? (array_map(
             fn(array|object $i): Phone => Phone::buildFromInput($i, $validate),
             $input->{'dataArray'}
-        ) : null;
+        )) : null;
 
         $obj = new self();
         $obj->dataArray = $dataArray;

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -454,30 +454,30 @@ class MyClass
             is_string($input->{'d'}) => $input->{'d'},
             default => null,
         }) : null;
-        $e = isset($input->{'e'}) ? $input->{'e'} : null;
-        $f = isset($input->{'f'}) ? match (true) {
+        $e = isset($input->{'e'}) ? ($input->{'e'}) : null;
+        $f = isset($input->{'f'}) ? (match (true) {
             is_array($input->{'f'}),
             is_string($input->{'f'}) => $input->{'f'},
             default => null,
-        } : null;
-        $g = property_exists($input, 'g') ? $input->{'g'} : null;
+        }) : null;
+        $g = property_exists($input, 'g') ? (($input->{'g'} !== null) ? ($input->{'g'}) : null) : null;
         if (property_exists($input, 'g')) {
             $__providedOptionals['g'] = true;
         }
-        $h = property_exists($input, 'h') ? match (true) {
+        $h = property_exists($input, 'h') ? (($input->{'h'} !== null) ? (match (true) {
             is_array($input->{'h'}),
             is_string($input->{'h'}) => $input->{'h'},
             default => null,
-        } : null;
+        }) : null) : null;
         if (property_exists($input, 'h')) {
             $__providedOptionals['h'] = true;
         }
-        $i = property_exists($input, 'i') ? match (true) {
+        $i = property_exists($input, 'i') ? (($input->{'i'} !== null) ? (match (true) {
             is_array($input->{'i'}),
             is_string($input->{'i'}),
             is_array($input->{'i'}) || is_object($input->{'i'}) => $input->{'i'},
             default => null,
-        } : null;
+        }) : null) : null;
         if (property_exists($input, 'i')) {
             $__providedOptionals['i'] = true;
         }
@@ -520,22 +520,22 @@ class MyClass
             };
         }
         if (isset($this->g) || array_key_exists('g', $this->_providedOptionals)) {
-            if (isset($this->g)) {
-                $output['g'] = $this->g;
-            }
+            $output['g'] = ($this->g !== null) ? (($this->g !== null) ? ($this->g) : null) : null;
         }
         if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
-            $output['h'] = match (true) {
+            $output['h'] = ($this->h !== null) ? (match (true) {
+                default => null,
                 is_array($this->h),
                 is_string($this->h) => $this->h,
-            };
+            }) : null;
         }
         if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
-            $output['i'] = match (true) {
+            $output['i'] = ($this->i !== null) ? (match (true) {
+                default => null,
                 is_array($this->i),
                 is_string($this->i) => $this->i,
                 is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), true),
-            };
+            }) : null;
         }
 
         return $output;
@@ -569,22 +569,22 @@ class MyClass
             };
         }
         if (isset($this->g) || array_key_exists('g', $this->_providedOptionals)) {
-            if (isset($this->g)) {
-                $output->{'g'} = $this->g;
-            }
+            $output->{'g'} = ($this->g !== null) ? (($this->g !== null) ? ($this->g) : null) : null;
         }
         if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
-            $output->{'h'} = match (true) {
+            $output->{'h'} = ($this->h !== null) ? (match (true) {
+                default => null,
                 is_array($this->h),
                 is_string($this->h) => $this->h,
-            };
+            }) : null;
         }
         if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
-            $output->{'i'} = match (true) {
+            $output->{'i'} = ($this->i !== null) ? (match (true) {
+                default => null,
                 is_array($this->i),
                 is_string($this->i) => $this->i,
                 is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i)),
-            };
+            }) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/Basic/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/Basic/Output-5.6/MyClass.php
@@ -131,7 +131,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
         $fooBar = $input->{'foo_bar'};
 
         $obj = new self($fooBar);

--- a/tests/Generator/Fixtures/Basic/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Basic/Output-7.4/MyClass.php
@@ -133,7 +133,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
         $fooBar = $input->{'foo_bar'};
 
         $obj = new self($fooBar);

--- a/tests/Generator/Fixtures/Basic/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Basic/Output-8.4/MyClass.php
@@ -127,7 +127,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
         $fooBar = $input->{'foo_bar'};
 
         $obj = new self($fooBar);

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -509,21 +509,21 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
-        $baz = property_exists($input, 'baz') ? $input->{'baz'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
+        $baz = property_exists($input, 'baz') ? (($input->{'baz'} !== null) ? ($input->{'baz'}) : null) : null;
         if (property_exists($input, 'baz')) {
             $__providedOptionals['baz'] = true;
         }
-        $qux = isset($input->{'qux'}) ? $input->{'qux'} : null;
-        $thud = isset($input->{'thud'}) ? $input->{'thud'} : null;
-        $grox = isset($input->{'grox'}) ? $input->{'grox'} : null;
-        $qwert = isset($input->{'qwert'}) ? match (true) {
+        $qux = isset($input->{'qux'}) ? ($input->{'qux'}) : null;
+        $thud = isset($input->{'thud'}) ? ($input->{'thud'}) : null;
+        $grox = isset($input->{'grox'}) ? ($input->{'grox'}) : null;
+        $qwert = isset($input->{'qwert'}) ? (match (true) {
             is_string($input->{'qwert'}) => $input->{'qwert'},
             is_int($input->{'qwert'}) || is_float($input->{'qwert'}) => str_contains((string)($input->{'qwert'}), '.') ? (float)($input->{'qwert'}) : (int)($input->{'qwert'}),
             default => null,
-        } : null;
-        $zyx = isset($input->{'zyx'}) ? $input->{'zyx'} : null;
+        }) : null;
+        $zyx = isset($input->{'zyx'}) ? ($input->{'zyx'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;
@@ -554,7 +554,7 @@ class MyClass
             $output['bar'] = $this->bar;
         }
         if (isset($this->baz) || array_key_exists('baz', $this->_providedOptionals)) {
-            $output['baz'] = $this->baz;
+            $output['baz'] = ($this->baz !== null) ? ($this->baz) : null;
         }
         if (isset($this->qux)) {
             $output['qux'] = $this->qux;
@@ -602,7 +602,7 @@ class MyClass
             $output->{'bar'} = $this->bar;
         }
         if (isset($this->baz) || array_key_exists('baz', $this->_providedOptionals)) {
-            $output->{'baz'} = $this->baz;
+            $output->{'baz'} = ($this->baz !== null) ? ($this->baz) : null;
         }
         if (isset($this->qux)) {
             $output->{'qux'} = $this->qux;

--- a/tests/Generator/Fixtures/Definitions/Output-5.6/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-5.6/Address.php
@@ -133,7 +133,7 @@ class Address
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? Address\Defs\Name::buildFromInput($input->{'name'}, $validate) : null;
+        $name = isset($input->{'name'}) ? (Address\Defs\Name::buildFromInput($input->{'name'}, $validate)) : null;
         $city = $input->{'city'};
 
         $obj = new self($city);

--- a/tests/Generator/Fixtures/Definitions/Output-5.6/Address/Defs/Name.php
+++ b/tests/Generator/Fixtures/Definitions/Output-5.6/Address/Defs/Name.php
@@ -84,7 +84,7 @@ class Name
             static::validateInput($input);
         }
 
-        $first = isset($input->{'first'}) ? $input->{'first'} : null;
+        $first = isset($input->{'first'}) ? ($input->{'first'}) : null;
 
         $obj = new self();
         $obj->first = $first;

--- a/tests/Generator/Fixtures/Definitions/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-5.6/MyClass.php
@@ -154,7 +154,7 @@ class MyClass
         }
 
         $id = (int)($input->{'id'});
-        $address = isset($input->{'address'}) ? Address::buildFromInput($input->{'address'}, $validate) : null;
+        $address = isset($input->{'address'}) ? (Address::buildFromInput($input->{'address'}, $validate)) : null;
 
         $obj = new self($id);
         $obj->address = $address;

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/Address.php
@@ -135,7 +135,7 @@ class Address
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? Address\Defs\Name::buildFromInput($input->{'name'}, $validate) : null;
+        $name = isset($input->{'name'}) ? (Address\Defs\Name::buildFromInput($input->{'name'}, $validate)) : null;
         $city = $input->{'city'};
 
         $obj = new self($city);

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/Address/Defs/Name.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/Address/Defs/Name.php
@@ -86,7 +86,7 @@ class Name
             static::validateInput($input);
         }
 
-        $first = isset($input->{'first'}) ? $input->{'first'} : null;
+        $first = isset($input->{'first'}) ? ($input->{'first'}) : null;
 
         $obj = new self();
         $obj->first = $first;

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/MyClass.php
@@ -156,7 +156,7 @@ class MyClass
         }
 
         $id = (int)($input->{'id'});
-        $address = isset($input->{'address'}) ? Address::buildFromInput($input->{'address'}, $validate) : null;
+        $address = isset($input->{'address'}) ? (Address::buildFromInput($input->{'address'}, $validate)) : null;
 
         $obj = new self($id);
         $obj->address = $address;

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/Address.php
@@ -129,7 +129,7 @@ class Address
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? Address\Defs\Name::buildFromInput($input->{'name'}, $validate) : null;
+        $name = isset($input->{'name'}) ? (Address\Defs\Name::buildFromInput($input->{'name'}, $validate)) : null;
         $city = $input->{'city'};
 
         $obj = new self($city);

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/Address/Defs/Name.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/Address/Defs/Name.php
@@ -80,7 +80,7 @@ class Name
             static::validateInput($input);
         }
 
-        $first = isset($input->{'first'}) ? $input->{'first'} : null;
+        $first = isset($input->{'first'}) ? ($input->{'first'}) : null;
 
         $obj = new self();
         $obj->first = $first;

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/MyClass.php
@@ -150,7 +150,7 @@ class MyClass
         }
 
         $id = (int)($input->{'id'});
-        $address = isset($input->{'address'}) ? Address::buildFromInput($input->{'address'}, $validate) : null;
+        $address = isset($input->{'address'}) ? (Address::buildFromInput($input->{'address'}, $validate)) : null;
 
         $obj = new self($id);
         $obj->address = $address;

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-5.6/Foo.php
@@ -150,7 +150,7 @@ class Foo
         }
 
         $color = $input->{'color'};
-        $size = isset($input->{'size'}) ? $input->{'size'} : null;
+        $size = isset($input->{'size'}) ? ($input->{'size'}) : null;
 
         $obj = new self($color);
         $obj->size = $size;

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-7.4/Foo.php
@@ -152,7 +152,7 @@ class Foo
         }
 
         $color = $input->{'color'};
-        $size = isset($input->{'size'}) ? $input->{'size'} : null;
+        $size = isset($input->{'size'}) ? ($input->{'size'}) : null;
 
         $obj = new self($color);
         $obj->size = $size;

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-8.4/Foo.php
@@ -128,7 +128,7 @@ class Foo
         }
 
         $color = Color::from($input->{'color'});
-        $size = isset($input->{'size'}) ? Size::from($input->{'size'}) : null;
+        $size = isset($input->{'size'}) ? (Size::from($input->{'size'})) : null;
 
         $obj = new self($color);
         $obj->size = $size;

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-5.6/Bar.php
@@ -84,7 +84,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->b = $b;

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-5.6/Foo.php
@@ -84,7 +84,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Bar.php
@@ -86,7 +86,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->b = $b;

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Foo.php
@@ -86,7 +86,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Bar.php
@@ -80,7 +80,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->b = $b;

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Foo.php
@@ -80,7 +80,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Bar.php
@@ -85,7 +85,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? Foo::buildFromInput($input->{'a'}, $validate) : null;
+        $a = isset($input->{'a'}) ? (Foo::buildFromInput($input->{'a'}, $validate)) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Foo.php
@@ -84,7 +84,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Bar.php
@@ -87,7 +87,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? Foo::buildFromInput($input->{'a'}, $validate) : null;
+        $a = isset($input->{'a'}) ? (Foo::buildFromInput($input->{'a'}, $validate)) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Foo.php
@@ -86,7 +86,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Bar.php
@@ -81,7 +81,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? Foo::buildFromInput($input->{'a'}, $validate) : null;
+        $a = isset($input->{'a'}) ? (Foo::buildFromInput($input->{'a'}, $validate)) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Foo.php
@@ -80,7 +80,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-5.6/Bar.php
@@ -84,7 +84,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-5.6/Foo.php
@@ -84,7 +84,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Bar.php
@@ -86,7 +86,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Foo.php
@@ -86,7 +86,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Bar.php
@@ -80,7 +80,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Foo.php
@@ -80,7 +80,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefsRefs/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-5.6/Bar.php
@@ -84,7 +84,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefsRefs/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-5.6/Foo.php
@@ -84,7 +84,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefsRefs/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-7.4/Bar.php
@@ -86,7 +86,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefsRefs/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-7.4/Foo.php
@@ -86,7 +86,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefsRefs/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-8.4/Bar.php
@@ -80,7 +80,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/DefsRefs/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-8.4/Foo.php
@@ -80,7 +80,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/Descriptions/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-5.6/Baz.php
@@ -93,7 +93,7 @@ class Baz
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/Descriptions/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-5.6/MyClass.php
@@ -144,8 +144,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
-        $bar = isset($input->{'bar'}) ? Baz::buildFromInput($input->{'bar'}, $validate) : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
+        $bar = isset($input->{'bar'}) ? (Baz::buildFromInput($input->{'bar'}, $validate)) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/Descriptions/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-7.4/Baz.php
@@ -95,7 +95,7 @@ class Baz
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/Descriptions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-7.4/MyClass.php
@@ -146,8 +146,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
-        $bar = isset($input->{'bar'}) ? Baz::buildFromInput($input->{'bar'}, $validate) : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
+        $bar = isset($input->{'bar'}) ? (Baz::buildFromInput($input->{'bar'}, $validate)) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/Descriptions/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-8.4/Baz.php
@@ -89,7 +89,7 @@ class Baz
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/Descriptions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-8.4/MyClass.php
@@ -140,8 +140,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
-        $bar = isset($input->{'bar'}) ? Baz::buildFromInput($input->{'bar'}, $validate) : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
+        $bar = isset($input->{'bar'}) ? (Baz::buildFromInput($input->{'bar'}, $validate)) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-5.6/MyClass.php
@@ -132,7 +132,7 @@ class MyClass
         }
 
         $foo_bar = $input->{'foo-bar'};
-        $_foo_bar = isset($input->{'foo bar'}) ? $input->{'foo bar'} : null;
+        $_foo_bar = isset($input->{'foo bar'}) ? ($input->{'foo bar'}) : null;
 
         $obj = new self($foo_bar);
         $obj->_foo_bar = $_foo_bar;

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-7.4/MyClass.php
@@ -134,7 +134,7 @@ class MyClass
         }
 
         $foo_bar = $input->{'foo-bar'};
-        $_foo_bar = isset($input->{'foo bar'}) ? $input->{'foo bar'} : null;
+        $_foo_bar = isset($input->{'foo bar'}) ? ($input->{'foo bar'}) : null;
 
         $obj = new self($foo_bar);
         $obj->_foo_bar = $_foo_bar;

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-8.4/MyClass.php
@@ -128,7 +128,7 @@ class MyClass
         }
 
         $foo_bar = $input->{'foo-bar'};
-        $_foo_bar = isset($input->{'foo bar'}) ? $input->{'foo bar'} : null;
+        $_foo_bar = isset($input->{'foo bar'}) ? ($input->{'foo bar'}) : null;
 
         $obj = new self($foo_bar);
         $obj->_foo_bar = $_foo_bar;

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-5.6/MyClass.php
@@ -145,9 +145,9 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foobar = isset($input->{'foobar'}) ? $input->{'foobar'} : null;
+        $foobar = isset($input->{'foobar'}) ? ($input->{'foobar'}) : null;
         $_fooBar_1 = $input->{'fooBar'};
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
 
         $obj = new self($_fooBar_1);
         $obj->foobar = $foobar;

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-7.4/MyClass.php
@@ -147,9 +147,9 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foobar = isset($input->{'foobar'}) ? $input->{'foobar'} : null;
+        $foobar = isset($input->{'foobar'}) ? ($input->{'foobar'}) : null;
         $_fooBar_1 = $input->{'fooBar'};
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
 
         $obj = new self($_fooBar_1);
         $obj->foobar = $foobar;

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-8.4/MyClass.php
@@ -141,9 +141,9 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foobar = isset($input->{'foobar'}) ? $input->{'foobar'} : null;
+        $foobar = isset($input->{'foobar'}) ? ($input->{'foobar'}) : null;
         $_fooBar_1 = $input->{'fooBar'};
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
 
         $obj = new self($_fooBar_1);
         $obj->foobar = $foobar;

--- a/tests/Generator/Fixtures/EmptyObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/EmptyObject/Output-8.4/MyClass.php
@@ -134,8 +134,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/EncodedRef/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-5.6/BarTest.php
@@ -84,7 +84,7 @@ class BarTest
             static::validateInput($input);
         }
 
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
 
         $obj = new self();
         $obj->bar = $bar;

--- a/tests/Generator/Fixtures/EncodedRef/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-5.6/Baz.php
@@ -171,9 +171,9 @@ class Baz
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? FooTest::buildFromInput($input->{'a'}, $validate) : null;
-        $b = isset($input->{'b'}) ? FooTest::buildFromInput($input->{'b'}, $validate) : null;
-        $c = isset($input->{'c'}) ? BarTest::buildFromInput($input->{'c'}, $validate) : null;
+        $a = isset($input->{'a'}) ? (FooTest::buildFromInput($input->{'a'}, $validate)) : null;
+        $b = isset($input->{'b'}) ? (FooTest::buildFromInput($input->{'b'}, $validate)) : null;
+        $c = isset($input->{'c'}) ? (BarTest::buildFromInput($input->{'c'}, $validate)) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/EncodedRef/Output-5.6/FooTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-5.6/FooTest.php
@@ -84,7 +84,7 @@ class FooTest
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/EncodedRef/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-7.4/BarTest.php
@@ -86,7 +86,7 @@ class BarTest
             static::validateInput($input);
         }
 
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
 
         $obj = new self();
         $obj->bar = $bar;

--- a/tests/Generator/Fixtures/EncodedRef/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-7.4/Baz.php
@@ -173,9 +173,9 @@ class Baz
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? FooTest::buildFromInput($input->{'a'}, $validate) : null;
-        $b = isset($input->{'b'}) ? FooTest::buildFromInput($input->{'b'}, $validate) : null;
-        $c = isset($input->{'c'}) ? BarTest::buildFromInput($input->{'c'}, $validate) : null;
+        $a = isset($input->{'a'}) ? (FooTest::buildFromInput($input->{'a'}, $validate)) : null;
+        $b = isset($input->{'b'}) ? (FooTest::buildFromInput($input->{'b'}, $validate)) : null;
+        $c = isset($input->{'c'}) ? (BarTest::buildFromInput($input->{'c'}, $validate)) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/EncodedRef/Output-7.4/FooTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-7.4/FooTest.php
@@ -86,7 +86,7 @@ class FooTest
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/EncodedRef/Output-8.4/BarTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-8.4/BarTest.php
@@ -80,7 +80,7 @@ class BarTest
             static::validateInput($input);
         }
 
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
 
         $obj = new self();
         $obj->bar = $bar;

--- a/tests/Generator/Fixtures/EncodedRef/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-8.4/Baz.php
@@ -167,9 +167,9 @@ class Baz
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? FooTest::buildFromInput($input->{'a'}, $validate) : null;
-        $b = isset($input->{'b'}) ? FooTest::buildFromInput($input->{'b'}, $validate) : null;
-        $c = isset($input->{'c'}) ? BarTest::buildFromInput($input->{'c'}, $validate) : null;
+        $a = isset($input->{'a'}) ? (FooTest::buildFromInput($input->{'a'}, $validate)) : null;
+        $b = isset($input->{'b'}) ? (FooTest::buildFromInput($input->{'b'}, $validate)) : null;
+        $c = isset($input->{'c'}) ? (BarTest::buildFromInput($input->{'c'}, $validate)) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/EncodedRef/Output-8.4/FooTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-8.4/FooTest.php
@@ -80,7 +80,7 @@ class FooTest
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/EnumMixed/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/EnumMixed/Output-5.6/MyClass.php
@@ -401,7 +401,7 @@ class MyClass
         $contradiction = (int)($input->{'contradiction'});
         $contradiction2 = $input->{'contradiction2'};
         $nullable = ($input->{'nullable'} !== null) ? ($input->{'nullable'}) : null;
-        $optionalNullable = property_exists($input, 'optionalNullable') ? $input->{'optionalNullable'} : null;
+        $optionalNullable = property_exists($input, 'optionalNullable') ? (($input->{'optionalNullable'} !== null) ? ($input->{'optionalNullable'}) : null) : null;
         if (property_exists($input, 'optionalNullable')) {
             $__providedOptionals['optionalNullable'] = true;
         }
@@ -427,7 +427,7 @@ class MyClass
         $output['contradiction2'] = $this->contradiction2;
         $output['nullable'] = $this->nullable;
         if (isset($this->optionalNullable) || array_key_exists('optionalNullable', $this->_providedOptionals)) {
-            $output['optionalNullable'] = $this->optionalNullable;
+            $output['optionalNullable'] = ($this->optionalNullable !== null) ? ($this->optionalNullable) : null;
         }
 
         return $output;
@@ -448,7 +448,7 @@ class MyClass
         $output->{'contradiction2'} = $this->contradiction2;
         $output->{'nullable'} = $this->nullable;
         if (isset($this->optionalNullable) || array_key_exists('optionalNullable', $this->_providedOptionals)) {
-            $output->{'optionalNullable'} = $this->optionalNullable;
+            $output->{'optionalNullable'} = ($this->optionalNullable !== null) ? ($this->optionalNullable) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/EnumMixed/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/EnumMixed/Output-7.4/MyClass.php
@@ -403,7 +403,7 @@ class MyClass
         $contradiction = (int)($input->{'contradiction'});
         $contradiction2 = $input->{'contradiction2'};
         $nullable = ($input->{'nullable'} !== null) ? ($input->{'nullable'}) : null;
-        $optionalNullable = property_exists($input, 'optionalNullable') ? $input->{'optionalNullable'} : null;
+        $optionalNullable = property_exists($input, 'optionalNullable') ? (($input->{'optionalNullable'} !== null) ? ($input->{'optionalNullable'}) : null) : null;
         if (property_exists($input, 'optionalNullable')) {
             $__providedOptionals['optionalNullable'] = true;
         }
@@ -429,7 +429,7 @@ class MyClass
         $output['contradiction2'] = $this->contradiction2;
         $output['nullable'] = $this->nullable;
         if (isset($this->optionalNullable) || array_key_exists('optionalNullable', $this->_providedOptionals)) {
-            $output['optionalNullable'] = $this->optionalNullable;
+            $output['optionalNullable'] = ($this->optionalNullable !== null) ? ($this->optionalNullable) : null;
         }
 
         return $output;
@@ -450,7 +450,7 @@ class MyClass
         $output->{'contradiction2'} = $this->contradiction2;
         $output->{'nullable'} = $this->nullable;
         if (isset($this->optionalNullable) || array_key_exists('optionalNullable', $this->_providedOptionals)) {
-            $output->{'optionalNullable'} = $this->optionalNullable;
+            $output->{'optionalNullable'} = ($this->optionalNullable !== null) ? ($this->optionalNullable) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/EnumMixed/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/EnumMixed/Output-8.4/MyClass.php
@@ -379,7 +379,7 @@ class MyClass
         $contradiction = (int)($input->{'contradiction'});
         $contradiction2 = $input->{'contradiction2'};
         $nullable = ($input->{'nullable'} !== null) ? (MyClassNullable::from($input->{'nullable'})) : null;
-        $optionalNullable = property_exists($input, 'optionalNullable') ? MyClassOptionalNullable::from($input->{'optionalNullable'}) : null;
+        $optionalNullable = property_exists($input, 'optionalNullable') ? (($input->{'optionalNullable'} !== null) ? (MyClassOptionalNullable::from($input->{'optionalNullable'})) : null) : null;
         if (property_exists($input, 'optionalNullable')) {
             $__providedOptionals['optionalNullable'] = true;
         }
@@ -405,7 +405,7 @@ class MyClass
         $output['contradiction2'] = $this->contradiction2;
         $output['nullable'] = ($this->nullable)->value;
         if (isset($this->optionalNullable) || array_key_exists('optionalNullable', $this->_providedOptionals)) {
-            $output['optionalNullable'] = ($this->optionalNullable)->value;
+            $output['optionalNullable'] = ($this->optionalNullable !== null) ? (($this->optionalNullable)->value) : null;
         }
 
         return $output;
@@ -426,7 +426,7 @@ class MyClass
         $output->{'contradiction2'} = $this->contradiction2;
         $output->{'nullable'} = ($this->nullable)->value;
         if (isset($this->optionalNullable) || array_key_exists('optionalNullable', $this->_providedOptionals)) {
-            $output->{'optionalNullable'} = ($this->optionalNullable)->value;
+            $output->{'optionalNullable'} = ($this->optionalNullable !== null) ? (($this->optionalNullable)->value) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
@@ -302,10 +302,10 @@ class Foo
             static::validateInput($input);
         }
 
-        $floatEnum = isset($input->{'floatEnum'}) ? $input->{'floatEnum'} : null;
-        $floatEnumRef = isset($input->{'floatEnumRef'}) ? $input->{'floatEnumRef'} : null;
-        $boolEnum = isset($input->{'boolEnum'}) ? $input->{'boolEnum'} : null;
-        $boolEnumRef = isset($input->{'boolEnumRef'}) ? $input->{'boolEnumRef'} : null;
+        $floatEnum = isset($input->{'floatEnum'}) ? ($input->{'floatEnum'}) : null;
+        $floatEnumRef = isset($input->{'floatEnumRef'}) ? ($input->{'floatEnumRef'}) : null;
+        $boolEnum = isset($input->{'boolEnum'}) ? ($input->{'boolEnum'}) : null;
+        $boolEnumRef = isset($input->{'boolEnumRef'}) ? ($input->{'boolEnumRef'}) : null;
         $requiredBoolEnumRef = $input->{'requiredBoolEnumRef'};
 
         $obj = new self($requiredBoolEnumRef);

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
@@ -304,10 +304,10 @@ class Foo
             static::validateInput($input);
         }
 
-        $floatEnum = isset($input->{'floatEnum'}) ? $input->{'floatEnum'} : null;
-        $floatEnumRef = isset($input->{'floatEnumRef'}) ? $input->{'floatEnumRef'} : null;
-        $boolEnum = isset($input->{'boolEnum'}) ? $input->{'boolEnum'} : null;
-        $boolEnumRef = isset($input->{'boolEnumRef'}) ? $input->{'boolEnumRef'} : null;
+        $floatEnum = isset($input->{'floatEnum'}) ? ($input->{'floatEnum'}) : null;
+        $floatEnumRef = isset($input->{'floatEnumRef'}) ? ($input->{'floatEnumRef'}) : null;
+        $boolEnum = isset($input->{'boolEnum'}) ? ($input->{'boolEnum'}) : null;
+        $boolEnumRef = isset($input->{'boolEnumRef'}) ? ($input->{'boolEnumRef'}) : null;
         $requiredBoolEnumRef = $input->{'requiredBoolEnumRef'};
 
         $obj = new self($requiredBoolEnumRef);

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
@@ -298,10 +298,10 @@ class Foo
             static::validateInput($input);
         }
 
-        $floatEnum = isset($input->{'floatEnum'}) ? $input->{'floatEnum'} : null;
-        $floatEnumRef = isset($input->{'floatEnumRef'}) ? $input->{'floatEnumRef'} : null;
-        $boolEnum = isset($input->{'boolEnum'}) ? $input->{'boolEnum'} : null;
-        $boolEnumRef = isset($input->{'boolEnumRef'}) ? $input->{'boolEnumRef'} : null;
+        $floatEnum = isset($input->{'floatEnum'}) ? ($input->{'floatEnum'}) : null;
+        $floatEnumRef = isset($input->{'floatEnumRef'}) ? ($input->{'floatEnumRef'}) : null;
+        $boolEnum = isset($input->{'boolEnum'}) ? ($input->{'boolEnum'}) : null;
+        $boolEnumRef = isset($input->{'boolEnumRef'}) ? ($input->{'boolEnumRef'}) : null;
         $requiredBoolEnumRef = $input->{'requiredBoolEnumRef'};
 
         $obj = new self($requiredBoolEnumRef);

--- a/tests/Generator/Fixtures/EnumWithNull/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/EnumWithNull/Output-7.4/MyClass.php
@@ -104,7 +104,7 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $foo = property_exists($input, 'foo') ? $input->{'foo'} : null;
+        $foo = property_exists($input, 'foo') ? (($input->{'foo'} !== null) ? ($input->{'foo'}) : null) : null;
         if (property_exists($input, 'foo')) {
             $__providedOptionals['foo'] = true;
         }
@@ -124,7 +124,7 @@ class MyClass
     {
         $output = [];
         if (isset($this->foo) || array_key_exists('foo', $this->_providedOptionals)) {
-            $output['foo'] = $this->foo;
+            $output['foo'] = ($this->foo !== null) ? ($this->foo) : null;
         }
 
         return $output;
@@ -139,7 +139,7 @@ class MyClass
     {
         $output = new \stdClass();
         if (isset($this->foo) || array_key_exists('foo', $this->_providedOptionals)) {
-            $output->{'foo'} = $this->foo;
+            $output->{'foo'} = ($this->foo !== null) ? ($this->foo) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/EnumWithNull/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/EnumWithNull/Output-8.4/MyClass.php
@@ -89,7 +89,7 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $foo = property_exists($input, 'foo') ? MyClassFoo::from($input->{'foo'}) : null;
+        $foo = property_exists($input, 'foo') ? (($input->{'foo'} !== null) ? (MyClassFoo::from($input->{'foo'})) : null) : null;
         if (property_exists($input, 'foo')) {
             $__providedOptionals['foo'] = true;
         }
@@ -109,7 +109,7 @@ class MyClass
     {
         $output = [];
         if (isset($this->foo) || array_key_exists('foo', $this->_providedOptionals)) {
-            $output['foo'] = ($this->foo)->value;
+            $output['foo'] = ($this->foo !== null) ? (($this->foo)->value) : null;
         }
 
         return $output;
@@ -124,7 +124,7 @@ class MyClass
     {
         $output = new \stdClass();
         if (isset($this->foo) || array_key_exists('foo', $this->_providedOptionals)) {
-            $output->{'foo'} = ($this->foo)->value;
+            $output->{'foo'} = ($this->foo !== null) ? (($this->foo)->value) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
@@ -111,7 +111,7 @@ class BarTest
             static::validateInput($input);
         }
 
-        $exampleProp = isset($input->{'exampleProp'}) ? (FooTest_1::validateInput($input->{'exampleProp'}, true)) ? (FooTest_1::buildFromInput($input->{'exampleProp'}, $validate)) : ((MoiKlass::validateInput($input->{'exampleProp'}, true)) ? (MoiKlass::buildFromInput($input->{'exampleProp'}, $validate)) : ((FooTest::validateInput($input->{'exampleProp'}, true)) ? (FooTest::buildFromInput($input->{'exampleProp'}, $validate)) : (null))) : null;
+        $exampleProp = isset($input->{'exampleProp'}) ? ((FooTest_1::validateInput($input->{'exampleProp'}, true)) ? (FooTest_1::buildFromInput($input->{'exampleProp'}, $validate)) : ((MoiKlass::validateInput($input->{'exampleProp'}, true)) ? (MoiKlass::buildFromInput($input->{'exampleProp'}, $validate)) : ((FooTest::validateInput($input->{'exampleProp'}, true)) ? (FooTest::buildFromInput($input->{'exampleProp'}, $validate)) : (null)))) : null;
 
         $obj = new self();
         $obj->exampleProp = $exampleProp;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/FooTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/FooTest.php
@@ -84,7 +84,7 @@ class FooTest
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/FooTest_1.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/FooTest_1.php
@@ -84,7 +84,7 @@ class FooTest_1
             static::validateInput($input);
         }
 
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->b = $b;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/MoiKlass.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/MoiKlass.php
@@ -84,7 +84,7 @@ class MoiKlass
             static::validateInput($input);
         }
 
-        $c = isset($input->{'c'}) ? $input->{'c'} : null;
+        $c = isset($input->{'c'}) ? ($input->{'c'}) : null;
 
         $obj = new self();
         $obj->c = $c;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -113,7 +113,7 @@ class BarTest
             static::validateInput($input);
         }
 
-        $exampleProp = isset($input->{'exampleProp'}) ? (FooTest_1::validateInput($input->{'exampleProp'}, true)) ? (FooTest_1::buildFromInput($input->{'exampleProp'}, $validate)) : ((MoiKlass::validateInput($input->{'exampleProp'}, true)) ? (MoiKlass::buildFromInput($input->{'exampleProp'}, $validate)) : ((FooTest::validateInput($input->{'exampleProp'}, true)) ? (FooTest::buildFromInput($input->{'exampleProp'}, $validate)) : (null))) : null;
+        $exampleProp = isset($input->{'exampleProp'}) ? ((FooTest_1::validateInput($input->{'exampleProp'}, true)) ? (FooTest_1::buildFromInput($input->{'exampleProp'}, $validate)) : ((MoiKlass::validateInput($input->{'exampleProp'}, true)) ? (MoiKlass::buildFromInput($input->{'exampleProp'}, $validate)) : ((FooTest::validateInput($input->{'exampleProp'}, true)) ? (FooTest::buildFromInput($input->{'exampleProp'}, $validate)) : (null)))) : null;
 
         $obj = new self();
         $obj->exampleProp = $exampleProp;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest.php
@@ -86,7 +86,7 @@ class FooTest
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest_1.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest_1.php
@@ -86,7 +86,7 @@ class FooTest_1
             static::validateInput($input);
         }
 
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->b = $b;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/MoiKlass.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/MoiKlass.php
@@ -86,7 +86,7 @@ class MoiKlass
             static::validateInput($input);
         }
 
-        $c = isset($input->{'c'}) ? $input->{'c'} : null;
+        $c = isset($input->{'c'}) ? ($input->{'c'}) : null;
 
         $obj = new self();
         $obj->c = $c;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
@@ -107,12 +107,12 @@ class BarTest
             static::validateInput($input);
         }
 
-        $exampleProp = isset($input->{'exampleProp'}) ? match (true) {
+        $exampleProp = isset($input->{'exampleProp'}) ? (match (true) {
             FooTest::validateInput($input->{'exampleProp'}, true) => FooTest::buildFromInput($input->{'exampleProp'}, $validate),
             MoiKlass::validateInput($input->{'exampleProp'}, true) => MoiKlass::buildFromInput($input->{'exampleProp'}, $validate),
             FooTest_1::validateInput($input->{'exampleProp'}, true) => FooTest_1::buildFromInput($input->{'exampleProp'}, $validate),
             default => null,
-        } : null;
+        }) : null;
 
         $obj = new self();
         $obj->exampleProp = $exampleProp;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest.php
@@ -80,7 +80,7 @@ class FooTest
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest_1.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest_1.php
@@ -80,7 +80,7 @@ class FooTest_1
             static::validateInput($input);
         }
 
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->b = $b;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/MoiKlass.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/MoiKlass.php
@@ -80,7 +80,7 @@ class MoiKlass
             static::validateInput($input);
         }
 
-        $c = isset($input->{'c'}) ? $input->{'c'} : null;
+        $c = isset($input->{'c'}) ? ($input->{'c'}) : null;
 
         $obj = new self();
         $obj->c = $c;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -1982,14 +1982,14 @@ class MyClass
         $_argc = $_input->{'argc'};
         $_argv = $_input->{'argv'};
         $input = $_input->{'input'};
-        $validate = isset($_input->{'validate'}) ? $_input->{'validate'} : null;
-        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? $_input->{'materializeDefaults'} : null;
+        $validate = isset($_input->{'validate'}) ? ($_input->{'validate'}) : null;
+        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? (($_input->{'materializeDefaults'} !== null) ? ($_input->{'materializeDefaults'}) : null) : null;
         if (property_exists($_input, 'materializeDefaults')) {
             $__providedOptionals['materializeDefaults'] = true;
         }
         $obj = $_input->{'obj'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
+        $testObj = isset($_input->{'testObj'}) ? (MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults)) : null;
         $_buildFromInput_1 = $_input->{'buildFromInput'};
         $_toArray_1 = $_input->{'toArray'};
         $_validateInput_1 = $_input->{'validateInput'};
@@ -2011,9 +2011,9 @@ class MyClass
         $_debugInfo_1 = $_input->{'__debugInfo'};
         $_clone_2 = $_input->{'__clone'};
         $files = $_input->{'files'};
-        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? (is_string($_input->{'ensureArgs1'})) ? ($_input->{'ensureArgs1'}) : ((MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative2::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : ((MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative1::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : (null))) : null;
-        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? MyClassEnsureArgs2::buildFromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults) : null;
-        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? array_map(function($i) use ($_validate, $_materializeDefaults) { return MyClassEnsureArgs3Item::buildFromInput($i, $_validate, $_materializeDefaults); }, $_input->{'ensureArgs3'}) : null;
+        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? ((is_string($_input->{'ensureArgs1'})) ? ($_input->{'ensureArgs1'}) : ((MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative2::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : ((MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative1::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : (null)))) : null;
+        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? (MyClassEnsureArgs2::buildFromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults)) : null;
+        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? (array_map(function($i) use ($_validate, $_materializeDefaults) { return MyClassEnsureArgs3Item::buildFromInput($i, $_validate, $_materializeDefaults); }, $_input->{'ensureArgs3'})) : null;
 
         $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $input, $obj, $includeDefaults, $_buildFromInput_1, $_toArray_1, $_validateInput_1, $_schema, $_defaults_1, $_providedOptionals_1, $_clone_1, $_construct_1, $_destruct_1, $_get_2, $_set_1, $_call_1, $_isset_1, $_unset_1, $_sleep_1, $_wakeup_1, $_toString_1, $_invoke_1, $_debugInfo_1, $_clone_2, $files);
         $_obj->validate = $validate;
@@ -2055,7 +2055,7 @@ class MyClass
             $output['validate'] = $this->validate;
         }
         if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
-            $output['materializeDefaults'] = $this->materializeDefaults;
+            $output['materializeDefaults'] = ($this->materializeDefaults !== null) ? ($this->materializeDefaults) : null;
         }
         $output['obj'] = $this->obj;
         $output['includeDefaults'] = $this->includeDefaults;
@@ -2137,7 +2137,7 @@ class MyClass
             $output->{'validate'} = $this->validate;
         }
         if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
-            $output->{'materializeDefaults'} = $this->materializeDefaults;
+            $output->{'materializeDefaults'} = ($this->materializeDefaults !== null) ? ($this->materializeDefaults) : null;
         }
         $output->{'obj'} = $this->obj;
         $output->{'includeDefaults'} = $this->includeDefaults;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs1Alternative1.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs1Alternative1.php
@@ -112,7 +112,7 @@ class MyClassEnsureArgs1Alternative1
             static::validateInput($input);
         }
 
-        $type = isset($input->{'type'}) ? $input->{'type'} : null;
+        $type = isset($input->{'type'}) ? ($input->{'type'}) : null;
 
         $obj = new self();
         $obj->type = $type;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassEnsureArgs3Item.php
@@ -109,7 +109,7 @@ class MyClassEnsureArgs3Item
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClassTestObj.php
@@ -84,7 +84,7 @@ class MyClassTestObj
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -1984,14 +1984,14 @@ class MyClass
         $_argc = $_input->{'argc'};
         $_argv = $_input->{'argv'};
         $input = $_input->{'input'};
-        $validate = isset($_input->{'validate'}) ? $_input->{'validate'} : null;
-        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? $_input->{'materializeDefaults'} : null;
+        $validate = isset($_input->{'validate'}) ? ($_input->{'validate'}) : null;
+        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? (($_input->{'materializeDefaults'} !== null) ? ($_input->{'materializeDefaults'}) : null) : null;
         if (property_exists($_input, 'materializeDefaults')) {
             $__providedOptionals['materializeDefaults'] = true;
         }
         $obj = $_input->{'obj'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
+        $testObj = isset($_input->{'testObj'}) ? (MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults)) : null;
         $_buildFromInput_1 = $_input->{'buildFromInput'};
         $_toArray_1 = $_input->{'toArray'};
         $_validateInput_1 = $_input->{'validateInput'};
@@ -2013,9 +2013,9 @@ class MyClass
         $_debugInfo_1 = $_input->{'__debugInfo'};
         $_clone_2 = $_input->{'__clone'};
         $files = $_input->{'files'};
-        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? (is_string($_input->{'ensureArgs1'})) ? ($_input->{'ensureArgs1'}) : ((MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative2::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : ((MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative1::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : (null))) : null;
-        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? MyClassEnsureArgs2::buildFromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults) : null;
-        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? array_map(fn ($i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::buildFromInput($i, $_validate, $_materializeDefaults), $_input->{'ensureArgs3'}) : null;
+        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? ((is_string($_input->{'ensureArgs1'})) ? ($_input->{'ensureArgs1'}) : ((MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative2::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : ((MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative1::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : (null)))) : null;
+        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? (MyClassEnsureArgs2::buildFromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults)) : null;
+        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? (array_map(fn ($i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::buildFromInput($i, $_validate, $_materializeDefaults), $_input->{'ensureArgs3'})) : null;
 
         $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $input, $obj, $includeDefaults, $_buildFromInput_1, $_toArray_1, $_validateInput_1, $_schema, $_defaults_1, $_providedOptionals_1, $_clone_1, $_construct_1, $_destruct_1, $_get_2, $_set_1, $_call_1, $_isset_1, $_unset_1, $_sleep_1, $_wakeup_1, $_toString_1, $_invoke_1, $_debugInfo_1, $_clone_2, $files);
         $_obj->validate = $validate;
@@ -2057,7 +2057,7 @@ class MyClass
             $output['validate'] = $this->validate;
         }
         if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
-            $output['materializeDefaults'] = $this->materializeDefaults;
+            $output['materializeDefaults'] = ($this->materializeDefaults !== null) ? ($this->materializeDefaults) : null;
         }
         $output['obj'] = $this->obj;
         $output['includeDefaults'] = $this->includeDefaults;
@@ -2139,7 +2139,7 @@ class MyClass
             $output->{'validate'} = $this->validate;
         }
         if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
-            $output->{'materializeDefaults'} = $this->materializeDefaults;
+            $output->{'materializeDefaults'} = ($this->materializeDefaults !== null) ? ($this->materializeDefaults) : null;
         }
         $output->{'obj'} = $this->obj;
         $output->{'includeDefaults'} = $this->includeDefaults;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs1Alternative1.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs1Alternative1.php
@@ -114,7 +114,7 @@ class MyClassEnsureArgs1Alternative1
             static::validateInput($input);
         }
 
-        $type = isset($input->{'type'}) ? $input->{'type'} : null;
+        $type = isset($input->{'type'}) ? ($input->{'type'}) : null;
 
         $obj = new self();
         $obj->type = $type;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs3Item.php
@@ -111,7 +111,7 @@ class MyClassEnsureArgs3Item
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassTestObj.php
@@ -86,7 +86,7 @@ class MyClassTestObj
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
@@ -1978,14 +1978,14 @@ class MyClass
         $_argc = $_input->{'argc'};
         $_argv = $_input->{'argv'};
         $input = $_input->{'input'};
-        $validate = isset($_input->{'validate'}) ? $_input->{'validate'} : null;
-        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? $_input->{'materializeDefaults'} : null;
+        $validate = isset($_input->{'validate'}) ? ($_input->{'validate'}) : null;
+        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? (($_input->{'materializeDefaults'} !== null) ? ($_input->{'materializeDefaults'}) : null) : null;
         if (property_exists($_input, 'materializeDefaults')) {
             $__providedOptionals['materializeDefaults'] = true;
         }
         $obj = $_input->{'obj'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
+        $testObj = isset($_input->{'testObj'}) ? (MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults)) : null;
         $_buildFromInput_1 = $_input->{'buildFromInput'};
         $_toArray_1 = $_input->{'toArray'};
         $_validateInput_1 = $_input->{'validateInput'};
@@ -2007,14 +2007,14 @@ class MyClass
         $_debugInfo_1 = $_input->{'__debugInfo'};
         $_clone_2 = $_input->{'__clone'};
         $files = $_input->{'files'};
-        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? match (true) {
+        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? (match (true) {
             MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true) => MyClassEnsureArgs1Alternative1::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults),
             MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true) => MyClassEnsureArgs1Alternative2::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults),
             is_string($_input->{'ensureArgs1'}) => $_input->{'ensureArgs1'},
             default => null,
-        } : null;
-        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? MyClassEnsureArgs2::buildFromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults) : null;
-        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? array_map(fn (array|object $i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::buildFromInput($i, $_validate, $_materializeDefaults), $_input->{'ensureArgs3'}) : null;
+        }) : null;
+        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? (MyClassEnsureArgs2::buildFromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults)) : null;
+        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? (array_map(fn (array|object $i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::buildFromInput($i, $_validate, $_materializeDefaults), $_input->{'ensureArgs3'})) : null;
 
         $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $input, $obj, $includeDefaults, $_buildFromInput_1, $_toArray_1, $_validateInput_1, $_schema, $_defaults_1, $_providedOptionals_1, $_clone_1, $_construct_1, $_destruct_1, $_get_2, $_set_1, $_call_1, $_isset_1, $_unset_1, $_sleep_1, $_wakeup_1, $_toString_1, $_invoke_1, $_debugInfo_1, $_clone_2, $files);
         $_obj->validate = $validate;
@@ -2056,7 +2056,7 @@ class MyClass
             $output['validate'] = $this->validate;
         }
         if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
-            $output['materializeDefaults'] = $this->materializeDefaults;
+            $output['materializeDefaults'] = ($this->materializeDefaults !== null) ? ($this->materializeDefaults) : null;
         }
         $output['obj'] = $this->obj;
         $output['includeDefaults'] = $this->includeDefaults;
@@ -2138,7 +2138,7 @@ class MyClass
             $output->{'validate'} = $this->validate;
         }
         if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
-            $output->{'materializeDefaults'} = $this->materializeDefaults;
+            $output->{'materializeDefaults'} = ($this->materializeDefaults !== null) ? ($this->materializeDefaults) : null;
         }
         $output->{'obj'} = $this->obj;
         $output->{'includeDefaults'} = $this->includeDefaults;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs1Alternative1.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs1Alternative1.php
@@ -99,7 +99,7 @@ class MyClassEnsureArgs1Alternative1
             static::validateInput($input);
         }
 
-        $type = isset($input->{'type'}) ? MyClassEnsureArgs1Alternative1Type::from($input->{'type'}) : null;
+        $type = isset($input->{'type'}) ? (MyClassEnsureArgs1Alternative1Type::from($input->{'type'})) : null;
 
         $obj = new self();
         $obj->type = $type;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs3Item.php
@@ -105,7 +105,7 @@ class MyClassEnsureArgs3Item
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassTestObj.php
@@ -80,7 +80,7 @@ class MyClassTestObj
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-5.6/MyClass.php
@@ -179,9 +179,9 @@ class MyClass
             static::validateInput($input);
         }
 
-        $bound = isset($input->{'bound'}) ? $input->{'bound'} : null;
-        $outbound = isset($input->{'outbound'}) ? $input->{'outbound'} : null;
-        $_outbound = isset($input->{'_outbound'}) ? $input->{'_outbound'} : null;
+        $bound = isset($input->{'bound'}) ? ($input->{'bound'}) : null;
+        $outbound = isset($input->{'outbound'}) ? ($input->{'outbound'}) : null;
+        $_outbound = isset($input->{'_outbound'}) ? ($input->{'_outbound'}) : null;
 
         $obj = new self();
         $obj->bound = $bound;

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-7.4/MyClass.php
@@ -181,9 +181,9 @@ class MyClass
             static::validateInput($input);
         }
 
-        $bound = isset($input->{'bound'}) ? $input->{'bound'} : null;
-        $outbound = isset($input->{'outbound'}) ? $input->{'outbound'} : null;
-        $_outbound = isset($input->{'_outbound'}) ? $input->{'_outbound'} : null;
+        $bound = isset($input->{'bound'}) ? ($input->{'bound'}) : null;
+        $outbound = isset($input->{'outbound'}) ? ($input->{'outbound'}) : null;
+        $_outbound = isset($input->{'_outbound'}) ? ($input->{'_outbound'}) : null;
 
         $obj = new self();
         $obj->bound = $bound;

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-8.4/MyClass.php
@@ -175,9 +175,9 @@ class MyClass
             static::validateInput($input);
         }
 
-        $bound = isset($input->{'bound'}) ? $input->{'bound'} : null;
-        $outbound = isset($input->{'outbound'}) ? $input->{'outbound'} : null;
-        $_outbound = isset($input->{'_outbound'}) ? $input->{'_outbound'} : null;
+        $bound = isset($input->{'bound'}) ? ($input->{'bound'}) : null;
+        $outbound = isset($input->{'outbound'}) ? ($input->{'outbound'}) : null;
+        $_outbound = isset($input->{'_outbound'}) ? ($input->{'_outbound'}) : null;
 
         $obj = new self();
         $obj->bound = $bound;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -1982,14 +1982,14 @@ class MyClass
         $_argc = $_input->{'argc'};
         $_argv = $_input->{'argv'};
         $input = $_input->{'input'};
-        $validate = isset($_input->{'validate'}) ? $_input->{'validate'} : null;
-        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? $_input->{'materializeDefaults'} : null;
+        $validate = isset($_input->{'validate'}) ? ($_input->{'validate'}) : null;
+        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? (($_input->{'materializeDefaults'} !== null) ? ($_input->{'materializeDefaults'}) : null) : null;
         if (property_exists($_input, 'materializeDefaults')) {
             $__providedOptionals['materializeDefaults'] = true;
         }
         $obj = $_input->{'obj'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
+        $testObj = isset($_input->{'testObj'}) ? (MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults)) : null;
         $_buildFromInput = $_input->{'buildFromInput'};
         $_toArray = $_input->{'toArray'};
         $_validateInput = $_input->{'validateInput'};
@@ -2011,9 +2011,9 @@ class MyClass
         $__debugInfo_1 = $_input->{'__debugInfo'};
         $__clone_1 = $_input->{'__clone'};
         $files = $_input->{'files'};
-        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? (is_string($_input->{'ensureArgs1'})) ? ($_input->{'ensureArgs1'}) : ((MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative2::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : ((MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative1::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : (null))) : null;
-        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? MyClassEnsureArgs2::buildFromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults) : null;
-        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? array_map(function($i) use ($_validate, $_materializeDefaults) { return MyClassEnsureArgs3Item::buildFromInput($i, $_validate, $_materializeDefaults); }, $_input->{'ensureArgs3'}) : null;
+        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? ((is_string($_input->{'ensureArgs1'})) ? ($_input->{'ensureArgs1'}) : ((MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative2::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : ((MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative1::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : (null)))) : null;
+        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? (MyClassEnsureArgs2::buildFromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults)) : null;
+        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? (array_map(function($i) use ($_validate, $_materializeDefaults) { return MyClassEnsureArgs3Item::buildFromInput($i, $_validate, $_materializeDefaults); }, $_input->{'ensureArgs3'})) : null;
 
         $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS_1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $input, $obj, $includeDefaults, $_buildFromInput, $_toArray, $_validateInput, $_schema, $_defaults_1, $_providedOptionals_1, $_clone, $__construct_1, $__destruct_1, $__get_1, $__set_1, $__call_1, $__isset_1, $__unset_1, $__sleep_1, $__wakeup_1, $__toString_1, $__invoke_1, $__debugInfo_1, $__clone_1, $files);
         $_obj->validate = $validate;
@@ -2055,7 +2055,7 @@ class MyClass
             $output['validate'] = $this->validate;
         }
         if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
-            $output['materializeDefaults'] = $this->materializeDefaults;
+            $output['materializeDefaults'] = ($this->materializeDefaults !== null) ? ($this->materializeDefaults) : null;
         }
         $output['obj'] = $this->obj;
         $output['includeDefaults'] = $this->includeDefaults;
@@ -2137,7 +2137,7 @@ class MyClass
             $output->{'validate'} = $this->validate;
         }
         if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
-            $output->{'materializeDefaults'} = $this->materializeDefaults;
+            $output->{'materializeDefaults'} = ($this->materializeDefaults !== null) ? ($this->materializeDefaults) : null;
         }
         $output->{'obj'} = $this->obj;
         $output->{'includeDefaults'} = $this->includeDefaults;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClassEnsureArgs1Alternative1.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClassEnsureArgs1Alternative1.php
@@ -112,7 +112,7 @@ class MyClassEnsureArgs1Alternative1
             static::validateInput($input);
         }
 
-        $type = isset($input->{'type'}) ? $input->{'type'} : null;
+        $type = isset($input->{'type'}) ? ($input->{'type'}) : null;
 
         $obj = new self();
         $obj->type = $type;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClassEnsureArgs3Item.php
@@ -109,7 +109,7 @@ class MyClassEnsureArgs3Item
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClassTestObj.php
@@ -84,7 +84,7 @@ class MyClassTestObj
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -1984,14 +1984,14 @@ class MyClass
         $_argc = $_input->{'argc'};
         $_argv = $_input->{'argv'};
         $input = $_input->{'input'};
-        $validate = isset($_input->{'validate'}) ? $_input->{'validate'} : null;
-        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? $_input->{'materializeDefaults'} : null;
+        $validate = isset($_input->{'validate'}) ? ($_input->{'validate'}) : null;
+        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? (($_input->{'materializeDefaults'} !== null) ? ($_input->{'materializeDefaults'}) : null) : null;
         if (property_exists($_input, 'materializeDefaults')) {
             $__providedOptionals['materializeDefaults'] = true;
         }
         $obj = $_input->{'obj'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
+        $testObj = isset($_input->{'testObj'}) ? (MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults)) : null;
         $_buildFromInput = $_input->{'buildFromInput'};
         $_toArray = $_input->{'toArray'};
         $_validateInput = $_input->{'validateInput'};
@@ -2013,9 +2013,9 @@ class MyClass
         $__debugInfo_1 = $_input->{'__debugInfo'};
         $__clone_1 = $_input->{'__clone'};
         $files = $_input->{'files'};
-        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? (is_string($_input->{'ensureArgs1'})) ? ($_input->{'ensureArgs1'}) : ((MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative2::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : ((MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative1::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : (null))) : null;
-        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? MyClassEnsureArgs2::buildFromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults) : null;
-        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? array_map(fn ($i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::buildFromInput($i, $_validate, $_materializeDefaults), $_input->{'ensureArgs3'}) : null;
+        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? ((is_string($_input->{'ensureArgs1'})) ? ($_input->{'ensureArgs1'}) : ((MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative2::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : ((MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true)) ? (MyClassEnsureArgs1Alternative1::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults)) : (null)))) : null;
+        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? (MyClassEnsureArgs2::buildFromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults)) : null;
+        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? (array_map(fn ($i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::buildFromInput($i, $_validate, $_materializeDefaults), $_input->{'ensureArgs3'})) : null;
 
         $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS_1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $input, $obj, $includeDefaults, $_buildFromInput, $_toArray, $_validateInput, $_schema, $_defaults_1, $_providedOptionals_1, $_clone, $__construct_1, $__destruct_1, $__get_1, $__set_1, $__call_1, $__isset_1, $__unset_1, $__sleep_1, $__wakeup_1, $__toString_1, $__invoke_1, $__debugInfo_1, $__clone_1, $files);
         $_obj->validate = $validate;
@@ -2057,7 +2057,7 @@ class MyClass
             $output['validate'] = $this->validate;
         }
         if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
-            $output['materializeDefaults'] = $this->materializeDefaults;
+            $output['materializeDefaults'] = ($this->materializeDefaults !== null) ? ($this->materializeDefaults) : null;
         }
         $output['obj'] = $this->obj;
         $output['includeDefaults'] = $this->includeDefaults;
@@ -2139,7 +2139,7 @@ class MyClass
             $output->{'validate'} = $this->validate;
         }
         if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
-            $output->{'materializeDefaults'} = $this->materializeDefaults;
+            $output->{'materializeDefaults'} = ($this->materializeDefaults !== null) ? ($this->materializeDefaults) : null;
         }
         $output->{'obj'} = $this->obj;
         $output->{'includeDefaults'} = $this->includeDefaults;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassEnsureArgs1Alternative1.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassEnsureArgs1Alternative1.php
@@ -114,7 +114,7 @@ class MyClassEnsureArgs1Alternative1
             static::validateInput($input);
         }
 
-        $type = isset($input->{'type'}) ? $input->{'type'} : null;
+        $type = isset($input->{'type'}) ? ($input->{'type'}) : null;
 
         $obj = new self();
         $obj->type = $type;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassEnsureArgs3Item.php
@@ -111,7 +111,7 @@ class MyClassEnsureArgs3Item
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassTestObj.php
@@ -86,7 +86,7 @@ class MyClassTestObj
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
@@ -1978,14 +1978,14 @@ class MyClass
         $_argc = $_input->{'argc'};
         $_argv = $_input->{'argv'};
         $input = $_input->{'input'};
-        $validate = isset($_input->{'validate'}) ? $_input->{'validate'} : null;
-        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? $_input->{'materializeDefaults'} : null;
+        $validate = isset($_input->{'validate'}) ? ($_input->{'validate'}) : null;
+        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? (($_input->{'materializeDefaults'} !== null) ? ($_input->{'materializeDefaults'}) : null) : null;
         if (property_exists($_input, 'materializeDefaults')) {
             $__providedOptionals['materializeDefaults'] = true;
         }
         $obj = $_input->{'obj'};
         $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
+        $testObj = isset($_input->{'testObj'}) ? (MyClassTestObj::buildFromInput($_input->{'testObj'}, $_validate, $_materializeDefaults)) : null;
         $_buildFromInput = $_input->{'buildFromInput'};
         $_toArray = $_input->{'toArray'};
         $_validateInput = $_input->{'validateInput'};
@@ -2007,14 +2007,14 @@ class MyClass
         $__debugInfo_1 = $_input->{'__debugInfo'};
         $__clone_1 = $_input->{'__clone'};
         $files = $_input->{'files'};
-        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? match (true) {
+        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? (match (true) {
             MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true) => MyClassEnsureArgs1Alternative1::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults),
             MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true) => MyClassEnsureArgs1Alternative2::buildFromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults),
             is_string($_input->{'ensureArgs1'}) => $_input->{'ensureArgs1'},
             default => null,
-        } : null;
-        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? MyClassEnsureArgs2::buildFromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults) : null;
-        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? array_map(fn (array|object $i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::buildFromInput($i, $_validate, $_materializeDefaults), $_input->{'ensureArgs3'}) : null;
+        }) : null;
+        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? (MyClassEnsureArgs2::buildFromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults)) : null;
+        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? (array_map(fn (array|object $i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::buildFromInput($i, $_validate, $_materializeDefaults), $_input->{'ensureArgs3'})) : null;
 
         $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS_1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $input, $obj, $includeDefaults, $_buildFromInput, $_toArray, $_validateInput, $_schema, $_defaults_1, $_providedOptionals_1, $_clone, $__construct_1, $__destruct_1, $__get_1, $__set_1, $__call_1, $__isset_1, $__unset_1, $__sleep_1, $__wakeup_1, $__toString_1, $__invoke_1, $__debugInfo_1, $__clone_1, $files);
         $_obj->validate = $validate;
@@ -2056,7 +2056,7 @@ class MyClass
             $output['validate'] = $this->validate;
         }
         if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
-            $output['materializeDefaults'] = $this->materializeDefaults;
+            $output['materializeDefaults'] = ($this->materializeDefaults !== null) ? ($this->materializeDefaults) : null;
         }
         $output['obj'] = $this->obj;
         $output['includeDefaults'] = $this->includeDefaults;
@@ -2138,7 +2138,7 @@ class MyClass
             $output->{'validate'} = $this->validate;
         }
         if (isset($this->materializeDefaults) || array_key_exists('materializeDefaults', $this->_providedOptionals)) {
-            $output->{'materializeDefaults'} = $this->materializeDefaults;
+            $output->{'materializeDefaults'} = ($this->materializeDefaults !== null) ? ($this->materializeDefaults) : null;
         }
         $output->{'obj'} = $this->obj;
         $output->{'includeDefaults'} = $this->includeDefaults;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassEnsureArgs1Alternative1.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassEnsureArgs1Alternative1.php
@@ -99,7 +99,7 @@ class MyClassEnsureArgs1Alternative1
             static::validateInput($input);
         }
 
-        $type = isset($input->{'type'}) ? MyClassEnsureArgs1Alternative1Type::from($input->{'type'}) : null;
+        $type = isset($input->{'type'}) ? (MyClassEnsureArgs1Alternative1Type::from($input->{'type'})) : null;
 
         $obj = new self();
         $obj->type = $type;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassEnsureArgs3Item.php
@@ -105,7 +105,7 @@ class MyClassEnsureArgs3Item
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassTestObj.php
@@ -80,7 +80,7 @@ class MyClassTestObj
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -835,53 +835,53 @@ class MyClass
         $__providedOptionals = [];
         $foo = $input->{'foo'};
         $bar = $input->{'bar'};
-        $baz = isset($input->{'baz'}) ? MyClassBaz::buildFromInput($input->{'baz'}, $validate, $materializeDefaults) : null;
-        $quxObj = property_exists($input, 'quxObj') ? MyClassQuxObj::buildFromInput($input->{'quxObj'}, $validate, $materializeDefaults) : null;
+        $baz = isset($input->{'baz'}) ? (MyClassBaz::buildFromInput($input->{'baz'}, $validate, $materializeDefaults)) : null;
+        $quxObj = property_exists($input, 'quxObj') ? (($input->{'quxObj'} !== null) ? (MyClassQuxObj::buildFromInput($input->{'quxObj'}, $validate, $materializeDefaults)) : null) : null;
         if (property_exists($input, 'quxObj')) {
             $__providedOptionals['quxObj'] = true;
         }
-        $quxObjNest = property_exists($input, 'quxObjNest') ? MyClassQuxObjNest::buildFromInput($input->{'quxObjNest'}, $validate, $materializeDefaults) : null;
+        $quxObjNest = property_exists($input, 'quxObjNest') ? (($input->{'quxObjNest'} !== null) ? (MyClassQuxObjNest::buildFromInput($input->{'quxObjNest'}, $validate, $materializeDefaults)) : null) : null;
         if (property_exists($input, 'quxObjNest')) {
             $__providedOptionals['quxObjNest'] = true;
         }
-        $thudArray = property_exists($input, 'thudArray') ? $input->{'thudArray'} : null;
+        $thudArray = property_exists($input, 'thudArray') ? (($input->{'thudArray'} !== null) ? ($input->{'thudArray'}) : null) : null;
         if (property_exists($input, 'thudArray')) {
             $__providedOptionals['thudArray'] = true;
         }
-        $xyyz = isset($input->{'xyyz'}) ? match (true) {
+        $xyyz = isset($input->{'xyyz'}) ? (match (true) {
             is_string($input->{'xyyz'}),
             is_array($input->{'xyyz'}) => $input->{'xyyz'},
             ObjDef::validateInput($input->{'xyyz'}, true) => ObjDef::buildFromInput($input->{'xyyz'}, $validate, $materializeDefaults),
             default => null,
-        } : null;
-        $buux = isset($input->{'buux'}) ? match (true) {
+        }) : null;
+        $buux = isset($input->{'buux'}) ? (match (true) {
             is_string($input->{'buux'}),
             is_array($input->{'buux'}) => $input->{'buux'},
             ObjDef::validateInput($input->{'buux'}, true) => ObjDef::buildFromInput($input->{'buux'}, $validate, $materializeDefaults),
             default => null,
-        } : null;
-        $boic = isset($input->{'boic'}) ? match (true) {
+        }) : null;
+        $boic = isset($input->{'boic'}) ? (match (true) {
             is_string($input->{'boic'}),
             is_array($input->{'boic'}) => $input->{'boic'},
             ObjDef::validateInput($input->{'boic'}, true) => ObjDef::buildFromInput($input->{'boic'}, $validate, $materializeDefaults),
             default => null,
-        } : null;
-        $poox = isset($input->{'poox'}) ? match (true) {
+        }) : null;
+        $poox = isset($input->{'poox'}) ? (match (true) {
             is_string($input->{'poox'}) => $input->{'poox'},
             NumericKeysObj::validateInput($input->{'poox'}, true) => NumericKeysObj::buildFromInput($input->{'poox'}, $validate, $materializeDefaults),
             default => null,
-        } : null;
-        $arrObjUnion = isset($input->{'arrObjUnion'}) ? match (true) {
+        }) : null;
+        $arrObjUnion = isset($input->{'arrObjUnion'}) ? (match (true) {
             is_array($input->{'arrObjUnion'}),
             is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) => $input->{'arrObjUnion'},
             default => null,
-        } : null;
-        $objArrUnion = isset($input->{'objArrUnion'}) ? match (true) {
+        }) : null;
+        $objArrUnion = isset($input->{'objArrUnion'}) ? (match (true) {
             is_array($input->{'objArrUnion'}),
             is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) => $input->{'objArrUnion'},
             default => null,
-        } : null;
-        $numKeysDefaults = isset($input->{'numKeysDefaults'}) ? MyClassNumKeysDefaults::buildFromInput($input->{'numKeysDefaults'}, $validate, $materializeDefaults) : null;
+        }) : null;
+        $numKeysDefaults = isset($input->{'numKeysDefaults'}) ? (MyClassNumKeysDefaults::buildFromInput($input->{'numKeysDefaults'}, $validate, $materializeDefaults)) : null;
 
         $obj = new self($foo, $bar);
         $obj->baz = $baz;
@@ -914,19 +914,13 @@ class MyClass
             $output['baz'] = ($this->baz)->toArray($includeDefaults);
         }
         if (isset($this->quxObj) || array_key_exists('quxObj', $this->_providedOptionals)) {
-            if (isset($this->quxObj)) {
-                $output['quxObj'] = ($this->quxObj)->toArray($includeDefaults);
-            }
+            $output['quxObj'] = ($this->quxObj !== null) ? (($this->quxObj !== null) ? (($this->quxObj)->toArray($includeDefaults)) : null) : null;
         }
         if (isset($this->quxObjNest) || array_key_exists('quxObjNest', $this->_providedOptionals)) {
-            if (isset($this->quxObjNest)) {
-                $output['quxObjNest'] = ($this->quxObjNest)->toArray($includeDefaults);
-            }
+            $output['quxObjNest'] = ($this->quxObjNest !== null) ? (($this->quxObjNest !== null) ? (($this->quxObjNest)->toArray($includeDefaults)) : null) : null;
         }
         if (isset($this->thudArray) || array_key_exists('thudArray', $this->_providedOptionals)) {
-            if (isset($this->thudArray)) {
-                $output['thudArray'] = $this->thudArray;
-            }
+            $output['thudArray'] = ($this->thudArray !== null) ? (($this->thudArray !== null) ? ($this->thudArray) : null) : null;
         }
         if (isset($this->xyyz)) {
             $output['xyyz'] = match (true) {
@@ -997,19 +991,13 @@ class MyClass
             $output->{'baz'} = ($this->baz)->toStdClass($includeDefaults);
         }
         if (isset($this->quxObj) || array_key_exists('quxObj', $this->_providedOptionals)) {
-            if (isset($this->quxObj)) {
-                $output->{'quxObj'} = ($this->quxObj)->toStdClass($includeDefaults);
-            }
+            $output->{'quxObj'} = ($this->quxObj !== null) ? (($this->quxObj !== null) ? (($this->quxObj)->toStdClass($includeDefaults)) : null) : null;
         }
         if (isset($this->quxObjNest) || array_key_exists('quxObjNest', $this->_providedOptionals)) {
-            if (isset($this->quxObjNest)) {
-                $output->{'quxObjNest'} = ($this->quxObjNest)->toStdClass($includeDefaults);
-            }
+            $output->{'quxObjNest'} = ($this->quxObjNest !== null) ? (($this->quxObjNest !== null) ? (($this->quxObjNest)->toStdClass($includeDefaults)) : null) : null;
         }
         if (isset($this->thudArray) || array_key_exists('thudArray', $this->_providedOptionals)) {
-            if (isset($this->thudArray)) {
-                $output->{'thudArray'} = $this->thudArray;
-            }
+            $output->{'thudArray'} = ($this->thudArray !== null) ? (($this->thudArray !== null) ? ($this->thudArray) : null) : null;
         }
         if (isset($this->xyyz)) {
             $output->{'xyyz'} = match (true) {

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassNumKeysDefaults.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassNumKeysDefaults.php
@@ -256,9 +256,9 @@ class MyClassNumKeysDefaults
             static::validateInput($input);
         }
 
-        $_0 = isset($input->{'0'}) ? $input->{'0'} : null;
-        $_1 = isset($input->{'1'}) ? $input->{'1'} : null;
-        $_2 = isset($input->{'2'}) ? $input->{'2'} : null;
+        $_0 = isset($input->{'0'}) ? ($input->{'0'}) : null;
+        $_1 = isset($input->{'1'}) ? ($input->{'1'}) : null;
+        $_2 = isset($input->{'2'}) ? ($input->{'2'}) : null;
 
         $obj = new self();
         $obj->_0 = $_0;

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObj.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObj.php
@@ -130,7 +130,7 @@ class MyClassQuxObj
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObjNest.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObjNest.php
@@ -161,7 +161,7 @@ class MyClassQuxObjNest
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/NumericKeysObj.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/NumericKeysObj.php
@@ -181,9 +181,9 @@ class NumericKeysObj
             static::validateInput($input);
         }
 
-        $_0 = isset($input->{'0'}) ? $input->{'0'} : null;
-        $_1 = isset($input->{'1'}) ? $input->{'1'} : null;
-        $_2 = isset($input->{'2'}) ? $input->{'2'} : null;
+        $_0 = isset($input->{'0'}) ? ($input->{'0'}) : null;
+        $_1 = isset($input->{'1'}) ? ($input->{'1'}) : null;
+        $_2 = isset($input->{'2'}) ? ($input->{'2'}) : null;
 
         $obj = new self();
         $obj->_0 = $_0;

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/ObjDef.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/ObjDef.php
@@ -87,7 +87,7 @@ class ObjDef
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/MutableSetters/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-5.6/Baz.php
@@ -69,7 +69,7 @@ class Baz
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/MutableSetters/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-5.6/MyClass.php
@@ -167,9 +167,9 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
         $bar = Baz::buildFromInput($input->{'bar'}, $validate);
-        $opt = property_exists($input, 'opt') ? $input->{'opt'} : null;
+        $opt = property_exists($input, 'opt') ? (($input->{'opt'} !== null) ? ($input->{'opt'}) : null) : null;
         if (property_exists($input, 'opt')) {
             $__providedOptionals['opt'] = true;
         }
@@ -194,7 +194,7 @@ class MyClass
         }
         $output['bar'] = $this->bar->toArray();
         if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
-            $output['opt'] = $this->opt;
+            $output['opt'] = ($this->opt !== null) ? ($this->opt) : null;
         }
 
         return $output;
@@ -213,7 +213,7 @@ class MyClass
         }
         $output->{'bar'} = $this->bar->toStdClass();
         if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
-            $output->{'opt'} = $this->opt;
+            $output->{'opt'} = ($this->opt !== null) ? ($this->opt) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/MutableSetters/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-7.4/Baz.php
@@ -71,7 +71,7 @@ class Baz
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
@@ -169,9 +169,9 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
         $bar = Baz::buildFromInput($input->{'bar'}, $validate);
-        $opt = property_exists($input, 'opt') ? $input->{'opt'} : null;
+        $opt = property_exists($input, 'opt') ? (($input->{'opt'} !== null) ? ($input->{'opt'}) : null) : null;
         if (property_exists($input, 'opt')) {
             $__providedOptionals['opt'] = true;
         }
@@ -196,7 +196,7 @@ class MyClass
         }
         $output['bar'] = $this->bar->toArray();
         if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
-            $output['opt'] = $this->opt;
+            $output['opt'] = ($this->opt !== null) ? ($this->opt) : null;
         }
 
         return $output;
@@ -215,7 +215,7 @@ class MyClass
         }
         $output->{'bar'} = $this->bar->toStdClass();
         if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
-            $output->{'opt'} = $this->opt;
+            $output->{'opt'} = ($this->opt !== null) ? ($this->opt) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/MutableSetters/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-8.4/Baz.php
@@ -65,7 +65,7 @@ class Baz
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
@@ -163,9 +163,9 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
         $bar = Baz::buildFromInput($input->{'bar'}, $validate);
-        $opt = property_exists($input, 'opt') ? $input->{'opt'} : null;
+        $opt = property_exists($input, 'opt') ? (($input->{'opt'} !== null) ? ($input->{'opt'}) : null) : null;
         if (property_exists($input, 'opt')) {
             $__providedOptionals['opt'] = true;
         }
@@ -190,7 +190,7 @@ class MyClass
         }
         $output['bar'] = $this->bar->toArray();
         if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
-            $output['opt'] = $this->opt;
+            $output['opt'] = ($this->opt !== null) ? ($this->opt) : null;
         }
 
         return $output;
@@ -209,7 +209,7 @@ class MyClass
         }
         $output->{'bar'} = $this->bar->toStdClass();
         if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
-            $output->{'opt'} = $this->opt;
+            $output->{'opt'} = ($this->opt !== null) ? ($this->opt) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/Baz.php
@@ -72,7 +72,7 @@ class Baz
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/MyClass.php
@@ -178,9 +178,9 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
         $bar = Baz::buildFromInput($input->{'bar'}, $validate);
-        $opt = property_exists($input, 'opt') ? $input->{'opt'} : null;
+        $opt = property_exists($input, 'opt') ? (($input->{'opt'} !== null) ? ($input->{'opt'}) : null) : null;
         if (property_exists($input, 'opt')) {
             $__providedOptionals['opt'] = true;
         }
@@ -205,7 +205,7 @@ class MyClass
         }
         $output['bar'] = $this->bar->toArray();
         if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
-            $output['opt'] = $this->opt;
+            $output['opt'] = ($this->opt !== null) ? ($this->opt) : null;
         }
 
         return $output;
@@ -224,7 +224,7 @@ class MyClass
         }
         $output->{'bar'} = $this->bar->toStdClass();
         if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
-            $output->{'opt'} = $this->opt;
+            $output->{'opt'} = ($this->opt !== null) ? ($this->opt) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/Baz.php
@@ -74,7 +74,7 @@ class Baz
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
@@ -180,9 +180,9 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
         $bar = Baz::buildFromInput($input->{'bar'}, $validate);
-        $opt = property_exists($input, 'opt') ? $input->{'opt'} : null;
+        $opt = property_exists($input, 'opt') ? (($input->{'opt'} !== null) ? ($input->{'opt'}) : null) : null;
         if (property_exists($input, 'opt')) {
             $__providedOptionals['opt'] = true;
         }
@@ -207,7 +207,7 @@ class MyClass
         }
         $output['bar'] = $this->bar->toArray();
         if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
-            $output['opt'] = $this->opt;
+            $output['opt'] = ($this->opt !== null) ? ($this->opt) : null;
         }
 
         return $output;
@@ -226,7 +226,7 @@ class MyClass
         }
         $output->{'bar'} = $this->bar->toStdClass();
         if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
-            $output->{'opt'} = $this->opt;
+            $output->{'opt'} = ($this->opt !== null) ? ($this->opt) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/Baz.php
@@ -68,7 +68,7 @@ class Baz
             static::validateInput($input);
         }
 
-        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+        $name = isset($input->{'name'}) ? ($input->{'name'}) : null;
 
         $obj = new self();
         $obj->name = $name;

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
@@ -174,9 +174,9 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
         $bar = Baz::buildFromInput($input->{'bar'}, $validate);
-        $opt = property_exists($input, 'opt') ? $input->{'opt'} : null;
+        $opt = property_exists($input, 'opt') ? (($input->{'opt'} !== null) ? ($input->{'opt'}) : null) : null;
         if (property_exists($input, 'opt')) {
             $__providedOptionals['opt'] = true;
         }
@@ -201,7 +201,7 @@ class MyClass
         }
         $output['bar'] = $this->bar->toArray();
         if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
-            $output['opt'] = $this->opt;
+            $output['opt'] = ($this->opt !== null) ? ($this->opt) : null;
         }
 
         return $output;
@@ -220,7 +220,7 @@ class MyClass
         }
         $output->{'bar'} = $this->bar->toStdClass();
         if (isset($this->opt) || array_key_exists('opt', $this->_providedOptionals)) {
-            $output->{'opt'} = $this->opt;
+            $output->{'opt'} = ($this->opt !== null) ? ($this->opt) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
@@ -141,8 +141,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $files = isset($input->{'files'}) ? array_map(function($i) use ($validate) { return MyClassFilesItem::buildFromInput($i, $validate); }, $input->{'files'}) : null;
-        $options = isset($input->{'options'}) ? OptionsObject::buildFromInput($input->{'options'}, $validate) : null;
+        $files = isset($input->{'files'}) ? (array_map(function($i) use ($validate) { return MyClassFilesItem::buildFromInput($i, $validate); }, $input->{'files'})) : null;
+        $options = isset($input->{'options'}) ? (OptionsObject::buildFromInput($input->{'options'}, $validate)) : null;
 
         $obj = new self();
         $obj->files = $files;

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClassFilesItem.php
@@ -134,8 +134,8 @@ class MyClassFilesItem
             static::validateInput($_input);
         }
 
-        $input = isset($_input->{'input'}) ? $_input->{'input'} : null;
-        $options = isset($_input->{'options'}) ? OptionsObject::buildFromInput($_input->{'options'}, $validate) : null;
+        $input = isset($_input->{'input'}) ? ($_input->{'input'}) : null;
+        $options = isset($_input->{'options'}) ? (OptionsObject::buildFromInput($_input->{'options'}, $validate)) : null;
 
         $obj = new self();
         $obj->input = $input;

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/OptionsObject.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/OptionsObject.php
@@ -83,7 +83,7 @@ class OptionsObject
             static::validateInput($input);
         }
 
-        $output = isset($input->{'output'}) ? $input->{'output'} : null;
+        $output = isset($input->{'output'}) ? ($input->{'output'}) : null;
 
         $obj = new self();
         $obj->output = $output;

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
@@ -143,8 +143,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $files = isset($input->{'files'}) ? array_map(fn ($i): MyClassFilesItem => MyClassFilesItem::buildFromInput($i, $validate), $input->{'files'}) : null;
-        $options = isset($input->{'options'}) ? OptionsObject::buildFromInput($input->{'options'}, $validate) : null;
+        $files = isset($input->{'files'}) ? (array_map(fn ($i): MyClassFilesItem => MyClassFilesItem::buildFromInput($i, $validate), $input->{'files'})) : null;
+        $options = isset($input->{'options'}) ? (OptionsObject::buildFromInput($input->{'options'}, $validate)) : null;
 
         $obj = new self();
         $obj->files = $files;

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
@@ -136,8 +136,8 @@ class MyClassFilesItem
             static::validateInput($_input);
         }
 
-        $input = isset($_input->{'input'}) ? $_input->{'input'} : null;
-        $options = isset($_input->{'options'}) ? OptionsObject::buildFromInput($_input->{'options'}, $validate) : null;
+        $input = isset($_input->{'input'}) ? ($_input->{'input'}) : null;
+        $options = isset($_input->{'options'}) ? (OptionsObject::buildFromInput($_input->{'options'}, $validate)) : null;
 
         $obj = new self();
         $obj->input = $input;

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/OptionsObject.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/OptionsObject.php
@@ -85,7 +85,7 @@ class OptionsObject
             static::validateInput($input);
         }
 
-        $output = isset($input->{'output'}) ? $input->{'output'} : null;
+        $output = isset($input->{'output'}) ? ($input->{'output'}) : null;
 
         $obj = new self();
         $obj->output = $output;

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
@@ -137,8 +137,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $files = isset($input->{'files'}) ? array_map(fn (array|object $i): MyClassFilesItem => MyClassFilesItem::buildFromInput($i, $validate), $input->{'files'}) : null;
-        $options = isset($input->{'options'}) ? OptionsObject::buildFromInput($input->{'options'}, $validate) : null;
+        $files = isset($input->{'files'}) ? (array_map(fn (array|object $i): MyClassFilesItem => MyClassFilesItem::buildFromInput($i, $validate), $input->{'files'})) : null;
+        $options = isset($input->{'options'}) ? (OptionsObject::buildFromInput($input->{'options'}, $validate)) : null;
 
         $obj = new self();
         $obj->files = $files;

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
@@ -130,8 +130,8 @@ class MyClassFilesItem
             static::validateInput($_input);
         }
 
-        $input = isset($_input->{'input'}) ? $_input->{'input'} : null;
-        $options = isset($_input->{'options'}) ? OptionsObject::buildFromInput($_input->{'options'}, $validate) : null;
+        $input = isset($_input->{'input'}) ? ($_input->{'input'}) : null;
+        $options = isset($_input->{'options'}) ? (OptionsObject::buildFromInput($_input->{'options'}, $validate)) : null;
 
         $obj = new self();
         $obj->input = $input;

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/OptionsObject.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/OptionsObject.php
@@ -79,7 +79,7 @@ class OptionsObject
             static::validateInput($input);
         }
 
-        $output = isset($input->{'output'}) ? $input->{'output'} : null;
+        $output = isset($input->{'output'}) ? ($input->{'output'}) : null;
 
         $obj = new self();
         $obj->output = $output;

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Fio.php
@@ -97,7 +97,7 @@ class Fio
         }
 
         $__providedOptionals = [];
-        $bar = property_exists($input, 'bar') ? $input->{'bar'} : null;
+        $bar = property_exists($input, 'bar') ? (($input->{'bar'} !== null) ? ($input->{'bar'}) : null) : null;
         if (property_exists($input, 'bar')) {
             $__providedOptionals['bar'] = true;
         }
@@ -117,7 +117,7 @@ class Fio
     {
         $output = [];
         if (isset($this->bar) || array_key_exists('bar', $this->_providedOptionals)) {
-            $output['bar'] = $this->bar;
+            $output['bar'] = ($this->bar !== null) ? ($this->bar) : null;
         }
 
         return $output;
@@ -132,7 +132,7 @@ class Fio
     {
         $output = new \stdClass();
         if (isset($this->bar) || array_key_exists('bar', $this->_providedOptionals)) {
-            $output->{'bar'} = $this->bar;
+            $output->{'bar'} = ($this->bar !== null) ? ($this->bar) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Phone.php
@@ -84,7 +84,7 @@ class Phone
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Record.php
@@ -289,16 +289,16 @@ class Record
             static::validateInput($input);
         }
 
-        $dataArray = isset($input->{'dataArray'}) ? array_map(
+        $dataArray = isset($input->{'dataArray'}) ? (array_map(
             fn($i) => Phone::buildFromInput($i, $validate),
             $input->{'dataArray'}
-        ) : null;
-        $dataArrayNested = isset($input->{'dataArrayNested'}) ? array_map(function($i) use ($validate) { return array_map(
+        )) : null;
+        $dataArrayNested = isset($input->{'dataArrayNested'}) ? (array_map(function($i) use ($validate) { return array_map(
             fn($i) => Phone::buildFromInput($i, $validate),
             $i
-        ); }, $input->{'dataArrayNested'}) : null;
-        $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'}) ? array_map(function($i) use ($validate) { return (Fio::validateInput($i, true)) ? (Fio::buildFromInput($i, $validate)) : ((Phone::validateInput($i, true)) ? (Phone::buildFromInput($i, $validate)) : (null)); }, $input->{'dataArrayAnyOf'}) : null;
-        $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'}) ? array_map(function($i) use ($validate) { return array_map(function($i) use ($validate) { return (Fio::validateInput($i, true)) ? (Fio::buildFromInput($i, $validate)) : ((Phone::validateInput($i, true)) ? (Phone::buildFromInput($i, $validate)) : (null)); }, $i); }, $input->{'dataArrayNestedAnyOf'}) : null;
+        ); }, $input->{'dataArrayNested'})) : null;
+        $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'}) ? (array_map(function($i) use ($validate) { return (Fio::validateInput($i, true)) ? (Fio::buildFromInput($i, $validate)) : ((Phone::validateInput($i, true)) ? (Phone::buildFromInput($i, $validate)) : (null)); }, $input->{'dataArrayAnyOf'})) : null;
+        $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'}) ? (array_map(function($i) use ($validate) { return array_map(function($i) use ($validate) { return (Fio::validateInput($i, true)) ? (Fio::buildFromInput($i, $validate)) : ((Phone::validateInput($i, true)) ? (Phone::buildFromInput($i, $validate)) : (null)); }, $i); }, $input->{'dataArrayNestedAnyOf'})) : null;
 
         $obj = new self();
         $obj->dataArray = $dataArray;

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Fio.php
@@ -99,7 +99,7 @@ class Fio
         }
 
         $__providedOptionals = [];
-        $bar = property_exists($input, 'bar') ? $input->{'bar'} : null;
+        $bar = property_exists($input, 'bar') ? (($input->{'bar'} !== null) ? ($input->{'bar'}) : null) : null;
         if (property_exists($input, 'bar')) {
             $__providedOptionals['bar'] = true;
         }
@@ -119,7 +119,7 @@ class Fio
     {
         $output = [];
         if (isset($this->bar) || array_key_exists('bar', $this->_providedOptionals)) {
-            $output['bar'] = $this->bar;
+            $output['bar'] = ($this->bar !== null) ? ($this->bar) : null;
         }
 
         return $output;
@@ -134,7 +134,7 @@ class Fio
     {
         $output = new \stdClass();
         if (isset($this->bar) || array_key_exists('bar', $this->_providedOptionals)) {
-            $output->{'bar'} = $this->bar;
+            $output->{'bar'} = ($this->bar !== null) ? ($this->bar) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Phone.php
@@ -86,7 +86,7 @@ class Phone
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Record.php
@@ -291,16 +291,16 @@ class Record
             static::validateInput($input);
         }
 
-        $dataArray = isset($input->{'dataArray'}) ? array_map(
+        $dataArray = isset($input->{'dataArray'}) ? (array_map(
             fn($i) => Phone::buildFromInput($i, $validate),
             $input->{'dataArray'}
-        ) : null;
-        $dataArrayNested = isset($input->{'dataArrayNested'}) ? array_map(fn($i) => array_map(
+        )) : null;
+        $dataArrayNested = isset($input->{'dataArrayNested'}) ? (array_map(fn($i) => array_map(
             fn($i) => Phone::buildFromInput($i, $validate),
             $i
-        ), $input->{'dataArrayNested'}) : null;
-        $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'}) ? array_map(fn($i) => (Fio::validateInput($i, true)) ? (Fio::buildFromInput($i, $validate)) : ((Phone::validateInput($i, true)) ? (Phone::buildFromInput($i, $validate)) : (null)), $input->{'dataArrayAnyOf'}) : null;
-        $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'}) ? array_map(fn($i) => array_map(fn($i) => (Fio::validateInput($i, true)) ? (Fio::buildFromInput($i, $validate)) : ((Phone::validateInput($i, true)) ? (Phone::buildFromInput($i, $validate)) : (null)), $i), $input->{'dataArrayNestedAnyOf'}) : null;
+        ), $input->{'dataArrayNested'})) : null;
+        $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'}) ? (array_map(fn($i) => (Fio::validateInput($i, true)) ? (Fio::buildFromInput($i, $validate)) : ((Phone::validateInput($i, true)) ? (Phone::buildFromInput($i, $validate)) : (null)), $input->{'dataArrayAnyOf'})) : null;
+        $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'}) ? (array_map(fn($i) => array_map(fn($i) => (Fio::validateInput($i, true)) ? (Fio::buildFromInput($i, $validate)) : ((Phone::validateInput($i, true)) ? (Phone::buildFromInput($i, $validate)) : (null)), $i), $input->{'dataArrayNestedAnyOf'})) : null;
 
         $obj = new self();
         $obj->dataArray = $dataArray;

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Fio.php
@@ -93,7 +93,7 @@ class Fio
         }
 
         $__providedOptionals = [];
-        $bar = property_exists($input, 'bar') ? $input->{'bar'} : null;
+        $bar = property_exists($input, 'bar') ? (($input->{'bar'} !== null) ? ($input->{'bar'}) : null) : null;
         if (property_exists($input, 'bar')) {
             $__providedOptionals['bar'] = true;
         }
@@ -113,7 +113,7 @@ class Fio
     {
         $output = [];
         if (isset($this->bar) || array_key_exists('bar', $this->_providedOptionals)) {
-            $output['bar'] = $this->bar;
+            $output['bar'] = ($this->bar !== null) ? ($this->bar) : null;
         }
 
         return $output;
@@ -128,7 +128,7 @@ class Fio
     {
         $output = new \stdClass();
         if (isset($this->bar) || array_key_exists('bar', $this->_providedOptionals)) {
-            $output->{'bar'} = $this->bar;
+            $output->{'bar'} = ($this->bar !== null) ? ($this->bar) : null;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Phone.php
@@ -80,7 +80,7 @@ class Phone
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Record.php
@@ -285,24 +285,24 @@ class Record
             static::validateInput($input);
         }
 
-        $dataArray = isset($input->{'dataArray'}) ? array_map(
+        $dataArray = isset($input->{'dataArray'}) ? (array_map(
             fn(array|object $i): Phone => Phone::buildFromInput($i, $validate),
             $input->{'dataArray'}
-        ) : null;
-        $dataArrayNested = isset($input->{'dataArrayNested'}) ? array_map(fn($i) => array_map(
+        )) : null;
+        $dataArrayNested = isset($input->{'dataArrayNested'}) ? (array_map(fn($i) => array_map(
             fn(array|object $i): Phone => Phone::buildFromInput($i, $validate),
             $i
-        ), $input->{'dataArrayNested'}) : null;
-        $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'}) ? array_map(fn($i) => match (true) {
+        ), $input->{'dataArrayNested'})) : null;
+        $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'}) ? (array_map(fn($i) => match (true) {
             Phone::validateInput($i, true) => Phone::buildFromInput($i, $validate),
             Fio::validateInput($i, true) => Fio::buildFromInput($i, $validate),
             default => null,
-        }, $input->{'dataArrayAnyOf'}) : null;
-        $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'}) ? array_map(fn($i) => array_map(fn($i) => match (true) {
+        }, $input->{'dataArrayAnyOf'})) : null;
+        $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'}) ? (array_map(fn($i) => array_map(fn($i) => match (true) {
             Phone::validateInput($i, true) => Phone::buildFromInput($i, $validate),
             Fio::validateInput($i, true) => Fio::buildFromInput($i, $validate),
             default => null,
-        }, $i), $input->{'dataArrayNestedAnyOf'}) : null;
+        }, $i), $input->{'dataArrayNestedAnyOf'})) : null;
 
         $obj = new self();
         $obj->dataArray = $dataArray;

--- a/tests/Generator/Fixtures/NoSchemaMetadata/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NoSchemaMetadata/Output-5.6/MyClass.php
@@ -143,7 +143,7 @@ class MyClass
         }
 
         $foo = $input->{'foo'};
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
 
         $obj = new self($foo);
         $obj->bar = $bar;

--- a/tests/Generator/Fixtures/NoSchemaMetadata/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoSchemaMetadata/Output-7.4/MyClass.php
@@ -145,7 +145,7 @@ class MyClass
         }
 
         $foo = $input->{'foo'};
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
 
         $obj = new self($foo);
         $obj->bar = $bar;

--- a/tests/Generator/Fixtures/NoSchemaMetadata/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoSchemaMetadata/Output-8.4/MyClass.php
@@ -139,7 +139,7 @@ class MyClass
         }
 
         $foo = $input->{'foo'};
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
 
         $obj = new self($foo);
         $obj->bar = $bar;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Bar.php
@@ -91,7 +91,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->b = $b;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
@@ -111,7 +111,7 @@ class Baz
             static::validateInput($input);
         }
 
-        $grox = isset($input->{'grox'}) ? (Bar::validateInput($input->{'grox'}, true)) ? (Bar::buildFromInput($input->{'grox'}, $validate)) : ((Foo::validateInput($input->{'grox'}, true)) ? (Foo::buildFromInput($input->{'grox'}, $validate)) : (null)) : null;
+        $grox = isset($input->{'grox'}) ? ((Bar::validateInput($input->{'grox'}, true)) ? (Bar::buildFromInput($input->{'grox'}, $validate)) : ((Foo::validateInput($input->{'grox'}, true)) ? (Foo::buildFromInput($input->{'grox'}, $validate)) : (null))) : null;
 
         $obj = new self();
         $obj->grox = $grox;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Foo.php
@@ -89,7 +89,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -124,7 +124,7 @@ class Qux
             static::validateInput($input);
         }
 
-        $grox = isset($input->{'grox'}) ? ((Foo::validateInput($input->{'grox'}, true)) || (Bar::validateInput($input->{'grox'}, true))) ? ((Bar::validateInput($input->{'grox'}, true)) ? (Bar::buildFromInput($input->{'grox'}, $validate)) : ((Foo::validateInput($input->{'grox'}, true)) ? (Foo::buildFromInput($input->{'grox'}, $validate)) : (null))) : ((is_array($input->{'grox'})) ? ($input->{'grox'}) : ((is_string($input->{'grox'})) ? ($input->{'grox'}) : (null))) : null;
+        $grox = isset($input->{'grox'}) ? (((Foo::validateInput($input->{'grox'}, true)) || (Bar::validateInput($input->{'grox'}, true))) ? ((Bar::validateInput($input->{'grox'}, true)) ? (Bar::buildFromInput($input->{'grox'}, $validate)) : ((Foo::validateInput($input->{'grox'}, true)) ? (Foo::buildFromInput($input->{'grox'}, $validate)) : (null))) : ((is_array($input->{'grox'})) ? ($input->{'grox'}) : ((is_string($input->{'grox'})) ? ($input->{'grox'}) : (null)))) : null;
 
         $obj = new self();
         $obj->grox = $grox;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Bar.php
@@ -93,7 +93,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->b = $b;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -113,7 +113,7 @@ class Baz
             static::validateInput($input);
         }
 
-        $grox = isset($input->{'grox'}) ? (Bar::validateInput($input->{'grox'}, true)) ? (Bar::buildFromInput($input->{'grox'}, $validate)) : ((Foo::validateInput($input->{'grox'}, true)) ? (Foo::buildFromInput($input->{'grox'}, $validate)) : (null)) : null;
+        $grox = isset($input->{'grox'}) ? ((Bar::validateInput($input->{'grox'}, true)) ? (Bar::buildFromInput($input->{'grox'}, $validate)) : ((Foo::validateInput($input->{'grox'}, true)) ? (Foo::buildFromInput($input->{'grox'}, $validate)) : (null))) : null;
 
         $obj = new self();
         $obj->grox = $grox;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Foo.php
@@ -91,7 +91,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -126,7 +126,7 @@ class Qux
             static::validateInput($input);
         }
 
-        $grox = isset($input->{'grox'}) ? ((Foo::validateInput($input->{'grox'}, true)) || (Bar::validateInput($input->{'grox'}, true))) ? ((Bar::validateInput($input->{'grox'}, true)) ? (Bar::buildFromInput($input->{'grox'}, $validate)) : ((Foo::validateInput($input->{'grox'}, true)) ? (Foo::buildFromInput($input->{'grox'}, $validate)) : (null))) : ((is_array($input->{'grox'})) ? ($input->{'grox'}) : ((is_string($input->{'grox'})) ? ($input->{'grox'}) : (null))) : null;
+        $grox = isset($input->{'grox'}) ? (((Foo::validateInput($input->{'grox'}, true)) || (Bar::validateInput($input->{'grox'}, true))) ? ((Bar::validateInput($input->{'grox'}, true)) ? (Bar::buildFromInput($input->{'grox'}, $validate)) : ((Foo::validateInput($input->{'grox'}, true)) ? (Foo::buildFromInput($input->{'grox'}, $validate)) : (null))) : ((is_array($input->{'grox'})) ? ($input->{'grox'}) : ((is_string($input->{'grox'})) ? ($input->{'grox'}) : (null)))) : null;
 
         $obj = new self();
         $obj->grox = $grox;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Bar.php
@@ -87,7 +87,7 @@ class Bar
             static::validateInput($input);
         }
 
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->b = $b;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
@@ -107,11 +107,11 @@ class Baz
             static::validateInput($input);
         }
 
-        $grox = isset($input->{'grox'}) ? match (true) {
+        $grox = isset($input->{'grox'}) ? (match (true) {
             Foo::validateInput($input->{'grox'}, true) => Foo::buildFromInput($input->{'grox'}, $validate),
             Bar::validateInput($input->{'grox'}, true) => Bar::buildFromInput($input->{'grox'}, $validate),
             default => null,
-        } : null;
+        }) : null;
 
         $obj = new self();
         $obj->grox = $grox;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Foo.php
@@ -85,7 +85,7 @@ class Foo
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
@@ -120,7 +120,7 @@ class Qux
             static::validateInput($input);
         }
 
-        $grox = isset($input->{'grox'}) ? match (true) {
+        $grox = isset($input->{'grox'}) ? (match (true) {
             is_string($input->{'grox'}),
             is_array($input->{'grox'}) => $input->{'grox'},
             (Foo::validateInput($input->{'grox'}, true)) || (Bar::validateInput($input->{'grox'}, true)) => match (true) {
@@ -129,7 +129,7 @@ class Qux
             default => null,
         },
             default => null,
-        } : null;
+        }) : null;
 
         $obj = new self();
         $obj->grox = $grox;

--- a/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass.php
@@ -130,8 +130,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $_1 = isset($input->{'1'}) ? $input->{'1'} : null;
-        $_2 = isset($input->{'2'}) ? MyClass_2::buildFromInput($input->{'2'}, $validate) : null;
+        $_1 = isset($input->{'1'}) ? ($input->{'1'}) : null;
+        $_2 = isset($input->{'2'}) ? (MyClass_2::buildFromInput($input->{'2'}, $validate)) : null;
 
         $obj = new self();
         $obj->_1 = $_1;

--- a/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass_2.php
+++ b/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass_2.php
@@ -176,9 +176,9 @@ class MyClass_2
             static::validateInput($input);
         }
 
-        $_1 = isset($input->{'1'}) ? $input->{'1'} : null;
-        $_2 = isset($input->{'2'}) ? $input->{'2'} : null;
-        $_3 = isset($input->{'3'}) ? $input->{'3'} : null;
+        $_1 = isset($input->{'1'}) ? ($input->{'1'}) : null;
+        $_2 = isset($input->{'2'}) ? ($input->{'2'}) : null;
+        $_3 = isset($input->{'3'}) ? ($input->{'3'}) : null;
 
         $obj = new self();
         $obj->_1 = $_1;

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-5.6/MyClass.php
@@ -131,7 +131,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
         $bar = $input->{'bar'};
 
         $obj = new self($bar);

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-7.4/MyClass.php
@@ -133,7 +133,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
         $bar = $input->{'bar'};
 
         $obj = new self($bar);

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
@@ -127,7 +127,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
         $bar = $input->{'bar'};
 
         $obj = new self($bar);

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -120,7 +120,7 @@ class MyClass
         }
 
         $foo = $input->{'foo'};
-        $bar = isset($input->{'bar'}) ? (is_array($input->{'bar'}) || is_object($input->{'bar'})) ? ($input->{'bar'}) : ((is_string($input->{'bar'})) ? ($input->{'bar'}) : (null)) : null;
+        $bar = isset($input->{'bar'}) ? ((is_array($input->{'bar'}) || is_object($input->{'bar'})) ? ($input->{'bar'}) : ((is_string($input->{'bar'})) ? ($input->{'bar'}) : (null))) : null;
 
         $obj = new self($foo);
         $obj->bar = $bar;

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -122,7 +122,7 @@ class MyClass
         }
 
         $foo = $input->{'foo'};
-        $bar = isset($input->{'bar'}) ? (is_array($input->{'bar'}) || is_object($input->{'bar'})) ? ($input->{'bar'}) : ((is_string($input->{'bar'})) ? ($input->{'bar'}) : (null)) : null;
+        $bar = isset($input->{'bar'}) ? ((is_array($input->{'bar'}) || is_object($input->{'bar'})) ? ($input->{'bar'}) : ((is_string($input->{'bar'})) ? ($input->{'bar'}) : (null))) : null;
 
         $obj = new self($foo);
         $obj->bar = $bar;

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
@@ -120,11 +120,11 @@ class MyClass
             is_array($input->{'foo'}) || is_object($input->{'foo'}) => $input->{'foo'},
             default => throw new \InvalidArgumentException("could not build property 'foo' from JSON"),
         };
-        $bar = isset($input->{'bar'}) ? match (true) {
+        $bar = isset($input->{'bar'}) ? (match (true) {
             is_string($input->{'bar'}),
             is_array($input->{'bar'}) || is_object($input->{'bar'}) => $input->{'bar'},
             default => null,
-        } : null;
+        }) : null;
 
         $obj = new self($foo);
         $obj->bar = $bar;

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClass.php
@@ -585,23 +585,23 @@ class MyClass
 
         $__providedOptionals = [];
         $foo = $input->{'foo'};
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
-        $baz = property_exists($input, 'baz') ? $input->{'baz'} : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
+        $baz = property_exists($input, 'baz') ? (($input->{'baz'} !== null) ? ($input->{'baz'}) : null) : null;
         if (property_exists($input, 'baz')) {
             $__providedOptionals['baz'] = true;
         }
-        $qux = property_exists($input, 'qux') ? $input->{'qux'} : null;
+        $qux = property_exists($input, 'qux') ? (($input->{'qux'} !== null) ? ($input->{'qux'}) : null) : null;
         if (property_exists($input, 'qux')) {
             $__providedOptionals['qux'] = true;
         }
         $quux = $input->{'quux'};
-        $xyyz = isset($input->{'xyyz'}) ? $input->{'xyyz'} : null;
+        $xyyz = isset($input->{'xyyz'}) ? ($input->{'xyyz'}) : null;
         $thud = $input->{'thud'};
-        $grox = property_exists($input, 'grox') ? MyClassGrox::buildFromInput($input->{'grox'}, $validate, $materializeDefaults) : null;
+        $grox = property_exists($input, 'grox') ? (($input->{'grox'} !== null) ? (MyClassGrox::buildFromInput($input->{'grox'}, $validate, $materializeDefaults)) : null) : null;
         if (property_exists($input, 'grox')) {
             $__providedOptionals['grox'] = true;
         }
-        $gooks = property_exists($input, 'gooks') ? MyClassGooks::buildFromInput($input->{'gooks'}, $validate, $materializeDefaults) : null;
+        $gooks = property_exists($input, 'gooks') ? (($input->{'gooks'} !== null) ? (MyClassGooks::buildFromInput($input->{'gooks'}, $validate, $materializeDefaults)) : null) : null;
         if (property_exists($input, 'gooks')) {
             $__providedOptionals['gooks'] = true;
         }
@@ -631,10 +631,10 @@ class MyClass
             $output['bar'] = $this->bar;
         }
         if (isset($this->baz) || array_key_exists('baz', $this->_providedOptionals)) {
-            $output['baz'] = $this->baz;
+            $output['baz'] = ($this->baz !== null) ? ($this->baz) : null;
         }
         if (isset($this->qux) || array_key_exists('qux', $this->_providedOptionals)) {
-            $output['qux'] = $this->qux;
+            $output['qux'] = ($this->qux !== null) ? ($this->qux) : null;
         }
         $output['quux'] = $this->quux;
         if (isset($this->xyyz)) {
@@ -642,14 +642,10 @@ class MyClass
         }
         $output['thud'] = $this->thud;
         if (isset($this->grox) || array_key_exists('grox', $this->_providedOptionals)) {
-            if (isset($this->grox)) {
-                $output['grox'] = ($this->grox)->toArray($includeDefaults);
-            }
+            $output['grox'] = ($this->grox !== null) ? (($this->grox !== null) ? (($this->grox)->toArray($includeDefaults)) : null) : null;
         }
         if (isset($this->gooks) || array_key_exists('gooks', $this->_providedOptionals)) {
-            if (isset($this->gooks)) {
-                $output['gooks'] = ($this->gooks)->toArray($includeDefaults);
-            }
+            $output['gooks'] = ($this->gooks !== null) ? (($this->gooks !== null) ? (($this->gooks)->toArray($includeDefaults)) : null) : null;
         }
 
         if ($includeDefaults) {
@@ -677,10 +673,10 @@ class MyClass
             $output->{'bar'} = $this->bar;
         }
         if (isset($this->baz) || array_key_exists('baz', $this->_providedOptionals)) {
-            $output->{'baz'} = $this->baz;
+            $output->{'baz'} = ($this->baz !== null) ? ($this->baz) : null;
         }
         if (isset($this->qux) || array_key_exists('qux', $this->_providedOptionals)) {
-            $output->{'qux'} = $this->qux;
+            $output->{'qux'} = ($this->qux !== null) ? ($this->qux) : null;
         }
         $output->{'quux'} = $this->quux;
         if (isset($this->xyyz)) {
@@ -688,14 +684,10 @@ class MyClass
         }
         $output->{'thud'} = $this->thud;
         if (isset($this->grox) || array_key_exists('grox', $this->_providedOptionals)) {
-            if (isset($this->grox)) {
-                $output->{'grox'} = ($this->grox)->toStdClass($includeDefaults);
-            }
+            $output->{'grox'} = ($this->grox !== null) ? (($this->grox !== null) ? (($this->grox)->toStdClass($includeDefaults)) : null) : null;
         }
         if (isset($this->gooks) || array_key_exists('gooks', $this->_providedOptionals)) {
-            if (isset($this->gooks)) {
-                $output->{'gooks'} = ($this->gooks)->toStdClass($includeDefaults);
-            }
+            $output->{'gooks'} = ($this->gooks !== null) ? (($this->gooks !== null) ? (($this->gooks)->toStdClass($includeDefaults)) : null) : null;
         }
 
         if ($includeDefaults) {

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClassGooks.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClassGooks.php
@@ -139,8 +139,8 @@ class MyClassGooks
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClassGrox.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClassGrox.php
@@ -140,8 +140,8 @@ class MyClassGrox
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
@@ -581,23 +581,23 @@ class MyClass
 
         $__providedOptionals = [];
         $foo = $input->{'foo'};
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
-        $baz = property_exists($input, 'baz') ? $input->{'baz'} : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
+        $baz = property_exists($input, 'baz') ? (($input->{'baz'} !== null) ? ($input->{'baz'}) : null) : null;
         if (property_exists($input, 'baz')) {
             $__providedOptionals['baz'] = true;
         }
-        $qux = property_exists($input, 'qux') ? $input->{'qux'} : null;
+        $qux = property_exists($input, 'qux') ? (($input->{'qux'} !== null) ? ($input->{'qux'}) : null) : null;
         if (property_exists($input, 'qux')) {
             $__providedOptionals['qux'] = true;
         }
         $quux = $input->{'quux'};
-        $xyyz = isset($input->{'xyyz'}) ? $input->{'xyyz'} : null;
+        $xyyz = isset($input->{'xyyz'}) ? ($input->{'xyyz'}) : null;
         $thud = $input->{'thud'};
-        $grox = property_exists($input, 'grox') ? MyClassGrox::buildFromInput($input->{'grox'}, $validate, $materializeDefaults) : null;
+        $grox = property_exists($input, 'grox') ? (($input->{'grox'} !== null) ? (MyClassGrox::buildFromInput($input->{'grox'}, $validate, $materializeDefaults)) : null) : null;
         if (property_exists($input, 'grox')) {
             $__providedOptionals['grox'] = true;
         }
-        $gooks = property_exists($input, 'gooks') ? MyClassGooks::buildFromInput($input->{'gooks'}, $validate, $materializeDefaults) : null;
+        $gooks = property_exists($input, 'gooks') ? (($input->{'gooks'} !== null) ? (MyClassGooks::buildFromInput($input->{'gooks'}, $validate, $materializeDefaults)) : null) : null;
         if (property_exists($input, 'gooks')) {
             $__providedOptionals['gooks'] = true;
         }
@@ -627,10 +627,10 @@ class MyClass
             $output['bar'] = $this->bar;
         }
         if (isset($this->baz) || array_key_exists('baz', $this->_providedOptionals)) {
-            $output['baz'] = $this->baz;
+            $output['baz'] = ($this->baz !== null) ? ($this->baz) : null;
         }
         if (isset($this->qux) || array_key_exists('qux', $this->_providedOptionals)) {
-            $output['qux'] = $this->qux;
+            $output['qux'] = ($this->qux !== null) ? ($this->qux) : null;
         }
         $output['quux'] = $this->quux;
         if (isset($this->xyyz)) {
@@ -638,14 +638,10 @@ class MyClass
         }
         $output['thud'] = $this->thud;
         if (isset($this->grox) || array_key_exists('grox', $this->_providedOptionals)) {
-            if (isset($this->grox)) {
-                $output['grox'] = ($this->grox)->toArray($includeDefaults);
-            }
+            $output['grox'] = ($this->grox !== null) ? (($this->grox !== null) ? (($this->grox)->toArray($includeDefaults)) : null) : null;
         }
         if (isset($this->gooks) || array_key_exists('gooks', $this->_providedOptionals)) {
-            if (isset($this->gooks)) {
-                $output['gooks'] = ($this->gooks)->toArray($includeDefaults);
-            }
+            $output['gooks'] = ($this->gooks !== null) ? (($this->gooks !== null) ? (($this->gooks)->toArray($includeDefaults)) : null) : null;
         }
 
         if ($includeDefaults) {
@@ -673,10 +669,10 @@ class MyClass
             $output->{'bar'} = $this->bar;
         }
         if (isset($this->baz) || array_key_exists('baz', $this->_providedOptionals)) {
-            $output->{'baz'} = $this->baz;
+            $output->{'baz'} = ($this->baz !== null) ? ($this->baz) : null;
         }
         if (isset($this->qux) || array_key_exists('qux', $this->_providedOptionals)) {
-            $output->{'qux'} = $this->qux;
+            $output->{'qux'} = ($this->qux !== null) ? ($this->qux) : null;
         }
         $output->{'quux'} = $this->quux;
         if (isset($this->xyyz)) {
@@ -684,14 +680,10 @@ class MyClass
         }
         $output->{'thud'} = $this->thud;
         if (isset($this->grox) || array_key_exists('grox', $this->_providedOptionals)) {
-            if (isset($this->grox)) {
-                $output->{'grox'} = ($this->grox)->toStdClass($includeDefaults);
-            }
+            $output->{'grox'} = ($this->grox !== null) ? (($this->grox !== null) ? (($this->grox)->toStdClass($includeDefaults)) : null) : null;
         }
         if (isset($this->gooks) || array_key_exists('gooks', $this->_providedOptionals)) {
-            if (isset($this->gooks)) {
-                $output->{'gooks'} = ($this->gooks)->toStdClass($includeDefaults);
-            }
+            $output->{'gooks'} = ($this->gooks !== null) ? (($this->gooks !== null) ? (($this->gooks)->toStdClass($includeDefaults)) : null) : null;
         }
 
         if ($includeDefaults) {

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClassGooks.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClassGooks.php
@@ -135,8 +135,8 @@ class MyClassGooks
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClassGrox.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClassGrox.php
@@ -136,8 +136,8 @@ class MyClassGrox
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
-        $b = isset($input->{'b'}) ? $input->{'b'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
+        $b = isset($input->{'b'}) ? ($input->{'b'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-5.6/MyClass.php
@@ -706,7 +706,7 @@ class MyClass
         $nazvanie_iur_litsa = $input->{'название юр.лица'};
         $IP_adres = $input->{'IP-адрес'};
         $_tildas = $input->{'~~tildas~~'};
-        $it_s_A = isset($input->{'it\'s "A"'}) ? $input->{'it\'s "A"'} : null;
+        $it_s_A = isset($input->{'it\'s "A"'}) ? ($input->{'it\'s "A"'}) : null;
 
         $obj = new self($foo, $_foo, $__foo, $foo_, $foo__, $_foo_, $__foo__, $foo_bar, $_foo_bar, $baz_qux, $_123_qwe, $Gorod, $nazvanie_iur_litsa, $IP_adres, $_tildas);
         $obj->it_s_A = $it_s_A;

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-7.4/MyClass.php
@@ -708,7 +708,7 @@ class MyClass
         $nazvanie_iur_litsa = $input->{'название юр.лица'};
         $IP_adres = $input->{'IP-адрес'};
         $_tildas = $input->{'~~tildas~~'};
-        $it_s_A = isset($input->{'it\'s "A"'}) ? $input->{'it\'s "A"'} : null;
+        $it_s_A = isset($input->{'it\'s "A"'}) ? ($input->{'it\'s "A"'}) : null;
 
         $obj = new self($foo, $_foo, $__foo, $foo_, $foo__, $_foo_, $__foo__, $foo_bar, $_foo_bar, $baz_qux, $_123_qwe, $Gorod, $nazvanie_iur_litsa, $IP_adres, $_tildas);
         $obj->it_s_A = $it_s_A;

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-8.4/MyClass.php
@@ -702,7 +702,7 @@ class MyClass
         $nazvanie_iur_litsa = $input->{'название юр.лица'};
         $IP_adres = $input->{'IP-адрес'};
         $_tildas = $input->{'~~tildas~~'};
-        $it_s_A = isset($input->{'it\'s "A"'}) ? $input->{'it\'s "A"'} : null;
+        $it_s_A = isset($input->{'it\'s "A"'}) ? ($input->{'it\'s "A"'}) : null;
 
         $obj = new self($foo, $_foo, $__foo, $foo_, $foo__, $_foo_, $__foo__, $foo_bar, $_foo_bar, $baz_qux, $_123_qwe, $Gorod, $nazvanie_iur_litsa, $IP_adres, $_tildas);
         $obj->it_s_A = $it_s_A;

--- a/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumberField.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumberField.php
@@ -96,7 +96,7 @@ class MyGenericStringNumberField
             static::validateInput($input);
         }
 
-        $field = isset($input->{'field'}) ? MyGenericStringNumber::buildFromInput($input->{'field'}, $validate) : null;
+        $field = isset($input->{'field'}) ? (MyGenericStringNumber::buildFromInput($input->{'field'}, $validate)) : null;
 
         $obj = new self();
         $obj->field = $field;

--- a/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumberField.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumberField.php
@@ -98,7 +98,7 @@ class MyGenericStringNumberField
             static::validateInput($input);
         }
 
-        $field = isset($input->{'field'}) ? MyGenericStringNumber::buildFromInput($input->{'field'}, $validate) : null;
+        $field = isset($input->{'field'}) ? (MyGenericStringNumber::buildFromInput($input->{'field'}, $validate)) : null;
 
         $obj = new self();
         $obj->field = $field;

--- a/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumberField.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumberField.php
@@ -92,7 +92,7 @@ class MyGenericStringNumberField
             static::validateInput($input);
         }
 
-        $field = isset($input->{'field'}) ? MyGenericStringNumber::buildFromInput($input->{'field'}, $validate) : null;
+        $field = isset($input->{'field'}) ? (MyGenericStringNumber::buildFromInput($input->{'field'}, $validate)) : null;
 
         $obj = new self();
         $obj->field = $field;

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
@@ -131,7 +131,7 @@ class Cat
         }
 
         $__providedOptionals = [];
-        $hasFur = property_exists($input, 'hasFur') ? $input->{'hasFur'} : null;
+        $hasFur = property_exists($input, 'hasFur') ? (($input->{'hasFur'} !== null) ? ($input->{'hasFur'}) : null) : null;
         if (property_exists($input, 'hasFur')) {
             $__providedOptionals['hasFur'] = true;
         }
@@ -152,7 +152,7 @@ class Cat
     {
         $output = [];
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
-            $output['hasFur'] = $this->hasFur;
+            $output['hasFur'] = ($this->hasFur !== null) ? ($this->hasFur) : null;
         }
 
         if ($includeDefaults) {
@@ -176,7 +176,7 @@ class Cat
     {
         $output = new \stdClass();
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
-            $output->{'hasFur'} = $this->hasFur;
+            $output->{'hasFur'} = ($this->hasFur !== null) ? ($this->hasFur) : null;
         }
 
         if ($includeDefaults) {

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
@@ -129,7 +129,7 @@ class GenericPet
         }
 
         $__providedOptionals = [];
-        $hasFur = property_exists($input, 'hasFur') ? $input->{'hasFur'} : null;
+        $hasFur = property_exists($input, 'hasFur') ? (($input->{'hasFur'} !== null) ? ($input->{'hasFur'}) : null) : null;
         if (property_exists($input, 'hasFur')) {
             $__providedOptionals['hasFur'] = true;
         }
@@ -150,7 +150,7 @@ class GenericPet
     {
         $output = [];
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
-            $output['hasFur'] = $this->hasFur;
+            $output['hasFur'] = ($this->hasFur !== null) ? ($this->hasFur) : null;
         }
 
         if ($includeDefaults) {
@@ -174,7 +174,7 @@ class GenericPet
     {
         $output = new \stdClass();
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
-            $output->{'hasFur'} = $this->hasFur;
+            $output->{'hasFur'} = ($this->hasFur !== null) ? ($this->hasFur) : null;
         }
 
         if ($includeDefaults) {

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Pets.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Pets.php
@@ -138,8 +138,8 @@ class Pets
             static::validateInput($input);
         }
 
-        $pet = isset($input->{'pet'}) ? GenericPet::buildFromInput($input->{'pet'}, $validate) : null;
-        $cat = isset($input->{'cat'}) ? Cat::buildFromInput($input->{'cat'}, $validate) : null;
+        $pet = isset($input->{'pet'}) ? (GenericPet::buildFromInput($input->{'pet'}, $validate)) : null;
+        $cat = isset($input->{'cat'}) ? (Cat::buildFromInput($input->{'cat'}, $validate)) : null;
 
         $obj = new self();
         $obj->pet = $pet;

--- a/tests/Generator/Fixtures/RefList/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-5.6/MyClass.php
@@ -89,10 +89,10 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? array_map(
+        $foo = isset($input->{'foo'}) ? (array_map(
             fn($i) => \Helmich\Schema2Class\Example\CustomerAddress::buildFromInput($i, $validate),
             $input->{'foo'}
-        ) : null;
+        )) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/RefList/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-7.4/MyClass.php
@@ -91,10 +91,10 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? array_map(
+        $foo = isset($input->{'foo'}) ? (array_map(
             fn($i) => \Helmich\Schema2Class\Example\CustomerAddress::buildFromInput($i, $validate),
             $input->{'foo'}
-        ) : null;
+        )) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/RefList/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-8.4/MyClass.php
@@ -85,10 +85,10 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? array_map(
+        $foo = isset($input->{'foo'}) ? (array_map(
             fn(array|object $i): \Helmich\Schema2Class\Example\CustomerAddress => \Helmich\Schema2Class\Example\CustomerAddress::buildFromInput($i, $validate),
             $input->{'foo'}
-        ) : null;
+        )) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/SingleElemTypeArray/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/SingleElemTypeArray/Output-8.4/MyClass.php
@@ -391,16 +391,16 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
-        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
-        $baz = isset($input->{'baz'}) ? $input->{'baz'} : null;
-        $qux = isset($input->{'qux'}) ? $input->{'qux'} : null;
-        $grox = property_exists($input, 'grox') ? $input->{'grox'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
+        $bar = isset($input->{'bar'}) ? ($input->{'bar'}) : null;
+        $baz = isset($input->{'baz'}) ? ($input->{'baz'}) : null;
+        $qux = isset($input->{'qux'}) ? ($input->{'qux'}) : null;
+        $grox = property_exists($input, 'grox') ? (($input->{'grox'} !== null) ? ($input->{'grox'}) : null) : null;
         if (property_exists($input, 'grox')) {
             $__providedOptionals['grox'] = true;
         }
-        $quux = isset($input->{'quux'}) ? MyClassQuux::buildFromInput($input->{'quux'}, $validate) : null;
-        $thud = isset($input->{'thud'}) ? $input->{'thud'} : null;
+        $quux = isset($input->{'quux'}) ? (MyClassQuux::buildFromInput($input->{'quux'}, $validate)) : null;
+        $thud = isset($input->{'thud'}) ? ($input->{'thud'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;
@@ -435,7 +435,7 @@ class MyClass
             $output['qux'] = $this->qux;
         }
         if (isset($this->grox) || array_key_exists('grox', $this->_providedOptionals)) {
-            $output['grox'] = $this->grox;
+            $output['grox'] = ($this->grox !== null) ? ($this->grox) : null;
         }
         if (isset($this->quux)) {
             $output['quux'] = ($this->quux)->toArray();
@@ -468,7 +468,7 @@ class MyClass
             $output->{'qux'} = $this->qux;
         }
         if (isset($this->grox) || array_key_exists('grox', $this->_providedOptionals)) {
-            $output->{'grox'} = $this->grox;
+            $output->{'grox'} = ($this->grox !== null) ? ($this->grox) : null;
         }
         if (isset($this->quux)) {
             $output->{'quux'} = ($this->quux)->toStdClass();

--- a/tests/Generator/Fixtures/SingleElemTypeArray/Output-8.4/MyClassQuux.php
+++ b/tests/Generator/Fixtures/SingleElemTypeArray/Output-8.4/MyClassQuux.php
@@ -80,7 +80,7 @@ class MyClassQuux
             static::validateInput($input);
         }
 
-        $a = isset($input->{'a'}) ? $input->{'a'} : null;
+        $a = isset($input->{'a'}) ? ($input->{'a'}) : null;
 
         $obj = new self();
         $obj->a = $a;

--- a/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
@@ -78,7 +78,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? (is_int($input->{'foo'}) || is_float($input->{'foo'})) ? (str_contains((string)($input->{'foo'}), '.') ? (float)($input->{'foo'}) : (int)($input->{'foo'})) : ((is_string($input->{'foo'})) ? ($input->{'foo'}) : (null)) : null;
+        $foo = isset($input->{'foo'}) ? ((is_int($input->{'foo'}) || is_float($input->{'foo'})) ? (str_contains((string)($input->{'foo'}), '.') ? (float)($input->{'foo'}) : (int)($input->{'foo'})) : ((is_string($input->{'foo'})) ? ($input->{'foo'}) : (null))) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
@@ -80,7 +80,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? (is_int($input->{'foo'}) || is_float($input->{'foo'})) ? (str_contains((string)($input->{'foo'}), '.') ? (float)($input->{'foo'}) : (int)($input->{'foo'})) : ((is_string($input->{'foo'})) ? ($input->{'foo'}) : (null)) : null;
+        $foo = isset($input->{'foo'}) ? ((is_int($input->{'foo'}) || is_float($input->{'foo'})) ? (str_contains((string)($input->{'foo'}), '.') ? (float)($input->{'foo'}) : (int)($input->{'foo'})) : ((is_string($input->{'foo'})) ? ($input->{'foo'}) : (null))) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
@@ -74,11 +74,11 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? match (true) {
+        $foo = isset($input->{'foo'}) ? (match (true) {
             is_string($input->{'foo'}) => $input->{'foo'},
             is_int($input->{'foo'}) || is_float($input->{'foo'}) => str_contains((string)($input->{'foo'}), '.') ? (float)($input->{'foo'}) : (int)($input->{'foo'}),
             default => null,
-        } : null;
+        }) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-5.6/MyClass.php
@@ -149,8 +149,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
-        $encoded = isset($input->{'encoded'}) ? $input->{'encoded'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
+        $encoded = isset($input->{'encoded'}) ? ($input->{'encoded'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-7.4/MyClass.php
@@ -151,8 +151,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
-        $encoded = isset($input->{'encoded'}) ? $input->{'encoded'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
+        $encoded = isset($input->{'encoded'}) ? ($input->{'encoded'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
@@ -145,8 +145,8 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
-        $encoded = isset($input->{'encoded'}) ? $input->{'encoded'} : null;
+        $foo = isset($input->{'foo'}) ? ($input->{'foo'}) : null;
+        $encoded = isset($input->{'encoded'}) ? ($input->{'encoded'}) : null;
 
         $obj = new self();
         $obj->foo = $foo;

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -113,7 +113,7 @@ class Cat
         }
 
         $__providedOptionals = [];
-        $hasFur = property_exists($input, 'hasFur') ? match (true) {
+        $hasFur = property_exists($input, 'hasFur') ? (($input->{'hasFur'} !== null) ? (match (true) {
             (($input->{'hasFur'}) === null) || (is_bool($input->{'hasFur'})) => ($input->{'hasFur'} !== null) ? ((bool)($input->{'hasFur'})) : null,
             (($input->{'hasFur'}) === null) || ((is_string($input->{'hasFur'})) || (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'}))) => ($input->{'hasFur'} !== null) ? (match (true) {
             is_string($input->{'hasFur'}) => $input->{'hasFur'},
@@ -127,7 +127,7 @@ class Cat
             default => null,
         },
             default => null,
-        } : null;
+        }) : null) : null;
         if (property_exists($input, 'hasFur')) {
             $__providedOptionals['hasFur'] = true;
         }
@@ -147,7 +147,8 @@ class Cat
     {
         $output = [];
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
-            $output['hasFur'] = match (true) {
+            $output['hasFur'] = ($this->hasFur !== null) ? (match (true) {
+                default => null,
                 (($this->hasFur) === null) || (is_bool($this->hasFur)) => ($this->hasFur !== null) ? ($this->hasFur) : null,
                 (($this->hasFur) === null) || ((is_string($this->hasFur)) || (is_int($this->hasFur) || is_float($this->hasFur))) => ($this->hasFur !== null) ? (match (true) {
                 default => null,
@@ -160,7 +161,7 @@ class Cat
                 is_int($this->hasFur) || is_float($this->hasFur),
                 is_bool($this->hasFur) => $this->hasFur,
             },
-            };
+            }) : null;
         }
 
         return $output;
@@ -175,7 +176,8 @@ class Cat
     {
         $output = new \stdClass();
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
-            $output->{'hasFur'} = match (true) {
+            $output->{'hasFur'} = ($this->hasFur !== null) ? (match (true) {
+                default => null,
                 (($this->hasFur) === null) || (is_bool($this->hasFur)) => ($this->hasFur !== null) ? ($this->hasFur) : null,
                 (($this->hasFur) === null) || ((is_string($this->hasFur)) || (is_int($this->hasFur) || is_float($this->hasFur))) => ($this->hasFur !== null) ? (match (true) {
                 default => null,
@@ -188,7 +190,7 @@ class Cat
                 is_int($this->hasFur) || is_float($this->hasFur),
                 is_bool($this->hasFur) => $this->hasFur,
             },
-            };
+            }) : null;
         }
 
         return $output;

--- a/tests/Generator/Property/OptionalPropertyDecoratorTest.php
+++ b/tests/Generator/Property/OptionalPropertyDecoratorTest.php
@@ -51,7 +51,7 @@ class OptionalPropertyDecoratorTest extends TestCase
 
         $result = $this->decorator->convertInputToType('variable');
 
-        $expected = '$myPropertyName = isset($variable[\'myPropertyName\']) ? INNER_EXPR : null;';
+        $expected = '$myPropertyName = isset($variable[\'myPropertyName\']) ? (INNER_EXPR) : null;';
 
         assertSame($expected, $result);
     }
@@ -71,7 +71,7 @@ class OptionalPropertyDecoratorTest extends TestCase
 
         $result = $decorator->convertInputToType('variable');
 
-        $expected = '$myPropertyName = array_key_exists(\'myPropertyName\', $variable) ? INNER_EXPR : null;';
+        $expected = '$myPropertyName = array_key_exists(\'myPropertyName\', $variable) ? (INNER_EXPR) : null;';
         assertSame($expected, $result);
     }
 


### PR DESCRIPTION
## Summary
- parenthesize nested ternaries when building optional nullable properties
- update snapshots

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688aa07f6920832da54a7e5ce01885b3