### PR TITLE
Use SchemaToClassFactory for nested generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Now it:
 - Improves type hints and PHPDoc type generation for complex types like unions, nested arrays, etc.
 - Adds a guard against passing anything other than an array/object to `fromInput`, building multi-line validation error messages.
 - Setter methods (`withX()`) now accept an optional `$validate` argument to be able skip validation, mirroring `fromInput()`.
+- Internal generation now consistently uses `SchemaToClassFactory` for nested types, enabling easier customization of the
+  generator instance.
 - Option `mutableSetters` allows generating mutable `setX()` methods (optionally chainable).
 - Skips emitting empty `__construct` or `__clone` methods.
 - Prints a notice when skipping `definitions` that do not describe an object.

--- a/src/Generator/Class/ClassGenerator.php
+++ b/src/Generator/Class/ClassGenerator.php
@@ -8,6 +8,8 @@ use Helmich\Schema2Class\Generator\Class\Property\ClassPropertySuiteFactory;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Helmich\Schema2Class\Generator\GeneratorRequest;
+use Helmich\Schema2Class\Generator\PropertyGenerator;
+use Laminas\Code\Generator\MethodGenerator;
 use Laminas\Code\DeclareStatement;
 use Laminas\Code\Generator\ClassGenerator as LaminasClassGenerator;
 use Laminas\Code\Generator\DocBlockGenerator;
@@ -74,7 +76,7 @@ class ClassGenerator
     
     /**
      * @param PropertyGenerator[] $propertyGenerators
-     * @param MethodGenerator[] $methodGenerators
+     * @param MethodGenerator[]   $methodGenerators
      */
     private function prepareFileGenerator(array $propertyGenerators, array $methodGenerators): FileGenerator
     {

--- a/src/Generator/GenerationRunner.php
+++ b/src/Generator/GenerationRunner.php
@@ -207,6 +207,7 @@ class GenerationRunner
                 $schema,
                 $validated,
                 $opts,
+                $this->factory,
             ))->withRootDefinitions(
                 array_merge($schema['definitions'] ?? [], $schema['$defs'] ?? [])
             );

--- a/src/Generator/GeneratorRequest.php
+++ b/src/Generator/GeneratorRequest.php
@@ -14,6 +14,7 @@ use Helmich\Schema2Class\Generator\ReferenceLookup\ReferenceLookup;
 use Helmich\Schema2Class\Spec\SpecificationOptions;
 use Helmich\Schema2Class\Spec\OptionsDefaults;
 use Helmich\Schema2Class\Spec\ValidatedSpecificationFilesItem;
+use Helmich\Schema2Class\Generator\SchemaToClassFactory;
 use Helmich\Schema2Class\Loader\SchemaLoader;
 use Laminas\Code\Generator\MethodGenerator;
 use Laminas\Code\Generator\PropertyGenerator;
@@ -69,6 +70,8 @@ class GeneratorRequest
      */
     private bool $currReqHasDefaults;
 
+    private SchemaToClassFactory $factory;
+
     public static function normalizeTargetVersion(int|string $version): string
     {
         $mapped = match ($version) {
@@ -81,7 +84,12 @@ class GeneratorRequest
         return self::semversifyVersionNumber($mapped);
     }
 
-    public function __construct(array $schema, ValidatedSpecificationFilesItem $spec, SpecificationOptions $opts)
+    public function __construct(
+        array $schema,
+        ValidatedSpecificationFilesItem $spec,
+        SpecificationOptions $opts,
+        ?SchemaToClassFactory $factory = null,
+    )
     {
         $opts = OptionsDefaults::applyDefaults($opts);
         $opts = $opts->withTargetPHPVersion(
@@ -96,6 +104,7 @@ class GeneratorRequest
         $this->schema = $schema;
         $this->spec   = $spec;
         $this->opts   = $opts;
+        $this->factory = $factory ?? new SchemaToClassFactory();
     }
 
     /**
@@ -122,6 +131,11 @@ class GeneratorRequest
     public function getRawSchema(): ?object
     {
         return $this->rawSchema;
+    }
+
+    public function getSchemaToClassFactory(): SchemaToClassFactory
+    {
+        return $this->factory;
     }
 
     private static function semversifyVersionNumber(string|int $versionNumber): string

--- a/src/Generator/Property/Type/IntersectProperty.php
+++ b/src/Generator/Property/Type/IntersectProperty.php
@@ -5,7 +5,6 @@ namespace Helmich\Schema2Class\Generator\Property\Type;
 
 use Helmich\Schema2Class\Generator\Class\MethodNames;
 use Helmich\Schema2Class\Generator\GeneratorException;
-use Helmich\Schema2Class\Generator\SchemaToClass;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -37,7 +36,7 @@ class IntersectProperty extends AbstractProperty
             ->withSchema($combined)
             ->withClass($propertyTypeName);
 
-        $generator = new SchemaToClass($writer, $output);
+        $generator = $this->generatorRequest->getSchemaToClassFactory()->build($writer, $output);
         $generator->schemaToClass($this->propagateRootDefinitions($req));
     }
 

--- a/src/Generator/Property/Type/NestedObjectProperty.php
+++ b/src/Generator/Property/Type/NestedObjectProperty.php
@@ -5,7 +5,6 @@ namespace Helmich\Schema2Class\Generator\Property\Type;
 
 use Helmich\Schema2Class\Generator\Class\MethodNames;
 use Helmich\Schema2Class\Generator\GeneratorException;
-use Helmich\Schema2Class\Generator\SchemaToClass;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -46,7 +45,7 @@ class NestedObjectProperty extends AbstractProperty
             ->withSchema($this->schema)
             ->withClass($this->subTypeName());
 
-        $generator = new SchemaToClass($writer, $output);
+        $generator = $this->generatorRequest->getSchemaToClassFactory()->build($writer, $output);
         $generator->schemaToClass($this->propagateRootDefinitions($req));
     }
 

--- a/src/Generator/Property/Type/ObjectArrayProperty.php
+++ b/src/Generator/Property/Type/ObjectArrayProperty.php
@@ -8,7 +8,6 @@ use Helmich\Schema2Class\Generator\Class\MethodNames;
 use Helmich\Schema2Class\Generator\GeneratorException;
 use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\Property\PropertyBuilder;
-use Helmich\Schema2Class\Generator\SchemaToClass;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -134,7 +133,7 @@ class ObjectArrayProperty extends AbstractProperty
             ->withSchema($this->itemSchema)
             ->withClass($this->subTypeName());
 
-        $generator = new SchemaToClass($writer, $output);
+        $generator = $this->generatorRequest->getSchemaToClassFactory()->build($writer, $output);
         $generator->schemaToClass($this->propagateRootDefinitions($req));
     }
 

--- a/src/Generator/Property/Type/PrimitiveArrayProperty.php
+++ b/src/Generator/Property/Type/PrimitiveArrayProperty.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator\Property\Type;
 
 use Helmich\Schema2Class\Generator\GeneratorRequest;
-use Helmich\Schema2Class\Generator\SchemaToClass;
 use Helmich\Schema2Class\Util\SchemaUtils;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Generator/Property/Type/StringEnumProperty.php
+++ b/src/Generator/Property/Type/StringEnumProperty.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator\Property\Type;
 
 use Helmich\Schema2Class\Generator\GeneratorException;
-use Helmich\Schema2Class\Generator\SchemaToClass;
 use Helmich\Schema2Class\Generator\Enum\SchemaToEnum;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Laminas\Code\Generator\PropertyValueGenerator;
@@ -42,7 +41,7 @@ class StringEnumProperty extends AbstractProperty
                 ->withSchema($this->schema)
                 ->withClass($this->subTypeName());
                 
-            $generator = new SchemaToClass($writer, $output);
+            $generator = $this->generatorRequest->getSchemaToClassFactory()->build($writer, $output);
             $generator->schemaToClass($this->propagateRootDefinitions($req));
         }
     }

--- a/src/Generator/Property/Type/TypedArrayProperty.php
+++ b/src/Generator/Property/Type/TypedArrayProperty.php
@@ -5,7 +5,6 @@ namespace Helmich\Schema2Class\Generator\Property\Type;
 
 use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\Property\PropertyBuilder;
-use Helmich\Schema2Class\Generator\SchemaToClass;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Generator/Property/Type/UnionProperty.php
+++ b/src/Generator/Property/Type/UnionProperty.php
@@ -9,7 +9,6 @@ use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\MatchGenerator;
 use Helmich\Schema2Class\Generator\Property\Type\NullProperty;
 use Helmich\Schema2Class\Generator\Property\PropertyBuilder;
-use Helmich\Schema2Class\Generator\SchemaToClass;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -267,7 +266,7 @@ class UnionProperty extends AbstractProperty
                     ->withSchema($subDef)
                     ->withClass($propertyTypeName);
 
-                $generator = new SchemaToClass($writer, $output);
+                $generator = $this->generatorRequest->getSchemaToClassFactory()->build($writer, $output);
                 $generator->schemaToClass($this->propagateRootDefinitions($req));
             }
         }


### PR DESCRIPTION
## Summary
- allow GeneratorRequest to carry a SchemaToClassFactory
- use the injected factory when generating nested types
- document factory-based generation in CHANGELOG

## Testing
- `vendor/bin/phpstan --memory-limit=512M` (fails: Match expression does not handle remaining value: true)
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688e9e62a0a8832d87ab63155a3afe9d