### PR TITLE
refactor: drop validate/materialize arg aliasing

### DIFF
--- a/src/Generator/Class/Method/FromInputMethodFactory.php
+++ b/src/Generator/Class/Method/FromInputMethodFactory.php
@@ -120,22 +120,16 @@ class FromInputMethodFactory
      */
     private function generateBody(): string
     {
-        $inputArgAlias = $this->ensureUniqueName(self::INPUT_ARG_NAME);
-        $validateArgAlias = $this->ensureUniqueName(self::VALIDATE_ARG_NAME);
-        $materializeArgAlias = $this->ensureUniqueName(self::DEFAULTS_ARG_NAME);
+        $inputArgAlias = self::INPUT_ARG_NAME;
+        $validateArgAlias = self::VALIDATE_ARG_NAME;
+        $materializeArgAlias = self::DEFAULTS_ARG_NAME;
 
         $providedOptionalsVarName = $this->ensureUniqueName('_'.PropertyNames::OPTIONALS);
         $objVarName = $this->ensureUniqueName(self::OBJ_VAR_NAME);
 
-        // TODO: find another way to propagate aliases names instead of mutating GeneratorRequest
-        $this->request->setCurrValidateArgAlias($validateArgAlias);
-        $this->request->setCurrMaterializeArgAlias($this->defaults ? $materializeArgAlias : null);
-
         $arrayToObjectExpr = $this->request->getOptions()->getArrayToObjectExpr();
 
         $bodyParts = [
-            // assign arguments to alias vars if there are properties with same names
-            $this->bodyVarAliases($inputArgAlias, $validateArgAlias, $materializeArgAlias),
             // in target PHP<8 we can't input specify $input type as `array|object` so we add a guard
             $this->bodyInputGuard($inputArgAlias),
             // convert input to object if needed, optionally cloning it when "defaults" are present
@@ -160,45 +154,6 @@ class FromInputMethodFactory
 
         $body = implode('', $bodyParts);
         return $body;
-    }
-
-    /**
-     * When there are collisions between internal var names and schema properties,
-     * it generates a block such as:
-     * ```
-     *     $_input = $input;
-     *     unset($input);
-     *     $_validate = $validate;
-     *     unset($validate);
-     *     $_materializeDefaults = $materializeDefaults;
-     *     unset($materializeDefaults);
-     * ```
-     */
-    private function bodyVarAliases(string $inputArgAlias, string $validateArgAlias, string $materializeArgAlias): string
-    {
-        $aliases = '';
-
-        $setAndUnset = static fn(string $set, string $unset): string =>
-            <<<PHP
-            \${$set} = \$$unset;
-            unset(\$$unset);\n
-            PHP;
-
-        if ($inputArgAlias !== self::INPUT_ARG_NAME) {
-            $aliases .= $setAndUnset($inputArgAlias, self::INPUT_ARG_NAME);
-        }
-        if ($validateArgAlias !== self::VALIDATE_ARG_NAME) {
-            $aliases .= $setAndUnset($validateArgAlias, self::VALIDATE_ARG_NAME);
-        }
-        if ($materializeArgAlias !== self::DEFAULTS_ARG_NAME) {
-            $aliases .= $setAndUnset($materializeArgAlias, self::DEFAULTS_ARG_NAME);
-        }
-
-        if ($aliases) {
-            $aliases .= "\n";
-        }
-
-        return $aliases;
     }
 
     /**
@@ -376,7 +331,7 @@ class FromInputMethodFactory
         $requiredProperties = $this->schemaProperties->filter(PropertyCollectionFilterFactory::onlyRequired());
         $constructorParams = [];
         foreach ($requiredProperties as $requiredProperty) {
-            $constructorParams[] = '$' . $requiredProperty->name();
+            $constructorParams[] = '$' . $requiredProperty->varName();
         }
         $paramsStr = join(", ", $constructorParams);
         $createNewInstance = "\${$objVarName} = new self({$paramsStr});\n";
@@ -400,7 +355,8 @@ class FromInputMethodFactory
         $assignments = [];
         foreach ($optionalProperties as $optionalProperty) {
             $name = $optionalProperty->name();
-            $assignments[] = "\${$objVarName}->{$name} = \${$name};";
+            $var = $optionalProperty->varName();
+            $assignments[] = "\${$objVarName}->{$name} = \${$var};";
         }
         $assignOptionalsToInstance = join("\n", $assignments) . "\n";
 

--- a/src/Generator/Class/SchemaPropertyCollector.php
+++ b/src/Generator/Class/SchemaPropertyCollector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator\Class;
 
 use Helmich\Schema2Class\Generator\GeneratorRequest;
+use Helmich\Schema2Class\Generator\Class\Method\FromInputMethodFactory;
+use Helmich\Schema2Class\Generator\Class\PropertyNames;
 use Helmich\Schema2Class\Generator\Property\Collection\PropertyCollection;
 use Helmich\Schema2Class\Generator\Property\PropertyBuilder;
 use Helmich\Schema2Class\Generator\Property\Decorator\OptionalPropertyDecorator;
@@ -145,6 +147,23 @@ class SchemaPropertyCollector
         }
         $used = array_values(array_unique($used));
 
+        $reservedVarNames = array_merge(
+            $reservedPropertyNames,
+            [
+                FromInputMethodFactory::INPUT_ARG_NAME,
+                FromInputMethodFactory::VALIDATE_ARG_NAME,
+                FromInputMethodFactory::DEFAULTS_ARG_NAME,
+                FromInputMethodFactory::OBJ_VAR_NAME,
+                '_' . PropertyNames::OPTIONALS,
+            ],
+        );
+        $usedVars = [];
+        foreach ($reservedVarNames as $n) {
+            $usedVars[] = StringUtils::safeCamelCase($n);
+            $usedVars[] = StringUtils::sanitizeIdentifier($n);
+        }
+        $usedVars = array_values(array_unique($usedVars));
+
         $usedMethods = [];
         foreach ($reservedMethodNames as $n) {
             $usedMethods[] = strtolower(StringUtils::safePascalCase(StringUtils::safeCamelCase($n)));
@@ -185,6 +204,24 @@ class SchemaPropertyCollector
 
             $used[]       = $newName;
             $usedMethods[] = $newPascal;
+
+            $baseVar = $schemaProp->varName();
+            $newVar = $baseVar;
+            if (in_array($newVar, $usedVars, true)) {
+                if ($baseVar[0] !== '_') {
+                    $newVar = '_' . $baseVar;
+                }
+                $i = 1;
+                $baseVarUnique = $newVar;
+                while (in_array($newVar, $usedVars, true)) {
+                    $newVar = $baseVarUnique . '_' . $i;
+                    $i++;
+                }
+            }
+            if ($newVar !== $baseVar) {
+                $schemaProp->setVarName($newVar);
+            }
+            $usedVars[] = $newVar;
         }
     }
 }

--- a/src/Generator/GeneratorRequest.php
+++ b/src/Generator/GeneratorRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator;
 
 use Composer\Semver\Comparator;
-use Helmich\Schema2Class\Generator\Class\Method\FromInputMethodFactory;
 use Helmich\Schema2Class\Generator\Hook\AddInterfaceHook;
 use Helmich\Schema2Class\Generator\Hook\AddMethodHook;
 use Helmich\Schema2Class\Generator\Hook\AddPropertyHook;
@@ -29,9 +28,8 @@ use Laminas\Code\Generator\PropertyGenerator as LaminasPropertyGenerator;
  * The request also stores runtime information such as registered {@see ReferenceLookup}
  * implementations and is cloned when modifications are needed for nested classes
  * 
- * Mutation is deliberately allowed for `currValidateArgAlias`, `currMaterializeArgAlias`,
- * and `currReqHasDefaults` to simplify passing information to nested contexts.
- * TODO: Rethink this.
+ * Mutation is deliberately allowed for `currReqHasDefaults` to simplify
+ * passing information to nested contexts. TODO: Rethink this.
  */
 class GeneratorRequest
 {
@@ -54,18 +52,6 @@ class GeneratorRequest
     /** @var array<class-string, ReferenceLookup> */
     private array $referenceLookup = [];
     
-    /**
-     * Name of the $validate argument in the currently generated fromInput method.
-     * This is set from the Generator during generation.
-     */
-    private string $currValidateArgAlias = FromInputMethodFactory::VALIDATE_ARG_NAME;
-
-    /**
-     * Name of the $materializeDefaults argument in the currently generated fromInput method
-     * (null when the argument is not generated). This is set from the Generator.
-     */
-    private ?string $currMaterializeArgAlias = null;
-
     /**
      * Whether the object schema from which the class is currently generated has defaults.
      */
@@ -376,42 +362,12 @@ class GeneratorRequest
     }
 
     /**
-     * This method is deliberately mutating (not `with...`) so that the active
-     * argument names can be updated for all property generators during code generation
-     * to ensure consistent variable names in nested contexts
-     */
-    public function setCurrValidateArgAlias(string $currValidateArgAlias): void
-    {
-        $this->currValidateArgAlias = $currValidateArgAlias;
-    }
-
-    /**
-     * This method is deliberately mutating (not `with...`) so that the active
-     * argument names can be updated for all property generators during code generation
-     * to ensure consistent variable names in nested contexts
-     */
-    public function setCurrMaterializeArgAlias(?string $currMaterializeArgAlias): void
-    {
-        $this->currMaterializeArgAlias = $currMaterializeArgAlias;
-    }
-
-    /**
      * This method is deliberately mutating (not `with...`) so that the information about
      * the presence of defaults is available to all property generators in nested contexts.
      */
     public function setCurrReqHasDefaults(bool $currReqHasDefaults): void
     {
         $this->currReqHasDefaults = $currReqHasDefaults;
-    }
-
-    public function getCurrValidateArgAlias(): string
-    {
-        return $this->currValidateArgAlias;
-    }
-
-    public function getCurrMaterializeArgAlias(): ?string
-    {
-        return $this->currMaterializeArgAlias;
     }
 
     public function getCurrReqHasDefaults(): bool

--- a/src/Generator/Property/Decorator/NullablePropertyDecorator.php
+++ b/src/Generator/Property/Decorator/NullablePropertyDecorator.php
@@ -102,7 +102,7 @@ class NullablePropertyDecorator implements PropertyDecoratorInterface
         // Key name in the JSON object
         $key   = $this->key;
         $keyStr  = var_export($key, true);
-        $name  = $this->inner->name(); // local variable to assign to
+        $name  = $this->inner->varName(); // local variable to assign to
 
         $accessor = "\${$inputVarName}->{{$keyStr}}";
 

--- a/src/Generator/Property/Decorator/OptionalPropertyDecorator.php
+++ b/src/Generator/Property/Decorator/OptionalPropertyDecorator.php
@@ -41,7 +41,7 @@ class OptionalPropertyDecorator extends NullablePropertyDecorator
     public function convertInputToType(string $inputVarName, string $optionalsVarName): string
     {
         $keyStr = var_export($this->key, true);
-        $name  = $this->inner->name();
+        $name  = $this->inner->varName();
 
         // JSON accessor:  $input->{'key'}   or   $input['key']
         $accessor = "\${$inputVarName}->{{$keyStr}}";

--- a/src/Generator/Property/Type/AbstractProperty.php
+++ b/src/Generator/Property/Type/AbstractProperty.php
@@ -102,7 +102,7 @@ abstract class AbstractProperty implements PropertyInterface
 
     public function convertInputToType(string $inputVarName, string $optionalsVarName): string
     {
-        $name = $this->name;
+        $name = $this->varName;
         $key  = $this->key;
         $keyStr = var_export($key, true);
         // build the raw lookup expression (using the JSON key only inside the braces)

--- a/src/Generator/Property/Type/IntersectProperty.php
+++ b/src/Generator/Property/Type/IntersectProperty.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator\Property\Type;
 
 use Helmich\Schema2Class\Generator\Class\MethodNames;
+use Helmich\Schema2Class\Generator\Class\Method\FromInputMethodFactory;
 use Helmich\Schema2Class\Generator\GeneratorException;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -63,12 +64,12 @@ class IntersectProperty extends AbstractProperty
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string
     {
-        $validateArg = $this->request->getCurrValidateArgAlias();
-        $materializeArg = $this->request->getCurrMaterializeArgAlias();
-
-        $args = [$expr, '$' . $validateArg];
-        if ($materializeArg !== null) {
-            $args[] = '$' . $materializeArg;
+        $args = [
+            $expr,
+            '$' . FromInputMethodFactory::VALIDATE_ARG_NAME,
+        ];
+        if ($this->request->getCurrReqHasDefaults()) {
+            $args[] = '$' . FromInputMethodFactory::DEFAULTS_ARG_NAME;
         }
         $argsStr = implode(', ', $args);
 

--- a/src/Generator/Property/Type/NestedObjectProperty.php
+++ b/src/Generator/Property/Type/NestedObjectProperty.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator\Property\Type;
 
 use Helmich\Schema2Class\Generator\Class\MethodNames;
+use Helmich\Schema2Class\Generator\Class\Method\FromInputMethodFactory;
 use Helmich\Schema2Class\Generator\GeneratorException;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -72,12 +73,12 @@ class NestedObjectProperty extends AbstractProperty
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string
     {
-        $validateArg = $this->request->getCurrValidateArgAlias();
-        $materializeArg = $this->request->getCurrMaterializeArgAlias();
-
-        $args = [$expr, '$' . $validateArg];
-        if ($materializeArg !== null) {
-            $args[] = '$' . $materializeArg;
+        $args = [
+            $expr,
+            '$' . FromInputMethodFactory::VALIDATE_ARG_NAME,
+        ];
+        if ($this->request->getCurrReqHasDefaults()) {
+            $args[] = '$' . FromInputMethodFactory::DEFAULTS_ARG_NAME;
         }
         $argsStr = implode(', ', $args);
 

--- a/src/Generator/Property/Type/ObjectArrayProperty.php
+++ b/src/Generator/Property/Type/ObjectArrayProperty.php
@@ -5,6 +5,7 @@ namespace Helmich\Schema2Class\Generator\Property\Type;
 
 use Helmich\Schema2Class\Generator\Class\Method\SerializeMethodFactory;
 use Helmich\Schema2Class\Generator\Class\MethodNames;
+use Helmich\Schema2Class\Generator\Class\Method\FromInputMethodFactory;
 use Helmich\Schema2Class\Generator\GeneratorException;
 use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\Property\PropertyBuilder;
@@ -164,12 +165,9 @@ class ObjectArrayProperty extends AbstractProperty
     
     private function buildUseClause(): string
     {
-        $validateArg = $this->request->getCurrValidateArgAlias();
-        $materializeArg = $this->request->getCurrMaterializeArgAlias();
-        
-        $vars = ['$' . $validateArg];
-        if ($materializeArg !== null) {
-            $vars[] = '$' . $materializeArg;
+        $vars = ['$' . FromInputMethodFactory::VALIDATE_ARG_NAME];
+        if ($this->request->getCurrReqHasDefaults()) {
+            $vars[] = '$' . FromInputMethodFactory::DEFAULTS_ARG_NAME;
         }
         return implode(', ', $vars);
     }

--- a/src/Generator/Property/Type/TypedArrayProperty.php
+++ b/src/Generator/Property/Type/TypedArrayProperty.php
@@ -7,6 +7,7 @@ use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\Property\PropertyBuilder;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Helmich\Schema2Class\Generator\Class\Method\FromInputMethodFactory;
 
 /**
  * Represents array of complex objects defined "items" schema.
@@ -93,12 +94,9 @@ class TypedArrayProperty extends AbstractProperty
             return "array_map(fn(\$i) => {$map}, {$expr})";
         }
 
-        $validateArg = $this->request->getCurrValidateArgAlias();
-        $materializeArg = $this->request->getCurrMaterializeArgAlias();
-
-        $use = ['$' . $validateArg];
-        if ($materializeArg !== null) {
-            $use[] = '$' . $materializeArg;
+        $use = ['$' . FromInputMethodFactory::VALIDATE_ARG_NAME];
+        if ($this->request->getCurrReqHasDefaults()) {
+            $use[] = '$' . FromInputMethodFactory::DEFAULTS_ARG_NAME;
         }
         $useExpr = implode(', ', $use);
         return "array_map(function(\$i) use ({$useExpr}) { return {$map}; }, {$expr})";

--- a/src/Generator/Property/Type/UnionProperty.php
+++ b/src/Generator/Property/Type/UnionProperty.php
@@ -52,7 +52,7 @@ class UnionProperty extends AbstractProperty
 
     public function convertInputToTypeMatch(string $inputVarName = 'input'): string
     {
-        $name  = $this->name;
+        $name  = $this->varName;
         $key   = $this->key;
         $keyStr = var_export($key, true);
 
@@ -82,15 +82,15 @@ class UnionProperty extends AbstractProperty
             return $this->convertInputToTypeMatch($inputVarName);
         }
     
-        $name   = $this->name;
+        $name   = $this->varName;
         $key    = $this->key;
         $keyStr = var_export($key, true);
-    
+
         $accessor = "\${$inputVarName}->{{$keyStr}}";
-    
+
         // Start with a "fallback" that just reassigns the raw value
         $conversions = [
-            "\$$key = {$accessor};" => ["discriminators" => [], "fallback" => true],
+            "\$$name = {$accessor};" => ["discriminators" => [], "fallback" => true],
         ];
     
         // Build up per‑arm conversions

--- a/src/Generator/ReferencedType/ReferencedTypeClass.php
+++ b/src/Generator/ReferencedType/ReferencedTypeClass.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator\ReferencedType;
 
 use Helmich\Schema2Class\Generator\Class\MethodNames;
+use Helmich\Schema2Class\Generator\Class\Method\FromInputMethodFactory;
 use Helmich\Schema2Class\Generator\GeneratorRequest;
 
 /**
@@ -74,15 +75,15 @@ readonly class ReferencedTypeClass implements ReferencedTypeInterface
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string
     {
-        $validateArg = $this->request->getCurrValidateArgAlias();
-        $materializeArg = $this->request->getCurrMaterializeArgAlias();
-
-        $args = [$expr, '$' . $validateArg];
-        if ($materializeArg !== null) {
-            $args[] = '$' . $materializeArg;
+        $args = [
+            $expr,
+            '$' . FromInputMethodFactory::VALIDATE_ARG_NAME,
+        ];
+        if ($this->request->getCurrReqHasDefaults()) {
+            $args[] = '$' . FromInputMethodFactory::DEFAULTS_ARG_NAME;
         }
         $argsStr = implode(', ', $args);
-        
+
         $cls = $this->relativeName();
         $FROM_INPUT = MethodNames::FROM_INPUT;
         return "{$cls}::{$FROM_INPUT}({$argsStr})";

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-5.6/MyClass.php
@@ -146,10 +146,10 @@ class MyClass
         }
 
         $foobar = isset($input->{'foobar'}) ? $input->{'foobar'} : null;
-        $_fooBar_1 = $input->{'fooBar'};
+        $fooBar = $input->{'fooBar'};
         $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
 
-        $obj = new self($_fooBar_1);
+        $obj = new self($fooBar);
         $obj->foobar = $foobar;
         $obj->bar = $bar;
         return $obj;

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-7.4/MyClass.php
@@ -148,10 +148,10 @@ class MyClass
         }
 
         $foobar = isset($input->{'foobar'}) ? $input->{'foobar'} : null;
-        $_fooBar_1 = $input->{'fooBar'};
+        $fooBar = $input->{'fooBar'};
         $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
 
-        $obj = new self($_fooBar_1);
+        $obj = new self($fooBar);
         $obj->foobar = $foobar;
         $obj->bar = $bar;
         return $obj;

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-8.4/MyClass.php
@@ -142,10 +142,10 @@ class MyClass
         }
 
         $foobar = isset($input->{'foobar'}) ? $input->{'foobar'} : null;
-        $_fooBar_1 = $input->{'fooBar'};
+        $fooBar = $input->{'fooBar'};
         $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
 
-        $obj = new self($_fooBar_1);
+        $obj = new self($fooBar);
         $obj->foobar = $foobar;
         $obj->bar = $bar;
         return $obj;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -2146,95 +2146,88 @@ class MyClass
      */
     public static function fromInput($input, bool $validate = true, bool $materializeDefaults = false)
     {
-        $_input = $input;
-        unset($input);
-        $_validate = $validate;
-        unset($validate);
-        $_materializeDefaults = $materializeDefaults;
-        unset($materializeDefaults);
-
-        if (!is_array($_input) && !is_object($_input)) {
+        if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(
-                'Input to fromInput must be array or object, got ' . gettype($_input)
+                'Input to fromInput must be array or object, got ' . gettype($input)
             );
         }
 
-        $_input = is_array($_input)
-            ? \JsonSchema\Validator::arrayToObjectRecursive($_input)
-            : ($_materializeDefaults ? clone $_input : $_input);
+        $input = is_array($input)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($input)
+            : ($materializeDefaults ? clone $input : $input);
 
-        if ($_materializeDefaults) {
+        if ($materializeDefaults) {
             foreach (self::$_defaults as $__k => $__v) {
-                if (!property_exists($_input, (string) $__k)) {
-                    $_input->{$__k} = ($__v['type'] ?? null) === 'object'
+                if (!property_exists($input, (string) $__k)) {
+                    $input->{$__k} = ($__v['type'] ?? null) === 'object'
                         ? \JsonSchema\Validator::arrayToObjectRecursive($__v['default'])
                         : $__v['default'];
                 }
             }
         }
 
-        if ($_validate) {
-            static::validateInput($_input);
+        if ($validate) {
+            static::validateInput($input);
         }
 
         $__providedOptionals = [];
-        $_GLOBALS_1 = $_input->{'_GLOBALS'};
-        $_GLOBALS_2 = $_input->{'GLOBALS'};
-        $_GLOBALS1_1 = $_input->{'GLOBALS_1'};
-        $_SERVER_1 = $_input->{'_SERVER'};
-        $_GET_1 = $_input->{'_GET'};
-        $_POST_1 = $_input->{'_POST'};
-        $_FILES_1 = $_input->{'_FILES'};
-        $_REQUEST_1 = $_input->{'_REQUEST'};
-        $_SESSION_1 = $_input->{'_SESSION'};
-        $_ENV_1 = $_input->{'_ENV'};
-        $_COOKIE_1 = $_input->{'_COOKIE'};
-        $_phpErrormsg = $_input->{'php_errormsg'};
-        $_httpResponseHeader = $_input->{'http_response_header'};
-        $_argc = $_input->{'argc'};
-        $_argv = $_input->{'argv'};
-        $input = $_input->{'input'};
-        $validate = isset($_input->{'validate'}) ? $_input->{'validate'} : null;
-        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? ($_input->{'materializeDefaults'} !== null ? $_input->{'materializeDefaults'} : null) : null;
-        if (property_exists($_input, 'materializeDefaults')) {
+        $_GLOBALS_1 = $input->{'_GLOBALS'};
+        $_GLOBALS_2 = $input->{'GLOBALS'};
+        $GLOBALS1 = $input->{'GLOBALS_1'};
+        $_SERVER_1 = $input->{'_SERVER'};
+        $_GET_1 = $input->{'_GET'};
+        $_POST_1 = $input->{'_POST'};
+        $_FILES_1 = $input->{'_FILES'};
+        $_REQUEST_1 = $input->{'_REQUEST'};
+        $_SESSION_1 = $input->{'_SESSION'};
+        $_ENV_1 = $input->{'_ENV'};
+        $_COOKIE_1 = $input->{'_COOKIE'};
+        $_phpErrormsg = $input->{'php_errormsg'};
+        $_httpResponseHeader = $input->{'http_response_header'};
+        $_argc = $input->{'argc'};
+        $_argv = $input->{'argv'};
+        $_input = $input->{'input'};
+        $_validate = isset($input->{'validate'}) ? $input->{'validate'} : null;
+        $_materializeDefaults = property_exists($input, 'materializeDefaults') ? ($input->{'materializeDefaults'} !== null ? $input->{'materializeDefaults'} : null) : null;
+        if (property_exists($input, 'materializeDefaults')) {
             $__providedOptionals['materializeDefaults'] = true;
         }
-        $obj = $_input->{'obj'};
-        $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::fromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
-        $_fromInput_1 = $_input->{'fromInput'};
-        $_toArray_1 = $_input->{'toArray'};
-        $_toStdClass_1 = $_input->{'toStdClass'};
-        $_validateInput_1 = $_input->{'validateInput'};
-        $_schema_1 = $_input->{'_schema'};
-        $_schema_2 = $_input->{'schema'};
-        $_defaults_1 = $_input->{'_defaults'};
-        $_defaults_2 = $_input->{'defaults'};
-        $_providedOptionals_1 = $_input->{'_providedOptionals'};
-        $_providedOptionals_2 = isset($_input->{'__providedOptionals'}) ? $_input->{'__providedOptionals'} : null;
-        $_clone_1 = $_input->{'clone'};
-        $_construct_1 = $_input->{'__construct'};
-        $_destruct_1 = $_input->{'__destruct'};
-        $_get_2 = $_input->{'__get'};
-        $_set_1 = $_input->{'__set'};
-        $_call_1 = $_input->{'__call'};
-        $_isset_1 = $_input->{'__isset'};
-        $_unset_1 = $_input->{'__unset'};
-        $_sleep_1 = $_input->{'__sleep'};
-        $_wakeup_1 = $_input->{'__wakeup'};
-        $_toString_1 = $_input->{'__toString'};
-        $_invoke_1 = $_input->{'__invoke'};
-        $_debugInfo_1 = $_input->{'__debugInfo'};
-        $_clone_2 = $_input->{'__clone'};
-        $files = $_input->{'files'};
-        $_this = $_input->{'this'};
-        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? ((is_string($_input->{'ensureArgs1'})) ? $_input->{'ensureArgs1'} : (((MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative2::fromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults) : (((MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative1::fromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults) : (null)))))) : null;
-        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults) : null;
-        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? array_map(function($i) use ($_validate, $_materializeDefaults) { return MyClassEnsureArgs3Item::fromInput($i, $_validate, $_materializeDefaults); }, $_input->{'ensureArgs3'}) : null;
+        $_obj = $input->{'obj'};
+        $includeDefaults = $input->{'includeDefaults'};
+        $testObj = isset($input->{'testObj'}) ? MyClassTestObj::fromInput($input->{'testObj'}, $validate, $materializeDefaults) : null;
+        $fromInput = $input->{'fromInput'};
+        $toArray = $input->{'toArray'};
+        $toStdClass = $input->{'toStdClass'};
+        $validateInput = $input->{'validateInput'};
+        $_schema_1 = $input->{'_schema'};
+        $_schema_2 = $input->{'schema'};
+        $_defaults_1 = $input->{'_defaults'};
+        $_defaults_2 = $input->{'defaults'};
+        $_providedOptionals_1 = $input->{'_providedOptionals'};
+        $_providedOptionals_2 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
+        $clone = $input->{'clone'};
+        $construct = $input->{'__construct'};
+        $destruct = $input->{'__destruct'};
+        $get = $input->{'__get'};
+        $set = $input->{'__set'};
+        $call = $input->{'__call'};
+        $isset = $input->{'__isset'};
+        $unset = $input->{'__unset'};
+        $sleep = $input->{'__sleep'};
+        $wakeup = $input->{'__wakeup'};
+        $toString = $input->{'__toString'};
+        $invoke = $input->{'__invoke'};
+        $debugInfo = $input->{'__debugInfo'};
+        $_clone = $input->{'__clone'};
+        $files = $input->{'files'};
+        $_this = $input->{'this'};
+        $ensureArgs1 = isset($input->{'ensureArgs1'}) ? ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : (((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (null)))))) : null;
+        $ensureArgs2 = isset($input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($input->{'ensureArgs2'}, $validate, $materializeDefaults) : null;
+        $ensureArgs3 = isset($input->{'ensureArgs3'}) ? array_map(function($i) use ($validate, $materializeDefaults) { return MyClassEnsureArgs3Item::fromInput($i, $validate, $materializeDefaults); }, $input->{'ensureArgs3'}) : null;
 
-        $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $input, $obj, $includeDefaults, $_fromInput_1, $_toArray_1, $_toStdClass_1, $_validateInput_1, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone_1, $_construct_1, $_destruct_1, $_get_2, $_set_1, $_call_1, $_isset_1, $_unset_1, $_sleep_1, $_wakeup_1, $_toString_1, $_invoke_1, $_debugInfo_1, $_clone_2, $files, $_this);
-        $_obj->validate = $validate;
-        $_obj->materializeDefaults = $materializeDefaults;
+        $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $GLOBALS1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $clone, $construct, $destruct, $get, $set, $call, $isset, $unset, $sleep, $wakeup, $toString, $invoke, $debugInfo, $_clone, $files, $_this);
+        $_obj->validate = $_validate;
+        $_obj->materializeDefaults = $_materializeDefaults;
         $_obj->testObj = $testObj;
         $_obj->_providedOptionals_2 = $_providedOptionals_2;
         $_obj->ensureArgs1 = $ensureArgs1;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -2148,95 +2148,88 @@ class MyClass
      */
     public static function fromInput($input, bool $validate = true, bool $materializeDefaults = false): MyClass
     {
-        $_input = $input;
-        unset($input);
-        $_validate = $validate;
-        unset($validate);
-        $_materializeDefaults = $materializeDefaults;
-        unset($materializeDefaults);
-
-        if (!is_array($_input) && !is_object($_input)) {
+        if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(
-                'Input to fromInput must be array or object, got ' . gettype($_input)
+                'Input to fromInput must be array or object, got ' . gettype($input)
             );
         }
 
-        $_input = is_array($_input)
-            ? \JsonSchema\Validator::arrayToObjectRecursive($_input)
-            : ($_materializeDefaults ? clone $_input : $_input);
+        $input = is_array($input)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($input)
+            : ($materializeDefaults ? clone $input : $input);
 
-        if ($_materializeDefaults) {
+        if ($materializeDefaults) {
             foreach (self::$_defaults as $__k => $__v) {
-                if (!property_exists($_input, (string) $__k)) {
-                    $_input->{$__k} = ($__v['type'] ?? null) === 'object'
+                if (!property_exists($input, (string) $__k)) {
+                    $input->{$__k} = ($__v['type'] ?? null) === 'object'
                         ? \JsonSchema\Validator::arrayToObjectRecursive($__v['default'])
                         : $__v['default'];
                 }
             }
         }
 
-        if ($_validate) {
-            static::validateInput($_input);
+        if ($validate) {
+            static::validateInput($input);
         }
 
         $__providedOptionals = [];
-        $_GLOBALS_1 = $_input->{'_GLOBALS'};
-        $_GLOBALS_2 = $_input->{'GLOBALS'};
-        $_GLOBALS1_1 = $_input->{'GLOBALS_1'};
-        $_SERVER_1 = $_input->{'_SERVER'};
-        $_GET_1 = $_input->{'_GET'};
-        $_POST_1 = $_input->{'_POST'};
-        $_FILES_1 = $_input->{'_FILES'};
-        $_REQUEST_1 = $_input->{'_REQUEST'};
-        $_SESSION_1 = $_input->{'_SESSION'};
-        $_ENV_1 = $_input->{'_ENV'};
-        $_COOKIE_1 = $_input->{'_COOKIE'};
-        $_phpErrormsg = $_input->{'php_errormsg'};
-        $_httpResponseHeader = $_input->{'http_response_header'};
-        $_argc = $_input->{'argc'};
-        $_argv = $_input->{'argv'};
-        $input = $_input->{'input'};
-        $validate = isset($_input->{'validate'}) ? $_input->{'validate'} : null;
-        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? ($_input->{'materializeDefaults'} !== null ? $_input->{'materializeDefaults'} : null) : null;
-        if (property_exists($_input, 'materializeDefaults')) {
+        $_GLOBALS_1 = $input->{'_GLOBALS'};
+        $_GLOBALS_2 = $input->{'GLOBALS'};
+        $GLOBALS1 = $input->{'GLOBALS_1'};
+        $_SERVER_1 = $input->{'_SERVER'};
+        $_GET_1 = $input->{'_GET'};
+        $_POST_1 = $input->{'_POST'};
+        $_FILES_1 = $input->{'_FILES'};
+        $_REQUEST_1 = $input->{'_REQUEST'};
+        $_SESSION_1 = $input->{'_SESSION'};
+        $_ENV_1 = $input->{'_ENV'};
+        $_COOKIE_1 = $input->{'_COOKIE'};
+        $_phpErrormsg = $input->{'php_errormsg'};
+        $_httpResponseHeader = $input->{'http_response_header'};
+        $_argc = $input->{'argc'};
+        $_argv = $input->{'argv'};
+        $_input = $input->{'input'};
+        $_validate = isset($input->{'validate'}) ? $input->{'validate'} : null;
+        $_materializeDefaults = property_exists($input, 'materializeDefaults') ? ($input->{'materializeDefaults'} !== null ? $input->{'materializeDefaults'} : null) : null;
+        if (property_exists($input, 'materializeDefaults')) {
             $__providedOptionals['materializeDefaults'] = true;
         }
-        $obj = $_input->{'obj'};
-        $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::fromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
-        $_fromInput_1 = $_input->{'fromInput'};
-        $_toArray_1 = $_input->{'toArray'};
-        $_toStdClass_1 = $_input->{'toStdClass'};
-        $_validateInput_1 = $_input->{'validateInput'};
-        $_schema_1 = $_input->{'_schema'};
-        $_schema_2 = $_input->{'schema'};
-        $_defaults_1 = $_input->{'_defaults'};
-        $_defaults_2 = $_input->{'defaults'};
-        $_providedOptionals_1 = $_input->{'_providedOptionals'};
-        $_providedOptionals_2 = isset($_input->{'__providedOptionals'}) ? $_input->{'__providedOptionals'} : null;
-        $_clone_1 = $_input->{'clone'};
-        $_construct_1 = $_input->{'__construct'};
-        $_destruct_1 = $_input->{'__destruct'};
-        $_get_2 = $_input->{'__get'};
-        $_set_1 = $_input->{'__set'};
-        $_call_1 = $_input->{'__call'};
-        $_isset_1 = $_input->{'__isset'};
-        $_unset_1 = $_input->{'__unset'};
-        $_sleep_1 = $_input->{'__sleep'};
-        $_wakeup_1 = $_input->{'__wakeup'};
-        $_toString_1 = $_input->{'__toString'};
-        $_invoke_1 = $_input->{'__invoke'};
-        $_debugInfo_1 = $_input->{'__debugInfo'};
-        $_clone_2 = $_input->{'__clone'};
-        $files = $_input->{'files'};
-        $_this = $_input->{'this'};
-        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? ((is_string($_input->{'ensureArgs1'})) ? $_input->{'ensureArgs1'} : (((MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative2::fromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults) : (((MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative1::fromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults) : (null)))))) : null;
-        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults) : null;
-        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? array_map(fn ($i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::fromInput($i, $_validate, $_materializeDefaults), $_input->{'ensureArgs3'}) : null;
+        $_obj = $input->{'obj'};
+        $includeDefaults = $input->{'includeDefaults'};
+        $testObj = isset($input->{'testObj'}) ? MyClassTestObj::fromInput($input->{'testObj'}, $validate, $materializeDefaults) : null;
+        $fromInput = $input->{'fromInput'};
+        $toArray = $input->{'toArray'};
+        $toStdClass = $input->{'toStdClass'};
+        $validateInput = $input->{'validateInput'};
+        $_schema_1 = $input->{'_schema'};
+        $_schema_2 = $input->{'schema'};
+        $_defaults_1 = $input->{'_defaults'};
+        $_defaults_2 = $input->{'defaults'};
+        $_providedOptionals_1 = $input->{'_providedOptionals'};
+        $_providedOptionals_2 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
+        $clone = $input->{'clone'};
+        $construct = $input->{'__construct'};
+        $destruct = $input->{'__destruct'};
+        $get = $input->{'__get'};
+        $set = $input->{'__set'};
+        $call = $input->{'__call'};
+        $isset = $input->{'__isset'};
+        $unset = $input->{'__unset'};
+        $sleep = $input->{'__sleep'};
+        $wakeup = $input->{'__wakeup'};
+        $toString = $input->{'__toString'};
+        $invoke = $input->{'__invoke'};
+        $debugInfo = $input->{'__debugInfo'};
+        $_clone = $input->{'__clone'};
+        $files = $input->{'files'};
+        $_this = $input->{'this'};
+        $ensureArgs1 = isset($input->{'ensureArgs1'}) ? ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : (((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (null)))))) : null;
+        $ensureArgs2 = isset($input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($input->{'ensureArgs2'}, $validate, $materializeDefaults) : null;
+        $ensureArgs3 = isset($input->{'ensureArgs3'}) ? array_map(fn ($i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::fromInput($i, $validate, $materializeDefaults), $input->{'ensureArgs3'}) : null;
 
-        $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $input, $obj, $includeDefaults, $_fromInput_1, $_toArray_1, $_toStdClass_1, $_validateInput_1, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone_1, $_construct_1, $_destruct_1, $_get_2, $_set_1, $_call_1, $_isset_1, $_unset_1, $_sleep_1, $_wakeup_1, $_toString_1, $_invoke_1, $_debugInfo_1, $_clone_2, $files, $_this);
-        $_obj->validate = $validate;
-        $_obj->materializeDefaults = $materializeDefaults;
+        $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $GLOBALS1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $clone, $construct, $destruct, $get, $set, $call, $isset, $unset, $sleep, $wakeup, $toString, $invoke, $debugInfo, $_clone, $files, $_this);
+        $_obj->validate = $_validate;
+        $_obj->materializeDefaults = $_materializeDefaults;
         $_obj->testObj = $testObj;
         $_obj->_providedOptionals_2 = $_providedOptionals_2;
         $_obj->ensureArgs1 = $ensureArgs1;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
@@ -2148,94 +2148,87 @@ class MyClass
      */
     public static function fromInput(array|object $input, bool $validate = true, bool $materializeDefaults = false): MyClass
     {
-        $_input = $input;
-        unset($input);
-        $_validate = $validate;
-        unset($validate);
-        $_materializeDefaults = $materializeDefaults;
-        unset($materializeDefaults);
+        $input = is_array($input)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($input)
+            : ($materializeDefaults ? clone $input : $input);
 
-        $_input = is_array($_input)
-            ? \JsonSchema\Validator::arrayToObjectRecursive($_input)
-            : ($_materializeDefaults ? clone $_input : $_input);
-
-        if ($_materializeDefaults) {
+        if ($materializeDefaults) {
             foreach (self::$_defaults as $__k => $__v) {
-                if (!property_exists($_input, (string) $__k)) {
-                    $_input->{$__k} = ($__v['type'] ?? null) === 'object'
+                if (!property_exists($input, (string) $__k)) {
+                    $input->{$__k} = ($__v['type'] ?? null) === 'object'
                         ? \JsonSchema\Validator::arrayToObjectRecursive($__v['default'])
                         : $__v['default'];
                 }
             }
         }
 
-        if ($_validate) {
-            static::validateInput($_input);
+        if ($validate) {
+            static::validateInput($input);
         }
 
         $__providedOptionals = [];
-        $_GLOBALS_1 = $_input->{'_GLOBALS'};
-        $_GLOBALS_2 = $_input->{'GLOBALS'};
-        $_GLOBALS1_1 = $_input->{'GLOBALS_1'};
-        $_SERVER_1 = $_input->{'_SERVER'};
-        $_GET_1 = $_input->{'_GET'};
-        $_POST_1 = $_input->{'_POST'};
-        $_FILES_1 = $_input->{'_FILES'};
-        $_REQUEST_1 = $_input->{'_REQUEST'};
-        $_SESSION_1 = $_input->{'_SESSION'};
-        $_ENV_1 = $_input->{'_ENV'};
-        $_COOKIE_1 = $_input->{'_COOKIE'};
-        $_phpErrormsg = $_input->{'php_errormsg'};
-        $_httpResponseHeader = $_input->{'http_response_header'};
-        $_argc = $_input->{'argc'};
-        $_argv = $_input->{'argv'};
-        $input = $_input->{'input'};
-        $validate = isset($_input->{'validate'}) ? $_input->{'validate'} : null;
-        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? ($_input->{'materializeDefaults'} !== null ? $_input->{'materializeDefaults'} : null) : null;
-        if (property_exists($_input, 'materializeDefaults')) {
+        $_GLOBALS_1 = $input->{'_GLOBALS'};
+        $_GLOBALS_2 = $input->{'GLOBALS'};
+        $GLOBALS1 = $input->{'GLOBALS_1'};
+        $_SERVER_1 = $input->{'_SERVER'};
+        $_GET_1 = $input->{'_GET'};
+        $_POST_1 = $input->{'_POST'};
+        $_FILES_1 = $input->{'_FILES'};
+        $_REQUEST_1 = $input->{'_REQUEST'};
+        $_SESSION_1 = $input->{'_SESSION'};
+        $_ENV_1 = $input->{'_ENV'};
+        $_COOKIE_1 = $input->{'_COOKIE'};
+        $_phpErrormsg = $input->{'php_errormsg'};
+        $_httpResponseHeader = $input->{'http_response_header'};
+        $_argc = $input->{'argc'};
+        $_argv = $input->{'argv'};
+        $_input = $input->{'input'};
+        $_validate = isset($input->{'validate'}) ? $input->{'validate'} : null;
+        $_materializeDefaults = property_exists($input, 'materializeDefaults') ? ($input->{'materializeDefaults'} !== null ? $input->{'materializeDefaults'} : null) : null;
+        if (property_exists($input, 'materializeDefaults')) {
             $__providedOptionals['materializeDefaults'] = true;
         }
-        $obj = $_input->{'obj'};
-        $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::fromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
-        $_fromInput_1 = $_input->{'fromInput'};
-        $_toArray_1 = $_input->{'toArray'};
-        $_toStdClass_1 = $_input->{'toStdClass'};
-        $_validateInput_1 = $_input->{'validateInput'};
-        $_schema_1 = $_input->{'_schema'};
-        $_schema_2 = $_input->{'schema'};
-        $_defaults_1 = $_input->{'_defaults'};
-        $_defaults_2 = $_input->{'defaults'};
-        $_providedOptionals_1 = $_input->{'_providedOptionals'};
-        $_providedOptionals_2 = isset($_input->{'__providedOptionals'}) ? $_input->{'__providedOptionals'} : null;
-        $_clone_1 = $_input->{'clone'};
-        $_construct_1 = $_input->{'__construct'};
-        $_destruct_1 = $_input->{'__destruct'};
-        $_get_2 = $_input->{'__get'};
-        $_set_1 = $_input->{'__set'};
-        $_call_1 = $_input->{'__call'};
-        $_isset_1 = $_input->{'__isset'};
-        $_unset_1 = $_input->{'__unset'};
-        $_sleep_1 = $_input->{'__sleep'};
-        $_wakeup_1 = $_input->{'__wakeup'};
-        $_toString_1 = $_input->{'__toString'};
-        $_invoke_1 = $_input->{'__invoke'};
-        $_debugInfo_1 = $_input->{'__debugInfo'};
-        $_clone_2 = $_input->{'__clone'};
-        $files = $_input->{'files'};
-        $_this = $_input->{'this'};
-        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? match (true) {
-            MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true) => MyClassEnsureArgs1Alternative1::fromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults),
-            MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true) => MyClassEnsureArgs1Alternative2::fromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults),
-            is_string($_input->{'ensureArgs1'}) => $_input->{'ensureArgs1'},
+        $_obj = $input->{'obj'};
+        $includeDefaults = $input->{'includeDefaults'};
+        $testObj = isset($input->{'testObj'}) ? MyClassTestObj::fromInput($input->{'testObj'}, $validate, $materializeDefaults) : null;
+        $fromInput = $input->{'fromInput'};
+        $toArray = $input->{'toArray'};
+        $toStdClass = $input->{'toStdClass'};
+        $validateInput = $input->{'validateInput'};
+        $_schema_1 = $input->{'_schema'};
+        $_schema_2 = $input->{'schema'};
+        $_defaults_1 = $input->{'_defaults'};
+        $_defaults_2 = $input->{'defaults'};
+        $_providedOptionals_1 = $input->{'_providedOptionals'};
+        $_providedOptionals_2 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
+        $clone = $input->{'clone'};
+        $construct = $input->{'__construct'};
+        $destruct = $input->{'__destruct'};
+        $get = $input->{'__get'};
+        $set = $input->{'__set'};
+        $call = $input->{'__call'};
+        $isset = $input->{'__isset'};
+        $unset = $input->{'__unset'};
+        $sleep = $input->{'__sleep'};
+        $wakeup = $input->{'__wakeup'};
+        $toString = $input->{'__toString'};
+        $invoke = $input->{'__invoke'};
+        $debugInfo = $input->{'__debugInfo'};
+        $_clone = $input->{'__clone'};
+        $files = $input->{'files'};
+        $_this = $input->{'this'};
+        $ensureArgs1 = isset($input->{'ensureArgs1'}) ? match (true) {
+            MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true) => MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults),
+            MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true) => MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults),
+            is_string($input->{'ensureArgs1'}) => $input->{'ensureArgs1'},
             default => null,
         } : null;
-        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults) : null;
-        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? array_map(fn (array|object $i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::fromInput($i, $_validate, $_materializeDefaults), $_input->{'ensureArgs3'}) : null;
+        $ensureArgs2 = isset($input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($input->{'ensureArgs2'}, $validate, $materializeDefaults) : null;
+        $ensureArgs3 = isset($input->{'ensureArgs3'}) ? array_map(fn (array|object $i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::fromInput($i, $validate, $materializeDefaults), $input->{'ensureArgs3'}) : null;
 
-        $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $input, $obj, $includeDefaults, $_fromInput_1, $_toArray_1, $_toStdClass_1, $_validateInput_1, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone_1, $_construct_1, $_destruct_1, $_get_2, $_set_1, $_call_1, $_isset_1, $_unset_1, $_sleep_1, $_wakeup_1, $_toString_1, $_invoke_1, $_debugInfo_1, $_clone_2, $files, $_this);
-        $_obj->validate = $validate;
-        $_obj->materializeDefaults = $materializeDefaults;
+        $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $GLOBALS1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $clone, $construct, $destruct, $get, $set, $call, $isset, $unset, $sleep, $wakeup, $toString, $invoke, $debugInfo, $_clone, $files, $_this);
+        $_obj->validate = $_validate;
+        $_obj->materializeDefaults = $_materializeDefaults;
         $_obj->testObj = $testObj;
         $_obj->_providedOptionals_2 = $_providedOptionals_2;
         $_obj->ensureArgs1 = $ensureArgs1;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -2146,97 +2146,90 @@ class MyClass
      */
     public static function fromInput($input, bool $validate = true, bool $materializeDefaults = false)
     {
-        $_input = $input;
-        unset($input);
-        $_validate = $validate;
-        unset($validate);
-        $_materializeDefaults = $materializeDefaults;
-        unset($materializeDefaults);
-
-        if (!is_array($_input) && !is_object($_input)) {
+        if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(
-                'Input to fromInput must be array or object, got ' . gettype($_input)
+                'Input to fromInput must be array or object, got ' . gettype($input)
             );
         }
 
-        $_input = is_array($_input)
-            ? \JsonSchema\Validator::arrayToObjectRecursive($_input)
-            : ($_materializeDefaults ? clone $_input : $_input);
+        $input = is_array($input)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($input)
+            : ($materializeDefaults ? clone $input : $input);
 
-        if ($_materializeDefaults) {
+        if ($materializeDefaults) {
             foreach (self::$_defaults as $__k => $__v) {
-                if (!property_exists($_input, (string) $__k)) {
-                    $_input->{$__k} = ($__v['type'] ?? null) === 'object'
+                if (!property_exists($input, (string) $__k)) {
+                    $input->{$__k} = ($__v['type'] ?? null) === 'object'
                         ? \JsonSchema\Validator::arrayToObjectRecursive($__v['default'])
                         : $__v['default'];
                 }
             }
         }
 
-        if ($_validate) {
-            static::validateInput($_input);
+        if ($validate) {
+            static::validateInput($input);
         }
 
         $___providedOptionals = [];
-        $_GLOBALS_1 = $_input->{'_GLOBALS'};
-        $_GLOBALS_2 = $_input->{'GLOBALS'};
-        $GLOBALS_1 = $_input->{'GLOBALS_1'};
-        $_SERVER_1 = $_input->{'_SERVER'};
-        $_GET_1 = $_input->{'_GET'};
-        $_POST_1 = $_input->{'_POST'};
-        $_FILES_1 = $_input->{'_FILES'};
-        $_REQUEST_1 = $_input->{'_REQUEST'};
-        $_SESSION_1 = $_input->{'_SESSION'};
-        $_ENV_1 = $_input->{'_ENV'};
-        $_COOKIE_1 = $_input->{'_COOKIE'};
-        $_php_errormsg = $_input->{'php_errormsg'};
-        $_http_response_header = $_input->{'http_response_header'};
-        $_argc = $_input->{'argc'};
-        $_argv = $_input->{'argv'};
-        $input = $_input->{'input'};
-        $validate = isset($_input->{'validate'}) ? $_input->{'validate'} : null;
-        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? ($_input->{'materializeDefaults'} !== null ? $_input->{'materializeDefaults'} : null) : null;
-        if (property_exists($_input, 'materializeDefaults')) {
+        $_GLOBALS_1 = $input->{'_GLOBALS'};
+        $_GLOBALS_2 = $input->{'GLOBALS'};
+        $GLOBALS_1 = $input->{'GLOBALS_1'};
+        $_SERVER_1 = $input->{'_SERVER'};
+        $_GET_1 = $input->{'_GET'};
+        $_POST_1 = $input->{'_POST'};
+        $_FILES_1 = $input->{'_FILES'};
+        $_REQUEST_1 = $input->{'_REQUEST'};
+        $_SESSION_1 = $input->{'_SESSION'};
+        $_ENV_1 = $input->{'_ENV'};
+        $_COOKIE_1 = $input->{'_COOKIE'};
+        $_php_errormsg = $input->{'php_errormsg'};
+        $_http_response_header = $input->{'http_response_header'};
+        $_argc = $input->{'argc'};
+        $_argv = $input->{'argv'};
+        $_input = $input->{'input'};
+        $_validate = isset($input->{'validate'}) ? $input->{'validate'} : null;
+        $_materializeDefaults = property_exists($input, 'materializeDefaults') ? ($input->{'materializeDefaults'} !== null ? $input->{'materializeDefaults'} : null) : null;
+        if (property_exists($input, 'materializeDefaults')) {
             $___providedOptionals['materializeDefaults'] = true;
         }
-        $obj = $_input->{'obj'};
-        $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::fromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
-        $_fromInput = $_input->{'fromInput'};
-        $_toArray = $_input->{'toArray'};
-        $_toStdClass = $_input->{'toStdClass'};
-        $_validateInput = $_input->{'validateInput'};
-        $_schema_1 = $_input->{'_schema'};
-        $_schema_2 = $_input->{'schema'};
-        $_defaults_1 = $_input->{'_defaults'};
-        $_defaults_2 = $_input->{'defaults'};
-        $_providedOptionals_1 = $_input->{'_providedOptionals'};
-        $__providedOptionals = isset($_input->{'__providedOptionals'}) ? $_input->{'__providedOptionals'} : null;
-        $_clone = $_input->{'clone'};
-        $__construct_1 = $_input->{'__construct'};
-        $__destruct_1 = $_input->{'__destruct'};
-        $__get_1 = $_input->{'__get'};
-        $__set_1 = $_input->{'__set'};
-        $__call_1 = $_input->{'__call'};
-        $__isset_1 = $_input->{'__isset'};
-        $__unset_1 = $_input->{'__unset'};
-        $__sleep_1 = $_input->{'__sleep'};
-        $__wakeup_1 = $_input->{'__wakeup'};
-        $__toString_1 = $_input->{'__toString'};
-        $__invoke_1 = $_input->{'__invoke'};
-        $__debugInfo_1 = $_input->{'__debugInfo'};
-        $__clone_1 = $_input->{'__clone'};
-        $files = $_input->{'files'};
-        $_this = $_input->{'this'};
-        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? ((is_string($_input->{'ensureArgs1'})) ? $_input->{'ensureArgs1'} : (((MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative2::fromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults) : (((MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative1::fromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults) : (null)))))) : null;
-        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults) : null;
-        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? array_map(function($i) use ($_validate, $_materializeDefaults) { return MyClassEnsureArgs3Item::fromInput($i, $_validate, $_materializeDefaults); }, $_input->{'ensureArgs3'}) : null;
+        $_obj = $input->{'obj'};
+        $includeDefaults = $input->{'includeDefaults'};
+        $testObj = isset($input->{'testObj'}) ? MyClassTestObj::fromInput($input->{'testObj'}, $validate, $materializeDefaults) : null;
+        $fromInput = $input->{'fromInput'};
+        $toArray = $input->{'toArray'};
+        $toStdClass = $input->{'toStdClass'};
+        $validateInput = $input->{'validateInput'};
+        $_schema_1 = $input->{'_schema'};
+        $_schema_2 = $input->{'schema'};
+        $_defaults_1 = $input->{'_defaults'};
+        $_defaults_2 = $input->{'defaults'};
+        $_providedOptionals_1 = $input->{'_providedOptionals'};
+        $__providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
+        $clone = $input->{'clone'};
+        $__construct = $input->{'__construct'};
+        $__destruct = $input->{'__destruct'};
+        $__get = $input->{'__get'};
+        $__set = $input->{'__set'};
+        $__call = $input->{'__call'};
+        $__isset = $input->{'__isset'};
+        $__unset = $input->{'__unset'};
+        $__sleep = $input->{'__sleep'};
+        $__wakeup = $input->{'__wakeup'};
+        $__toString = $input->{'__toString'};
+        $__invoke = $input->{'__invoke'};
+        $__debugInfo = $input->{'__debugInfo'};
+        $__clone = $input->{'__clone'};
+        $files = $input->{'files'};
+        $_this = $input->{'this'};
+        $ensureArgs1 = isset($input->{'ensureArgs1'}) ? ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : (((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (null)))))) : null;
+        $ensureArgs2 = isset($input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($input->{'ensureArgs2'}, $validate, $materializeDefaults) : null;
+        $ensureArgs3 = isset($input->{'ensureArgs3'}) ? array_map(function($i) use ($validate, $materializeDefaults) { return MyClassEnsureArgs3Item::fromInput($i, $validate, $materializeDefaults); }, $input->{'ensureArgs3'}) : null;
 
-        $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $input, $obj, $includeDefaults, $_fromInput, $_toArray, $_toStdClass, $_validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone, $__construct_1, $__destruct_1, $__get_1, $__set_1, $__call_1, $__isset_1, $__unset_1, $__sleep_1, $__wakeup_1, $__toString_1, $__invoke_1, $__debugInfo_1, $__clone_1, $files, $_this);
-        $_obj->validate = $validate;
-        $_obj->materializeDefaults = $materializeDefaults;
+        $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $clone, $__construct, $__destruct, $__get, $__set, $__call, $__isset, $__unset, $__sleep, $__wakeup, $__toString, $__invoke, $__debugInfo, $__clone, $files, $_this);
+        $_obj->validate = $_validate;
+        $_obj->materializeDefaults = $_materializeDefaults;
         $_obj->testObj = $testObj;
-        $_obj->__providedOptionals = $__providedOptionals;
+        $_obj->__providedOptionals = $__providedOptionals_1;
         $_obj->ensureArgs1 = $ensureArgs1;
         $_obj->ensureArgs2 = $ensureArgs2;
         $_obj->ensureArgs3 = $ensureArgs3;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -2148,97 +2148,90 @@ class MyClass
      */
     public static function fromInput($input, bool $validate = true, bool $materializeDefaults = false): MyClass
     {
-        $_input = $input;
-        unset($input);
-        $_validate = $validate;
-        unset($validate);
-        $_materializeDefaults = $materializeDefaults;
-        unset($materializeDefaults);
-
-        if (!is_array($_input) && !is_object($_input)) {
+        if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(
-                'Input to fromInput must be array or object, got ' . gettype($_input)
+                'Input to fromInput must be array or object, got ' . gettype($input)
             );
         }
 
-        $_input = is_array($_input)
-            ? \JsonSchema\Validator::arrayToObjectRecursive($_input)
-            : ($_materializeDefaults ? clone $_input : $_input);
+        $input = is_array($input)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($input)
+            : ($materializeDefaults ? clone $input : $input);
 
-        if ($_materializeDefaults) {
+        if ($materializeDefaults) {
             foreach (self::$_defaults as $__k => $__v) {
-                if (!property_exists($_input, (string) $__k)) {
-                    $_input->{$__k} = ($__v['type'] ?? null) === 'object'
+                if (!property_exists($input, (string) $__k)) {
+                    $input->{$__k} = ($__v['type'] ?? null) === 'object'
                         ? \JsonSchema\Validator::arrayToObjectRecursive($__v['default'])
                         : $__v['default'];
                 }
             }
         }
 
-        if ($_validate) {
-            static::validateInput($_input);
+        if ($validate) {
+            static::validateInput($input);
         }
 
         $___providedOptionals = [];
-        $_GLOBALS_1 = $_input->{'_GLOBALS'};
-        $_GLOBALS_2 = $_input->{'GLOBALS'};
-        $GLOBALS_1 = $_input->{'GLOBALS_1'};
-        $_SERVER_1 = $_input->{'_SERVER'};
-        $_GET_1 = $_input->{'_GET'};
-        $_POST_1 = $_input->{'_POST'};
-        $_FILES_1 = $_input->{'_FILES'};
-        $_REQUEST_1 = $_input->{'_REQUEST'};
-        $_SESSION_1 = $_input->{'_SESSION'};
-        $_ENV_1 = $_input->{'_ENV'};
-        $_COOKIE_1 = $_input->{'_COOKIE'};
-        $_php_errormsg = $_input->{'php_errormsg'};
-        $_http_response_header = $_input->{'http_response_header'};
-        $_argc = $_input->{'argc'};
-        $_argv = $_input->{'argv'};
-        $input = $_input->{'input'};
-        $validate = isset($_input->{'validate'}) ? $_input->{'validate'} : null;
-        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? ($_input->{'materializeDefaults'} !== null ? $_input->{'materializeDefaults'} : null) : null;
-        if (property_exists($_input, 'materializeDefaults')) {
+        $_GLOBALS_1 = $input->{'_GLOBALS'};
+        $_GLOBALS_2 = $input->{'GLOBALS'};
+        $GLOBALS_1 = $input->{'GLOBALS_1'};
+        $_SERVER_1 = $input->{'_SERVER'};
+        $_GET_1 = $input->{'_GET'};
+        $_POST_1 = $input->{'_POST'};
+        $_FILES_1 = $input->{'_FILES'};
+        $_REQUEST_1 = $input->{'_REQUEST'};
+        $_SESSION_1 = $input->{'_SESSION'};
+        $_ENV_1 = $input->{'_ENV'};
+        $_COOKIE_1 = $input->{'_COOKIE'};
+        $_php_errormsg = $input->{'php_errormsg'};
+        $_http_response_header = $input->{'http_response_header'};
+        $_argc = $input->{'argc'};
+        $_argv = $input->{'argv'};
+        $_input = $input->{'input'};
+        $_validate = isset($input->{'validate'}) ? $input->{'validate'} : null;
+        $_materializeDefaults = property_exists($input, 'materializeDefaults') ? ($input->{'materializeDefaults'} !== null ? $input->{'materializeDefaults'} : null) : null;
+        if (property_exists($input, 'materializeDefaults')) {
             $___providedOptionals['materializeDefaults'] = true;
         }
-        $obj = $_input->{'obj'};
-        $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::fromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
-        $_fromInput = $_input->{'fromInput'};
-        $_toArray = $_input->{'toArray'};
-        $_toStdClass = $_input->{'toStdClass'};
-        $_validateInput = $_input->{'validateInput'};
-        $_schema_1 = $_input->{'_schema'};
-        $_schema_2 = $_input->{'schema'};
-        $_defaults_1 = $_input->{'_defaults'};
-        $_defaults_2 = $_input->{'defaults'};
-        $_providedOptionals_1 = $_input->{'_providedOptionals'};
-        $__providedOptionals = isset($_input->{'__providedOptionals'}) ? $_input->{'__providedOptionals'} : null;
-        $_clone = $_input->{'clone'};
-        $__construct_1 = $_input->{'__construct'};
-        $__destruct_1 = $_input->{'__destruct'};
-        $__get_1 = $_input->{'__get'};
-        $__set_1 = $_input->{'__set'};
-        $__call_1 = $_input->{'__call'};
-        $__isset_1 = $_input->{'__isset'};
-        $__unset_1 = $_input->{'__unset'};
-        $__sleep_1 = $_input->{'__sleep'};
-        $__wakeup_1 = $_input->{'__wakeup'};
-        $__toString_1 = $_input->{'__toString'};
-        $__invoke_1 = $_input->{'__invoke'};
-        $__debugInfo_1 = $_input->{'__debugInfo'};
-        $__clone_1 = $_input->{'__clone'};
-        $files = $_input->{'files'};
-        $_this = $_input->{'this'};
-        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? ((is_string($_input->{'ensureArgs1'})) ? $_input->{'ensureArgs1'} : (((MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative2::fromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults) : (((MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative1::fromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults) : (null)))))) : null;
-        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults) : null;
-        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? array_map(fn ($i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::fromInput($i, $_validate, $_materializeDefaults), $_input->{'ensureArgs3'}) : null;
+        $_obj = $input->{'obj'};
+        $includeDefaults = $input->{'includeDefaults'};
+        $testObj = isset($input->{'testObj'}) ? MyClassTestObj::fromInput($input->{'testObj'}, $validate, $materializeDefaults) : null;
+        $fromInput = $input->{'fromInput'};
+        $toArray = $input->{'toArray'};
+        $toStdClass = $input->{'toStdClass'};
+        $validateInput = $input->{'validateInput'};
+        $_schema_1 = $input->{'_schema'};
+        $_schema_2 = $input->{'schema'};
+        $_defaults_1 = $input->{'_defaults'};
+        $_defaults_2 = $input->{'defaults'};
+        $_providedOptionals_1 = $input->{'_providedOptionals'};
+        $__providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
+        $clone = $input->{'clone'};
+        $__construct = $input->{'__construct'};
+        $__destruct = $input->{'__destruct'};
+        $__get = $input->{'__get'};
+        $__set = $input->{'__set'};
+        $__call = $input->{'__call'};
+        $__isset = $input->{'__isset'};
+        $__unset = $input->{'__unset'};
+        $__sleep = $input->{'__sleep'};
+        $__wakeup = $input->{'__wakeup'};
+        $__toString = $input->{'__toString'};
+        $__invoke = $input->{'__invoke'};
+        $__debugInfo = $input->{'__debugInfo'};
+        $__clone = $input->{'__clone'};
+        $files = $input->{'files'};
+        $_this = $input->{'this'};
+        $ensureArgs1 = isset($input->{'ensureArgs1'}) ? ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : (((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (null)))))) : null;
+        $ensureArgs2 = isset($input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($input->{'ensureArgs2'}, $validate, $materializeDefaults) : null;
+        $ensureArgs3 = isset($input->{'ensureArgs3'}) ? array_map(fn ($i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::fromInput($i, $validate, $materializeDefaults), $input->{'ensureArgs3'}) : null;
 
-        $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $input, $obj, $includeDefaults, $_fromInput, $_toArray, $_toStdClass, $_validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone, $__construct_1, $__destruct_1, $__get_1, $__set_1, $__call_1, $__isset_1, $__unset_1, $__sleep_1, $__wakeup_1, $__toString_1, $__invoke_1, $__debugInfo_1, $__clone_1, $files, $_this);
-        $_obj->validate = $validate;
-        $_obj->materializeDefaults = $materializeDefaults;
+        $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $clone, $__construct, $__destruct, $__get, $__set, $__call, $__isset, $__unset, $__sleep, $__wakeup, $__toString, $__invoke, $__debugInfo, $__clone, $files, $_this);
+        $_obj->validate = $_validate;
+        $_obj->materializeDefaults = $_materializeDefaults;
         $_obj->testObj = $testObj;
-        $_obj->__providedOptionals = $__providedOptionals;
+        $_obj->__providedOptionals = $__providedOptionals_1;
         $_obj->ensureArgs1 = $ensureArgs1;
         $_obj->ensureArgs2 = $ensureArgs2;
         $_obj->ensureArgs3 = $ensureArgs3;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
@@ -2148,96 +2148,89 @@ class MyClass
      */
     public static function fromInput(array|object $input, bool $validate = true, bool $materializeDefaults = false): MyClass
     {
-        $_input = $input;
-        unset($input);
-        $_validate = $validate;
-        unset($validate);
-        $_materializeDefaults = $materializeDefaults;
-        unset($materializeDefaults);
+        $input = is_array($input)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($input)
+            : ($materializeDefaults ? clone $input : $input);
 
-        $_input = is_array($_input)
-            ? \JsonSchema\Validator::arrayToObjectRecursive($_input)
-            : ($_materializeDefaults ? clone $_input : $_input);
-
-        if ($_materializeDefaults) {
+        if ($materializeDefaults) {
             foreach (self::$_defaults as $__k => $__v) {
-                if (!property_exists($_input, (string) $__k)) {
-                    $_input->{$__k} = ($__v['type'] ?? null) === 'object'
+                if (!property_exists($input, (string) $__k)) {
+                    $input->{$__k} = ($__v['type'] ?? null) === 'object'
                         ? \JsonSchema\Validator::arrayToObjectRecursive($__v['default'])
                         : $__v['default'];
                 }
             }
         }
 
-        if ($_validate) {
-            static::validateInput($_input);
+        if ($validate) {
+            static::validateInput($input);
         }
 
         $___providedOptionals = [];
-        $_GLOBALS_1 = $_input->{'_GLOBALS'};
-        $_GLOBALS_2 = $_input->{'GLOBALS'};
-        $GLOBALS_1 = $_input->{'GLOBALS_1'};
-        $_SERVER_1 = $_input->{'_SERVER'};
-        $_GET_1 = $_input->{'_GET'};
-        $_POST_1 = $_input->{'_POST'};
-        $_FILES_1 = $_input->{'_FILES'};
-        $_REQUEST_1 = $_input->{'_REQUEST'};
-        $_SESSION_1 = $_input->{'_SESSION'};
-        $_ENV_1 = $_input->{'_ENV'};
-        $_COOKIE_1 = $_input->{'_COOKIE'};
-        $_php_errormsg = $_input->{'php_errormsg'};
-        $_http_response_header = $_input->{'http_response_header'};
-        $_argc = $_input->{'argc'};
-        $_argv = $_input->{'argv'};
-        $input = $_input->{'input'};
-        $validate = isset($_input->{'validate'}) ? $_input->{'validate'} : null;
-        $materializeDefaults = property_exists($_input, 'materializeDefaults') ? ($_input->{'materializeDefaults'} !== null ? $_input->{'materializeDefaults'} : null) : null;
-        if (property_exists($_input, 'materializeDefaults')) {
+        $_GLOBALS_1 = $input->{'_GLOBALS'};
+        $_GLOBALS_2 = $input->{'GLOBALS'};
+        $GLOBALS_1 = $input->{'GLOBALS_1'};
+        $_SERVER_1 = $input->{'_SERVER'};
+        $_GET_1 = $input->{'_GET'};
+        $_POST_1 = $input->{'_POST'};
+        $_FILES_1 = $input->{'_FILES'};
+        $_REQUEST_1 = $input->{'_REQUEST'};
+        $_SESSION_1 = $input->{'_SESSION'};
+        $_ENV_1 = $input->{'_ENV'};
+        $_COOKIE_1 = $input->{'_COOKIE'};
+        $_php_errormsg = $input->{'php_errormsg'};
+        $_http_response_header = $input->{'http_response_header'};
+        $_argc = $input->{'argc'};
+        $_argv = $input->{'argv'};
+        $_input = $input->{'input'};
+        $_validate = isset($input->{'validate'}) ? $input->{'validate'} : null;
+        $_materializeDefaults = property_exists($input, 'materializeDefaults') ? ($input->{'materializeDefaults'} !== null ? $input->{'materializeDefaults'} : null) : null;
+        if (property_exists($input, 'materializeDefaults')) {
             $___providedOptionals['materializeDefaults'] = true;
         }
-        $obj = $_input->{'obj'};
-        $includeDefaults = $_input->{'includeDefaults'};
-        $testObj = isset($_input->{'testObj'}) ? MyClassTestObj::fromInput($_input->{'testObj'}, $_validate, $_materializeDefaults) : null;
-        $_fromInput = $_input->{'fromInput'};
-        $_toArray = $_input->{'toArray'};
-        $_toStdClass = $_input->{'toStdClass'};
-        $_validateInput = $_input->{'validateInput'};
-        $_schema_1 = $_input->{'_schema'};
-        $_schema_2 = $_input->{'schema'};
-        $_defaults_1 = $_input->{'_defaults'};
-        $_defaults_2 = $_input->{'defaults'};
-        $_providedOptionals_1 = $_input->{'_providedOptionals'};
-        $__providedOptionals = isset($_input->{'__providedOptionals'}) ? $_input->{'__providedOptionals'} : null;
-        $_clone = $_input->{'clone'};
-        $__construct_1 = $_input->{'__construct'};
-        $__destruct_1 = $_input->{'__destruct'};
-        $__get_1 = $_input->{'__get'};
-        $__set_1 = $_input->{'__set'};
-        $__call_1 = $_input->{'__call'};
-        $__isset_1 = $_input->{'__isset'};
-        $__unset_1 = $_input->{'__unset'};
-        $__sleep_1 = $_input->{'__sleep'};
-        $__wakeup_1 = $_input->{'__wakeup'};
-        $__toString_1 = $_input->{'__toString'};
-        $__invoke_1 = $_input->{'__invoke'};
-        $__debugInfo_1 = $_input->{'__debugInfo'};
-        $__clone_1 = $_input->{'__clone'};
-        $files = $_input->{'files'};
-        $_this = $_input->{'this'};
-        $ensureArgs1 = isset($_input->{'ensureArgs1'}) ? match (true) {
-            MyClassEnsureArgs1Alternative1::validateInput($_input->{'ensureArgs1'}, true) => MyClassEnsureArgs1Alternative1::fromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults),
-            MyClassEnsureArgs1Alternative2::validateInput($_input->{'ensureArgs1'}, true) => MyClassEnsureArgs1Alternative2::fromInput($_input->{'ensureArgs1'}, $_validate, $_materializeDefaults),
-            is_string($_input->{'ensureArgs1'}) => $_input->{'ensureArgs1'},
+        $_obj = $input->{'obj'};
+        $includeDefaults = $input->{'includeDefaults'};
+        $testObj = isset($input->{'testObj'}) ? MyClassTestObj::fromInput($input->{'testObj'}, $validate, $materializeDefaults) : null;
+        $fromInput = $input->{'fromInput'};
+        $toArray = $input->{'toArray'};
+        $toStdClass = $input->{'toStdClass'};
+        $validateInput = $input->{'validateInput'};
+        $_schema_1 = $input->{'_schema'};
+        $_schema_2 = $input->{'schema'};
+        $_defaults_1 = $input->{'_defaults'};
+        $_defaults_2 = $input->{'defaults'};
+        $_providedOptionals_1 = $input->{'_providedOptionals'};
+        $__providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
+        $clone = $input->{'clone'};
+        $__construct = $input->{'__construct'};
+        $__destruct = $input->{'__destruct'};
+        $__get = $input->{'__get'};
+        $__set = $input->{'__set'};
+        $__call = $input->{'__call'};
+        $__isset = $input->{'__isset'};
+        $__unset = $input->{'__unset'};
+        $__sleep = $input->{'__sleep'};
+        $__wakeup = $input->{'__wakeup'};
+        $__toString = $input->{'__toString'};
+        $__invoke = $input->{'__invoke'};
+        $__debugInfo = $input->{'__debugInfo'};
+        $__clone = $input->{'__clone'};
+        $files = $input->{'files'};
+        $_this = $input->{'this'};
+        $ensureArgs1 = isset($input->{'ensureArgs1'}) ? match (true) {
+            MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true) => MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults),
+            MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true) => MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults),
+            is_string($input->{'ensureArgs1'}) => $input->{'ensureArgs1'},
             default => null,
         } : null;
-        $ensureArgs2 = isset($_input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($_input->{'ensureArgs2'}, $_validate, $_materializeDefaults) : null;
-        $ensureArgs3 = isset($_input->{'ensureArgs3'}) ? array_map(fn (array|object $i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::fromInput($i, $_validate, $_materializeDefaults), $_input->{'ensureArgs3'}) : null;
+        $ensureArgs2 = isset($input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($input->{'ensureArgs2'}, $validate, $materializeDefaults) : null;
+        $ensureArgs3 = isset($input->{'ensureArgs3'}) ? array_map(fn (array|object $i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::fromInput($i, $validate, $materializeDefaults), $input->{'ensureArgs3'}) : null;
 
-        $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $input, $obj, $includeDefaults, $_fromInput, $_toArray, $_toStdClass, $_validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone, $__construct_1, $__destruct_1, $__get_1, $__set_1, $__call_1, $__isset_1, $__unset_1, $__sleep_1, $__wakeup_1, $__toString_1, $__invoke_1, $__debugInfo_1, $__clone_1, $files, $_this);
-        $_obj->validate = $validate;
-        $_obj->materializeDefaults = $materializeDefaults;
+        $_obj = new self($_GLOBALS_1, $_GLOBALS_2, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $clone, $__construct, $__destruct, $__get, $__set, $__call, $__isset, $__unset, $__sleep, $__wakeup, $__toString, $__invoke, $__debugInfo, $__clone, $files, $_this);
+        $_obj->validate = $_validate;
+        $_obj->materializeDefaults = $_materializeDefaults;
         $_obj->testObj = $testObj;
-        $_obj->__providedOptionals = $__providedOptionals;
+        $_obj->__providedOptionals = $__providedOptionals_1;
         $_obj->ensureArgs1 = $ensureArgs1;
         $_obj->ensureArgs2 = $ensureArgs2;
         $_obj->ensureArgs3 = $ensureArgs3;

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -851,24 +851,24 @@ class MyClass
         $xyyz = isset($input->{'xyyz'}) ? match (true) {
             is_string($input->{'xyyz'}),
             is_array($input->{'xyyz'}) => $input->{'xyyz'},
-            ObjDef::validateInput($input->{'xyyz'}, true) => ObjDef::fromInput($input->{'xyyz'}, $validate, $materializeDefaults),
+            ObjDef::validateInput($input->{'xyyz'}, true) => ObjDef::fromInput($input->{'xyyz'}, $validate),
             default => null,
         } : null;
         $buux = isset($input->{'buux'}) ? match (true) {
             is_string($input->{'buux'}),
             is_array($input->{'buux'}) => $input->{'buux'},
-            ObjDef::validateInput($input->{'buux'}, true) => ObjDef::fromInput($input->{'buux'}, $validate, $materializeDefaults),
+            ObjDef::validateInput($input->{'buux'}, true) => ObjDef::fromInput($input->{'buux'}, $validate),
             default => null,
         } : null;
         $boic = isset($input->{'boic'}) ? match (true) {
             is_string($input->{'boic'}),
             is_array($input->{'boic'}) => $input->{'boic'},
-            ObjDef::validateInput($input->{'boic'}, true) => ObjDef::fromInput($input->{'boic'}, $validate, $materializeDefaults),
+            ObjDef::validateInput($input->{'boic'}, true) => ObjDef::fromInput($input->{'boic'}, $validate),
             default => null,
         } : null;
         $poox = isset($input->{'poox'}) ? match (true) {
             is_string($input->{'poox'}) => $input->{'poox'},
-            NumericKeysObj::validateInput($input->{'poox'}, true) => NumericKeysObj::fromInput($input->{'poox'}, $validate, $materializeDefaults),
+            NumericKeysObj::validateInput($input->{'poox'}, true) => NumericKeysObj::fromInput($input->{'poox'}, $validate),
             default => null,
         } : null;
         $arrObjUnion = isset($input->{'arrObjUnion'}) ? match (true) {
@@ -926,27 +926,27 @@ class MyClass
             $output['xyyz'] = match (true) {
                 is_string($this->xyyz),
                 is_array($this->xyyz) => $this->xyyz,
-                ($this->xyyz) instanceof ObjDef => $this->xyyz->toArray($includeDefaults),
+                ($this->xyyz) instanceof ObjDef => $this->xyyz->toArray(),
             };
         }
         if (isset($this->buux)) {
             $output['buux'] = match (true) {
                 is_string($this->buux),
                 is_array($this->buux) => $this->buux,
-                ($this->buux) instanceof ObjDef => $this->buux->toArray($includeDefaults),
+                ($this->buux) instanceof ObjDef => $this->buux->toArray(),
             };
         }
         if (isset($this->boic)) {
             $output['boic'] = match (true) {
                 is_string($this->boic),
                 is_array($this->boic) => $this->boic,
-                ($this->boic) instanceof ObjDef => $this->boic->toArray($includeDefaults),
+                ($this->boic) instanceof ObjDef => $this->boic->toArray(),
             };
         }
         if (isset($this->poox)) {
             $output['poox'] = match (true) {
                 is_string($this->poox) => $this->poox,
-                ($this->poox) instanceof NumericKeysObj => $this->poox->toArray($includeDefaults),
+                ($this->poox) instanceof NumericKeysObj => $this->poox->toArray(),
             };
         }
         if (isset($this->arrObjUnion)) {
@@ -1003,27 +1003,27 @@ class MyClass
             $output->{'xyyz'} = match (true) {
                 is_string($this->xyyz),
                 is_array($this->xyyz) => $this->xyyz,
-                ($this->xyyz) instanceof ObjDef => $this->xyyz->toStdClass($includeDefaults),
+                ($this->xyyz) instanceof ObjDef => $this->xyyz->toStdClass(),
             };
         }
         if (isset($this->buux)) {
             $output->{'buux'} = match (true) {
                 is_string($this->buux),
                 is_array($this->buux) => $this->buux,
-                ($this->buux) instanceof ObjDef => $this->buux->toStdClass($includeDefaults),
+                ($this->buux) instanceof ObjDef => $this->buux->toStdClass(),
             };
         }
         if (isset($this->boic)) {
             $output->{'boic'} = match (true) {
                 is_string($this->boic),
                 is_array($this->boic) => $this->boic,
-                ($this->boic) instanceof ObjDef => $this->boic->toStdClass($includeDefaults),
+                ($this->boic) instanceof ObjDef => $this->boic->toStdClass(),
             };
         }
         if (isset($this->poox)) {
             $output->{'poox'} = match (true) {
                 is_string($this->poox) => $this->poox,
-                ($this->poox) instanceof NumericKeysObj => $this->poox->toStdClass($includeDefaults),
+                ($this->poox) instanceof NumericKeysObj => $this->poox->toStdClass(),
             };
         }
         if (isset($this->arrObjUnion)) {

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClassFilesItem.php
@@ -120,25 +120,22 @@ class MyClassFilesItem
      */
     public static function fromInput($input, bool $validate = true)
     {
-        $_input = $input;
-        unset($input);
-
-        if (!is_array($_input) && !is_object($_input)) {
+        if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(
-                'Input to fromInput must be array or object, got ' . gettype($_input)
+                'Input to fromInput must be array or object, got ' . gettype($input)
             );
         }
 
-        $_input = is_array($_input) ? \JsonSchema\Validator::arrayToObjectRecursive($_input) : $_input;
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
         if ($validate) {
-            static::validateInput($_input);
+            static::validateInput($input);
         }
 
-        $input = isset($_input->{'input'}) ? $_input->{'input'} : null;
-        $options = isset($_input->{'options'}) ? OptionsObject::fromInput($_input->{'options'}, $validate) : null;
+        $_input = isset($input->{'input'}) ? $input->{'input'} : null;
+        $options = isset($input->{'options'}) ? OptionsObject::fromInput($input->{'options'}, $validate) : null;
 
         $obj = new self();
-        $obj->input = $input;
+        $obj->input = $_input;
         $obj->options = $options;
         return $obj;
     }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
@@ -122,25 +122,22 @@ class MyClassFilesItem
      */
     public static function fromInput($input, bool $validate = true): MyClassFilesItem
     {
-        $_input = $input;
-        unset($input);
-
-        if (!is_array($_input) && !is_object($_input)) {
+        if (!is_array($input) && !is_object($input)) {
             throw new \InvalidArgumentException(
-                'Input to fromInput must be array or object, got ' . gettype($_input)
+                'Input to fromInput must be array or object, got ' . gettype($input)
             );
         }
 
-        $_input = is_array($_input) ? \JsonSchema\Validator::arrayToObjectRecursive($_input) : $_input;
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
         if ($validate) {
-            static::validateInput($_input);
+            static::validateInput($input);
         }
 
-        $input = isset($_input->{'input'}) ? $_input->{'input'} : null;
-        $options = isset($_input->{'options'}) ? OptionsObject::fromInput($_input->{'options'}, $validate) : null;
+        $_input = isset($input->{'input'}) ? $input->{'input'} : null;
+        $options = isset($input->{'options'}) ? OptionsObject::fromInput($input->{'options'}, $validate) : null;
 
         $obj = new self();
-        $obj->input = $input;
+        $obj->input = $_input;
         $obj->options = $options;
         return $obj;
     }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
@@ -122,19 +122,16 @@ class MyClassFilesItem
      */
     public static function fromInput(array|object $input, bool $validate = true): MyClassFilesItem
     {
-        $_input = $input;
-        unset($input);
-
-        $_input = is_array($_input) ? \JsonSchema\Validator::arrayToObjectRecursive($_input) : $_input;
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
         if ($validate) {
-            static::validateInput($_input);
+            static::validateInput($input);
         }
 
-        $input = isset($_input->{'input'}) ? $_input->{'input'} : null;
-        $options = isset($_input->{'options'}) ? OptionsObject::fromInput($_input->{'options'}, $validate) : null;
+        $_input = isset($input->{'input'}) ? $input->{'input'} : null;
+        $options = isset($input->{'options'}) ? OptionsObject::fromInput($input->{'options'}, $validate) : null;
 
         $obj = new self();
-        $obj->input = $input;
+        $obj->input = $_input;
         $obj->options = $options;
         return $obj;
     }

--- a/tests/Generator/Property/IntersectPropertyTest.php
+++ b/tests/Generator/Property/IntersectPropertyTest.php
@@ -29,7 +29,6 @@ class IntersectPropertyTest extends TestCase
             new ValidatedSpecificationFilesItem("BarNs", "Foo", ""),
             new SpecificationOptions(),
         );
-        $this->generatorRequest->setCurrValidateArgAlias('validate');
         $this->generatorRequest->setCurrReqHasDefaults(false);
         $this->property = new IntersectProperty('myPropertyName', ['allOf' => []], $this->generatorRequest);
     }

--- a/tests/Generator/Property/NestedObjectPropertyTest.php
+++ b/tests/Generator/Property/NestedObjectPropertyTest.php
@@ -23,7 +23,6 @@ class NestedObjectPropertyTest extends TestCase
     protected function setUp(): void
     {
         $this->generatorRequest = new GeneratorRequest([], new ValidatedSpecificationFilesItem("BarNs", "Foo", ""), new SpecificationOptions());
-        $this->generatorRequest->setCurrValidateArgAlias('validate');
         $this->generatorRequest->setCurrReqHasDefaults(false);
         $this->property = new NestedObjectProperty('myPropertyName', ['allOf' => []], $this->generatorRequest);
     }

--- a/tests/Generator/Property/ObjectArrayPropertyTest.php
+++ b/tests/Generator/Property/ObjectArrayPropertyTest.php
@@ -24,7 +24,6 @@ class ObjectArrayPropertyTest extends TestCase
     protected function setUp(): void
     {
         $this->generatorRequest = new GeneratorRequest([], new ValidatedSpecificationFilesItem("", "Foo", ""), new SpecificationOptions());
-        $this->generatorRequest->setCurrValidateArgAlias('validate');
         $this->generatorRequest->setCurrReqHasDefaults(false);
         $this->property = new ObjectArrayProperty('myPropertyName', ['type' => 'array', 'items' => ['type' => 'object']], $this->generatorRequest);
     }

--- a/tests/Generator/Property/OptionalPropertyDecoratorTest.php
+++ b/tests/Generator/Property/OptionalPropertyDecoratorTest.php
@@ -32,6 +32,7 @@ class OptionalPropertyDecoratorTest extends TestCase
         $this->innerProperty->schema()->willReturn([]);
         $this->innerProperty->allowsNull()->willReturn(false);
         $this->innerProperty->formatValue(Argument::any())->willReturn(new PropertyValueGenerator(null));
+        $this->innerProperty->varName()->willReturn('myPropertyName');
         
         $this->request = new GeneratorRequest(
                 [],
@@ -59,7 +60,6 @@ class OptionalPropertyDecoratorTest extends TestCase
 
     public function testConvertInputToType()
     {
-        $this->innerProperty->name()->shouldBeCalled()->willReturn('myPropertyName');
         $this->innerProperty
             ->inputMappingExpr('$variable->{\'myPropertyName\'}', true)
             ->shouldBeCalled()
@@ -77,7 +77,7 @@ class OptionalPropertyDecoratorTest extends TestCase
         $prophecy = $this->prophesize(PropertyInterface::class);
         $prophecy->schema()->willReturn(['default' => false]);
         $prophecy->allowsNull()->willReturn(true);
-        $prophecy->name()->willReturn('myPropertyName');
+        $prophecy->varName()->willReturn('myPropertyName');
         $prophecy
             ->inputMappingExpr('$variable->{\'myPropertyName\'}', true)
             ->willReturn('INNER_EXPR');

--- a/tests/Generator/Property/UnionPropertyTest.php
+++ b/tests/Generator/Property/UnionPropertyTest.php
@@ -26,7 +26,6 @@ class UnionPropertyTest extends TestCase
     protected function setUp(): void
     {
         $this->generatorRequest = new GeneratorRequest([], new ValidatedSpecificationFilesItem("BarNs", "Foo", ""), new SpecificationOptions());
-        $this->generatorRequest->setCurrValidateArgAlias('validate');
         $this->generatorRequest->setCurrReqHasDefaults(false);
         $this->property = new UnionProperty(
             'myPropertyName',


### PR DESCRIPTION
## Summary
- stop tracking validate/materializeDefaults aliases in `GeneratorRequest`
- pick unique temp vars for properties via `SchemaPropertyCollector`
- simplify `fromInput` generation to use constant arg names and property varNames

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_688fb629c804832dbfc26938283a0a8c