### PR TITLE
Refactor naming resolution for schema properties

### DIFF
--- a/src/Generator/Class/ClassGenerator.php
+++ b/src/Generator/Class/ClassGenerator.php
@@ -6,6 +6,7 @@ namespace Helmich\Schema2Class\Generator\Class;
 use Helmich\Schema2Class\Generator\Class\Method\ClassMethodSuiteFactory;
 use Helmich\Schema2Class\Generator\Class\Property\ClassPropertySuiteFactory;
 use Helmich\Schema2Class\Generator\Class\Property\PropertyGenerator;
+use Helmich\Schema2Class\Generator\Class\PropertyIdentifierResolver;
 use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Writer\WriterInterface;
 use Laminas\Code\DeclareStatement;
@@ -37,6 +38,9 @@ class ClassGenerator
     {
         $collector = new SchemaPropertyCollector();
         $schemaProperties = $collector->collectPropertiesFromSchema($this->schema, $this->request);
+
+        (new PropertyIdentifierResolver($this->request))->resolve($schemaProperties);
+
         $hasOptionalNullable = $collector->hasOptionalNullable($schemaProperties);
         $defaults = $collector->collectDefaults($this->schema, $this->request);
 

--- a/src/Generator/Class/Method/ClassMethodSuiteFactory.php
+++ b/src/Generator/Class/Method/ClassMethodSuiteFactory.php
@@ -5,7 +5,6 @@ namespace Helmich\Schema2Class\Generator\Class\Method;
 
 use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\Property\Collection\PropertyCollection;
-use Helmich\Schema2Class\Util\ReservedNames;
 use Laminas\Code\Generator\MethodGenerator;
 
 /**
@@ -47,57 +46,6 @@ class ClassMethodSuiteFactory
 
         $methodGenerators = array_values(array_filter($methodGenerators));
 
-        // check whether each name is unique and rename if necessary
-        $this->ensureUniqueMethodNames($methodGenerators);
-
         return $methodGenerators;
-    }
-
-    /**
-     * Iterates provided `MethodGenerator` objects and changes their names if needed
-     * @param MethodGenerator[] $methodGenerators 
-     */
-    private function ensureUniqueMethodNames(array $methodGenerators): void
-    {
-        $reservedMethodNames = ReservedNames::getBannedMethodNames();
-
-        $reserved = array_map('strtolower', $reservedMethodNames);
-        $used = [];
-
-        foreach ($methodGenerators as $method) {
-            $name   = $method->getName();
-            $lcName = strtolower($name);
-
-            if (!in_array($lcName, $used, true) && in_array($lcName, $reserved, true)) {
-                $used[] = $lcName;
-                continue;
-            }
-
-            $candidate = $name;
-            $prefix    = '';
-            $base      = $name;
-
-            if (preg_match('/^(set|get|without|with)(.+)$/', $name, $m)) {
-                $prefix = $m[1];
-                $base   = $m[2];
-            }
-
-            $i = 1;
-            while (in_array(strtolower($candidate), $used, true) || in_array(strtolower($candidate), $reserved, true)) {
-                if ($prefix !== '') {
-                    $suffix   = $i > 1 ? $base . '_' . ($i - 1) : $base;
-                    $candidate = $prefix . '_' . $suffix;
-                } else {
-                    $candidate = $name . '_' . $i;
-                }
-                $i++;
-            }
-
-            if ($candidate !== $name) {
-                $method->setName($candidate);
-            }
-
-            $used[] = strtolower($candidate);
-        }
     }
 }

--- a/src/Generator/Class/Method/ConstructorFactory.php
+++ b/src/Generator/Class/Method/ConstructorFactory.php
@@ -29,7 +29,7 @@ class ConstructorFactory
         $requiredProperties = $this->schemaProperties->filter(PropertyCollectionFilterFactory::onlyRequired());
 
         foreach ($requiredProperties as $requiredProperty) {
-            $paramName = $requiredProperty->name();
+            $paramName = $requiredProperty->varName();
             $params[]  = new ParameterGenerator(
                 $paramName,
                 $requiredProperty->typeHint()

--- a/src/Generator/Class/Method/PropertyAccessorsFactory.php
+++ b/src/Generator/Class/Method/PropertyAccessorsFactory.php
@@ -6,8 +6,6 @@ namespace Helmich\Schema2Class\Generator\Class\Method;
 use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\Property\Collection\PropertyCollection;
 use Helmich\Schema2Class\Generator\Property\Collection\PropertyCollectionFilterFactory;
-use Helmich\Schema2Class\Generator\Property\Type\PropertyInterface;
-use Helmich\Schema2Class\Util\StringUtils;
 use Laminas\Code\Generator\MethodGenerator;
 
 /** 
@@ -35,10 +33,9 @@ class PropertyAccessorsFactory
         $getterFactory = new GetterFactory($this->request);
         $setterFactory = new SetterFactory($this->request);
         $unsetterFactory = new UnsetterFactory($this->request);
-        
+
         foreach ($filteredProperties as $property) {
-            // TODO: move pascal-casing logic into a method in PropertyInterface?
-            $pascalName = $this->pascalName($property);
+            $pascalName = $property->methodName();
 
             $methodsGenerators[] = $getterFactory->generateGetter($property, $pascalName);
             $methodsGenerators[] = $setterFactory->generateSetter($property, $pascalName);
@@ -46,13 +43,5 @@ class PropertyAccessorsFactory
         }
 
         return array_values(array_filter($methodsGenerators));
-    }
-
-    private function pascalName(PropertyInterface $property): string
-    {
-        $propName = $property->name();
-        return $this->request->getOptions()->getPreservePropertyNames()
-            ? StringUtils::pascalCasePreserveOuterUnderscores($propName)
-            : StringUtils::safePascalCase($propName);
     }
 }

--- a/src/Generator/Class/Method/SetterFactory.php
+++ b/src/Generator/Class/Method/SetterFactory.php
@@ -42,6 +42,7 @@ class SetterFactory
         $prefix = $this->mutating ? 'set' : 'with';
         $methodName = $prefix . $pascalName;
         $propName = $property->name();
+        $paramName = $property->varName();
 
         // We first unwrap only optional property decorator but leave other
         // decorators in place to get the correct type hint / annotation
@@ -71,9 +72,9 @@ class SetterFactory
             $addValidation = false;
         }
 
-        $docBlock = $this->buildDocBlock($property, $propName, $propAnnotatedType, $addValidation);
-        $parameters = $this->buildParams($propName, $propTypeHint, $addValidation);
-        $body = $this->generateBody($property, $propName, $addValidation);
+        $docBlock = $this->buildDocBlock($property, $paramName, $propAnnotatedType, $addValidation);
+        $parameters = $this->buildParams($paramName, $propTypeHint, $addValidation);
+        $body = $this->generateBody($property, $propName, $paramName, $addValidation);
 
         $methodGen = new MethodGenerator(
             name: $methodName,
@@ -96,13 +97,13 @@ class SetterFactory
 
     private function buildDocBlock(
         PropertyInterface $property,
-        string $propName,
+        string $paramName,
         string $propAnnotatedType,
         bool $addValidation,
     ): DocBlockGenerator
     {
         $tags = [
-            new ParamTag($propName, [str_replace('|null', '', $propAnnotatedType)])
+            new ParamTag($paramName, [str_replace('|null', '', $propAnnotatedType)])
         ];
 
         if ($this->chainable) {
@@ -125,9 +126,9 @@ class SetterFactory
         return $docBlock;
     }
 
-    private function buildParams(string $propName, ?string $propTypeHint, bool $addValidation): array
+    private function buildParams(string $paramName, ?string $propTypeHint, bool $addValidation): array
     {
-        $parameters = [new ParameterGenerator($propName, $propTypeHint)];
+        $parameters = [new ParameterGenerator($paramName, $propTypeHint)];
         if ($addValidation) {
             $validateParam = new ParameterGenerator('validate', 'bool');
             $validateParam->setDefaultValue(true);
@@ -136,7 +137,7 @@ class SetterFactory
         return $parameters;
     }
 
-    private function generateBody(PropertyInterface $property, string $propName, bool $addValidation): string
+    private function generateBody(PropertyInterface $property, string $propName, string $paramName, bool $addValidation): string
     {
         $propKey = var_export($property->key(), true);
         
@@ -149,7 +150,7 @@ class SetterFactory
                 <<<PHP
                 if (\$validate) {
                     \$validator = {$newValidatorExpr};
-                    \$validator->validate(\$$propName, self::\${$SCHEMA}['properties'][{$propKey}]);
+                    \$validator->validate(\$$paramName, self::\${$SCHEMA}['properties'][{$propKey}]);
                     if (!\$validator->isValid()) {
                         throw new \\InvalidArgumentException(\$validator->getErrors()[0]['message']);
                     }
@@ -162,7 +163,7 @@ class SetterFactory
         if ($this->mutating) {
             $body =
                 $validationBlock .
-                "\$this->{$propName} = \$$propName;";
+                "\$this->{$propName} = \$$paramName;";
 
             if ($property instanceof OptionalPropertyDecorator && $property->isOptionalNullable()) {
                 $body .= "\n\$this->{$OPTIONALS}[{$propKey}] = true;";
@@ -175,7 +176,7 @@ class SetterFactory
             $body =
                 $validationBlock .
                 "\$clone = clone \$this;\n" .
-                "\$clone->$propName = \$$propName;\n";
+                "\$clone->$propName = \$$paramName;\n";
 
             if ($property instanceof OptionalPropertyDecorator && $property->isOptionalNullable()) {
                 $body .= "\$clone->{$OPTIONALS}[{$propKey}] = true;\n";

--- a/src/Generator/Class/PropertyIdentifierResolver.php
+++ b/src/Generator/Class/PropertyIdentifierResolver.php
@@ -1,0 +1,183 @@
+<?php
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Generator\Class;
+
+use Helmich\Schema2Class\Generator\Class\Method\FromInputMethodFactory;
+use Helmich\Schema2Class\Generator\Class\PropertyNames;
+use Helmich\Schema2Class\Generator\GeneratorRequest;
+use Helmich\Schema2Class\Generator\Property\Collection\PropertyCollection;
+use Helmich\Schema2Class\Generator\Property\Collection\PropertyCollectionFilterFactory;
+use Helmich\Schema2Class\Util\ReservedNames;
+use Helmich\Schema2Class\Util\StringUtils;
+
+/**
+ * Resolves class property names, accessor method names and temporary variable names
+ * for all collected schema properties.
+ *
+ * The resolver makes sure that all identifiers are unique and valid within their
+ * respective namespaces (class property, method and local variable scope).
+ */
+class PropertyIdentifierResolver
+{
+    public function __construct(private GeneratorRequest $request)
+    {
+    }
+
+    public function resolve(PropertyCollection $properties): void
+    {
+        $this->resolvePropertyNames($properties);
+        $this->resolveMethodNames($properties);
+        $this->resolveVarNames($properties);
+    }
+
+    private function resolvePropertyNames(PropertyCollection $properties): void
+    {
+        $reserved = array_merge(['this'], PropertyNames::all());
+
+        $props = iterator_to_array($properties, false);
+        usort($props, function ($a, $b) {
+            $cmp = strcmp($a->name(), $b->name());
+            if ($cmp !== 0) {
+                return $cmp;
+            }
+            return strcmp($a->key(), $b->key());
+        });
+
+        $used = [];
+        foreach ($reserved as $r) {
+            $used[$r] = true;
+        }
+
+        foreach ($props as $prop) {
+            $base = $prop->name();
+            $candidate = $base;
+
+            if (isset($used[$candidate])) {
+                if ($base[0] !== '_') {
+                    $candidate = '_' . $base;
+                }
+                $i = 1;
+                $baseUnique = $candidate;
+                while (isset($used[$candidate])) {
+                    $candidate = $baseUnique . '_' . $i;
+                    $i++;
+                }
+            }
+
+            if ($candidate !== $base) {
+                $prop->setName($candidate);
+            }
+
+            $prop->setVarName($prop->name());
+
+            $used[$prop->name()] = true;
+        }
+    }
+
+    private function resolveMethodNames(PropertyCollection $properties): void
+    {
+        $filtered = $properties->filter(
+            PropertyCollectionFilterFactory::excludeDeprecatedCaseVariants($properties)
+        );
+
+        $props = iterator_to_array($filtered, false);
+        usort($props, function ($a, $b) {
+            $cmp = strcmp(strtolower($a->methodName()), strtolower($b->methodName()));
+            if ($cmp !== 0) {
+                return $cmp;
+            }
+            return strcmp($a->key(), $b->key());
+        });
+
+        $used = [];
+        $prefixes = ['get', 'set', 'with', 'without', 'unset'];
+
+        foreach ($props as $prop) {
+            // recompute method name in case property name changed
+            $methodName = $this->request->getOptions()->getPreservePropertyNames()
+                ? StringUtils::pascalCasePreserveOuterUnderscores($prop->name())
+                : StringUtils::safePascalCase($prop->name());
+            $prop->setMethodName($methodName);
+
+            $base = $prop->methodName();
+            $candidate = $base;
+
+            if ($this->methodNamesCollide($candidate, $used, $prefixes)) {
+                if ($base[0] !== '_') {
+                    $candidate = '_' . $base;
+                }
+                $i = 1;
+                $baseUnique = $candidate;
+                while ($this->methodNamesCollide($candidate, $used, $prefixes)) {
+                    $candidate = $baseUnique . '_' . $i;
+                    $i++;
+                }
+            }
+
+            if ($candidate !== $base) {
+                $prop->setMethodName($candidate);
+            }
+
+            foreach ($prefixes as $prefix) {
+                $used[] = strtolower($prefix . $prop->methodName());
+            }
+        }
+    }
+
+    private function methodNamesCollide(string $candidate, array $used, array $prefixes): bool
+    {
+        foreach ($prefixes as $prefix) {
+            if (in_array(strtolower($prefix . $candidate), $used, true)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function resolveVarNames(PropertyCollection $properties): void
+    {
+        $reserved = array_merge(
+            ReservedNames::getBannedVarNames(),
+            FromInputMethodFactory::allVarNames()
+        );
+
+        $props = iterator_to_array($properties, false);
+        usort($props, function ($a, $b) {
+            $cmp = strcmp($a->varName(), $b->varName());
+            if ($cmp !== 0) {
+                return $cmp;
+            }
+            return strcmp($a->key(), $b->key());
+        });
+
+        $used = [];
+        foreach ($reserved as $r) {
+            $used[$r] = true;
+        }
+
+        foreach ($props as $prop) {
+            $base = $prop->varName();
+            $candidate = $base;
+
+            if (isset($used[$candidate])) {
+                if ($base[0] !== '_') {
+                    $candidate = '_' . $base;
+                }
+                $i = 1;
+                $baseUnique = $candidate;
+                while (isset($used[$candidate])) {
+                    $candidate = $baseUnique . '_' . $i;
+                    $i++;
+                }
+            }
+
+            if ($candidate !== $base) {
+                $prop->setVarName($candidate);
+            }
+
+            $used[$prop->varName()] = true;
+        }
+    }
+}
+

--- a/src/Generator/Class/SchemaPropertyCollector.php
+++ b/src/Generator/Class/SchemaPropertyCollector.php
@@ -7,10 +7,7 @@ use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\Property\Collection\PropertyCollection;
 use Helmich\Schema2Class\Generator\Property\PropertyBuilder;
 use Helmich\Schema2Class\Generator\Property\Decorator\OptionalPropertyDecorator;
-use Helmich\Schema2Class\Generator\Class\Method\FromInputMethodFactory;
-use Helmich\Schema2Class\Util\ReservedNames;
 use Helmich\Schema2Class\Util\SchemaUtils;
-use Helmich\Schema2Class\Util\StringUtils;
 
 /**
  * Collects property information from a JSON schema and applies name sanitisation
@@ -31,11 +28,6 @@ class SchemaPropertyCollector
                 $properties->add($property);
             }
         }
-
-        $this->ensureUniquePropertyNames(
-            $properties,
-            $req->getOptions()->getPreservePropertyNames(),
-        );
 
         return $properties;
     }
@@ -134,82 +126,4 @@ class SchemaPropertyCollector
         return ['default' => null, 'type' => null];
     }
     
-    private function ensureUniquePropertyNames(PropertyCollection $schemaProperties, bool $preservePropertyNames): void
-    {
-        $reservedPropertyNames = ReservedNames::getBannedVarNames();
-        $reservedMethodNames = ReservedNames::getBannedMethodNames();
-
-        $used = [];
-        foreach (array_merge($reservedPropertyNames, $reservedMethodNames) as $n) {
-            $used[] = StringUtils::safeCamelCase($n);
-            $used[] = StringUtils::sanitizeIdentifier($n);
-        }
-        $used = array_values(array_unique($used));
-
-        $usedMethods = [];
-        foreach ($reservedMethodNames as $n) {
-            $usedMethods[] = strtolower(StringUtils::safePascalCase(StringUtils::safeCamelCase($n)));
-            $usedMethods[] = strtolower(StringUtils::safePascalCase(StringUtils::sanitizeIdentifier($n)));
-        }
-        $usedMethods = array_values(array_unique($usedMethods));
-
-        foreach ($schemaProperties as $schemaProp) {
-            $base    = $schemaProp->name();
-            $newName = $base;
-            $newPascal  = strtolower(StringUtils::safePascalCase($newName));
-
-            // Of collides with "used",
-            // OR if "preserve" option disabled and pascal-variant collides with "usedMethods" – change
-            $needsChange = fn(string $_newName, string $_newPascal) => in_array($_newName, $used, true)
-                || (!$preservePropertyNames && in_array($_newPascal, $usedMethods, true));
-
-            if ($needsChange($newName, $newPascal)) {
-                if ($base[0] !== '_') {
-                    $newName = '_' . $base;
-                    $newPascal = strtolower(StringUtils::safePascalCase($newName));
-                }
-
-                $i = 1;
-                $baseUnique = $newName;
-
-                while ($needsChange($newName, $newPascal)) {
-                    $newName = $baseUnique . '_' . $i;
-                    $newPascal = strtolower(StringUtils::safePascalCase($newName));
-                    $i++;
-                }
-            }
-
-            // rename the property
-            if ($newName !== $base) {
-                $schemaProp->setName($newName);
-            }
-            $schemaProp->setVarName($schemaProp->name());
-
-            $used[]       = $newName;
-            $usedMethods[] = $newPascal;
-        }
-
-        $usedVarNames = FromInputMethodFactory::allVarNames();
-
-        foreach ($schemaProperties as $schemaProp) {
-            $baseVar = $schemaProp->varName();
-            $newVar = $baseVar;
-
-            if (in_array($newVar, $usedVarNames, true)) {
-                if ($baseVar[0] !== '_') {
-                    $newVar = '_' . $baseVar;
-                }
-                $i = 1;
-                $baseUnique = $newVar;
-                while (in_array($newVar, $usedVarNames, true)) {
-                    $newVar = $baseUnique . '_' . $i;
-                    $i++;
-                }
-            }
-            if ($newVar !== $baseVar) {
-                $schemaProp->setVarName($newVar);
-            }
-            $usedVarNames[] = $newVar;
-        }
-    }
 }

--- a/src/Util/ReservedNames.php
+++ b/src/Util/ReservedNames.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Helmich\Schema2Class\Util;
 
-use Helmich\Schema2Class\Generator\Class\MethodNames;
 use Helmich\Schema2Class\Generator\Class\PropertyNames;
 
 /**
@@ -56,7 +55,6 @@ class ReservedNames
             '__invoke',
             '__debugInfo',
             '__clone',
-            ...MethodNames::all(),
         ];
     }
 }

--- a/tests/Generator/Class/ClassGeneratorTest.php
+++ b/tests/Generator/Class/ClassGeneratorTest.php
@@ -65,18 +65,18 @@ class ClassGeneratorTest extends TestCase
         $files = $writer->getWrittenFiles();
         $code  = current($files);
 
+        $this->assertStringContainsString('function getFooBar2()', $code);
+        $this->assertStringContainsString('function get_FooBar()', $code);
         $this->assertStringContainsString('function getFooBar()', $code);
         $this->assertStringContainsString('function getFooBar1()', $code);
-        $this->assertStringContainsString('function getFooBar2()', $code);
-        $this->assertStringContainsString('function getFooBar3()', $code);
+        $this->assertStringContainsString('function withFooBar2(', $code);
+        $this->assertStringContainsString('function with_FooBar(', $code);
         $this->assertStringContainsString('function withFooBar(', $code);
         $this->assertStringContainsString('function withFooBar1(', $code);
-        $this->assertStringContainsString('function withFooBar2(', $code);
-        $this->assertStringContainsString('function withFooBar3(', $code);
+        $this->assertStringContainsString('function withoutFooBar2(', $code);
+        $this->assertStringContainsString('function without_FooBar(', $code);
         $this->assertStringContainsString('function withoutFooBar(', $code);
         $this->assertStringContainsString('function withoutFooBar1(', $code);
-        $this->assertStringContainsString('function withoutFooBar2(', $code);
-        $this->assertStringContainsString('function withoutFooBar3(', $code);
     }
 
     public function testGeneratedCodeMatchesFixture(): void

--- a/tests/Generator/Class/PropertyIdentifierResolverTest.php
+++ b/tests/Generator/Class/PropertyIdentifierResolverTest.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Generator\Class;
+
+use Helmich\Schema2Class\Generator\GeneratorRequest;
+use Helmich\Schema2Class\Spec\SpecificationOptions;
+use Helmich\Schema2Class\Spec\ValidatedSpecificationFilesItem;
+use PHPUnit\Framework\TestCase;
+
+class PropertyIdentifierResolverTest extends TestCase
+{
+    public function testStableIdentifiersRegardlessOfPropertyOrder(): void
+    {
+        $schemaA = [
+            'properties' => [
+                'foo-bar' => ['type' => 'string'],
+                'foo_bar' => ['type' => 'string'],
+                'bound' => ['type' => 'string'],
+                'outbound' => ['type' => 'string'],
+        'input' => ['type' => 'string'],
+                'GLOBALS' => ['type' => 'string'],
+            ],
+        ];
+
+        $schemaB = ['properties' => array_reverse($schemaA['properties'], true)];
+
+        $expected = [
+            'foo-bar' => ['fooBar', 'FooBar', 'fooBar'],
+            'foo_bar' => ['_fooBar', '_FooBar', '_fooBar'],
+            'bound' => ['bound', 'Bound', 'bound'],
+            'outbound' => ['outbound', '_Outbound', 'outbound'],
+            'input' => ['input', 'Input', '_input'],
+            'GLOBALS' => ['GLOBALS', 'GLOBALS', '_GLOBALS_1'],
+        ];
+        ksort($expected);
+
+        $mapA = $this->resolveForSchema($schemaA);
+        $mapB = $this->resolveForSchema($schemaB);
+
+        self::assertSame($expected, $mapA);
+        self::assertSame($expected, $mapB);
+    }
+
+    public function testCaseVariantCollisionsYieldDeterministicNames(): void
+    {
+        $schemaA = [
+            'properties' => [
+                'foo' => ['type' => 'string'],
+                'Foo' => ['type' => 'string'],
+            ],
+        ];
+        $schemaB = ['properties' => array_reverse($schemaA['properties'], true)];
+
+        $expected = [
+            'foo' => ['foo', '_Foo', 'foo'],
+            'Foo' => ['Foo', 'Foo', 'Foo'],
+        ];
+        ksort($expected);
+
+        $mapA = $this->resolveForSchema($schemaA);
+        $mapB = $this->resolveForSchema($schemaB);
+
+        self::assertSame($expected, $mapA);
+        self::assertSame($expected, $mapB);
+    }
+
+    public function testTemporaryVarNamesAvoidReservedNames(): void
+    {
+        $schema = [
+            'properties' => [
+                'input' => ['type' => 'string'],
+                'GLOBALS' => ['type' => 'string'],
+            ],
+        ];
+
+        $map = $this->resolveForSchema($schema);
+
+        $expected = [
+            'GLOBALS' => ['GLOBALS', 'GLOBALS', '_GLOBALS_1'],
+            'input' => ['input', 'Input', '_input'],
+        ];
+        ksort($expected);
+        self::assertSame($expected, $map);
+    }
+
+    /**
+     * @return array<string, array{0:string,1:string,2:string}>
+     */
+    private function resolveForSchema(array $schema): array
+    {
+        $req = new GeneratorRequest(
+            $schema,
+            new ValidatedSpecificationFilesItem('Ns', 'Foo', ''),
+            new SpecificationOptions(),
+        );
+
+        $collector = new SchemaPropertyCollector();
+        $props = $collector->collectPropertiesFromSchema($schema, $req);
+        (new PropertyIdentifierResolver($req))->resolve($props);
+
+        $map = [];
+        foreach ($props as $p) {
+            $map[$p->key()] = [$p->name(), $p->methodName(), $p->varName()];
+        }
+
+        ksort($map);
+
+        return $map;
+    }
+}
+

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-5.6/MyClass.php
@@ -27,50 +27,21 @@ class MyClass
     /**
      * @var string
      */
-    private $foo_bar;
+    private $_foo_bar;
 
     /**
      * @var string
      */
-    private $_foo_bar;
+    private $foo_bar;
 
     /**
-     * @param string $foo_bar
      * @param string $_foo_bar
-     */
-    public function __construct($foo_bar, $_foo_bar)
-    {
-        $this->foo_bar = $foo_bar;
-        $this->_foo_bar = $_foo_bar;
-    }
-
-    /**
-     * @return string
-     */
-    public function getFooBar()
-    {
-        return $this->foo_bar;
-    }
-
-    /**
      * @param string $foo_bar
-     * @return self
-     * @param bool $validate
      */
-    public function withFooBar($foo_bar, bool $validate = true)
+    public function __construct($_foo_bar, $foo_bar)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->foo_bar = $foo_bar;
-
-        return $clone;
+        $this->_foo_bar = $_foo_bar;
+        $this->foo_bar = $foo_bar;
     }
 
     /**
@@ -90,7 +61,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo bar']);
+            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -98,6 +69,35 @@ class MyClass
 
         $clone = clone $this;
         $clone->_foo_bar = $_foo_bar;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFooBar()
+    {
+        return $this->foo_bar;
+    }
+
+    /**
+     * @param string $foo_bar
+     * @return self
+     * @param bool $validate
+     */
+    public function withFooBar($foo_bar, bool $validate = true)
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar = $foo_bar;
 
         return $clone;
     }
@@ -123,10 +123,10 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo_bar = $input->{'foo-bar'};
-        $_foo_bar = $input->{'foo bar'};
+        $_foo_bar = $input->{'foo-bar'};
+        $foo_bar = $input->{'foo bar'};
 
-        $obj = new self($foo_bar, $_foo_bar);
+        $obj = new self($_foo_bar, $foo_bar);
 
         return $obj;
     }
@@ -139,8 +139,8 @@ class MyClass
     public function toArray()
     {
         $output = [];
-        $output['foo-bar'] = $this->foo_bar;
-        $output['foo bar'] = $this->_foo_bar;
+        $output['foo-bar'] = $this->_foo_bar;
+        $output['foo bar'] = $this->foo_bar;
 
         return $output;
     }
@@ -153,8 +153,8 @@ class MyClass
     public function toStdClass()
     {
         $output = new \stdClass();
-        $output->{'foo-bar'} = $this->foo_bar;
-        $output->{'foo bar'} = $this->_foo_bar;
+        $output->{'foo-bar'} = $this->_foo_bar;
+        $output->{'foo bar'} = $this->foo_bar;
 
         return $output;
     }

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-7.4/MyClass.php
@@ -29,50 +29,21 @@ class MyClass
     /**
      * @var string
      */
-    private string $foo_bar;
+    private string $_foo_bar;
 
     /**
      * @var string
      */
-    private string $_foo_bar;
+    private string $foo_bar;
 
     /**
-     * @param string $foo_bar
      * @param string $_foo_bar
-     */
-    public function __construct(string $foo_bar, string $_foo_bar)
-    {
-        $this->foo_bar = $foo_bar;
-        $this->_foo_bar = $_foo_bar;
-    }
-
-    /**
-     * @return string
-     */
-    public function getFooBar(): string
-    {
-        return $this->foo_bar;
-    }
-
-    /**
      * @param string $foo_bar
-     * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $foo_bar, bool $validate = true): self
+    public function __construct(string $_foo_bar, string $foo_bar)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->foo_bar = $foo_bar;
-
-        return $clone;
+        $this->_foo_bar = $_foo_bar;
+        $this->foo_bar = $foo_bar;
     }
 
     /**
@@ -92,7 +63,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo bar']);
+            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -100,6 +71,35 @@ class MyClass
 
         $clone = clone $this;
         $clone->_foo_bar = $_foo_bar;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFooBar(): string
+    {
+        return $this->foo_bar;
+    }
+
+    /**
+     * @param string $foo_bar
+     * @return self
+     * @param bool $validate
+     */
+    public function withFooBar(string $foo_bar, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar = $foo_bar;
 
         return $clone;
     }
@@ -125,10 +125,10 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo_bar = $input->{'foo-bar'};
-        $_foo_bar = $input->{'foo bar'};
+        $_foo_bar = $input->{'foo-bar'};
+        $foo_bar = $input->{'foo bar'};
 
-        $obj = new self($foo_bar, $_foo_bar);
+        $obj = new self($_foo_bar, $foo_bar);
 
         return $obj;
     }
@@ -141,8 +141,8 @@ class MyClass
     public function toArray(): array
     {
         $output = [];
-        $output['foo-bar'] = $this->foo_bar;
-        $output['foo bar'] = $this->_foo_bar;
+        $output['foo-bar'] = $this->_foo_bar;
+        $output['foo bar'] = $this->foo_bar;
 
         return $output;
     }
@@ -155,8 +155,8 @@ class MyClass
     public function toStdClass(): \stdClass
     {
         $output = new \stdClass();
-        $output->{'foo-bar'} = $this->foo_bar;
-        $output->{'foo bar'} = $this->_foo_bar;
+        $output->{'foo-bar'} = $this->_foo_bar;
+        $output->{'foo bar'} = $this->foo_bar;
 
         return $output;
     }

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-8.4/MyClass.php
@@ -29,50 +29,21 @@ class MyClass
     /**
      * @var string
      */
-    private string $foo_bar;
+    private string $_foo_bar;
 
     /**
      * @var string
      */
-    private string $_foo_bar;
+    private string $foo_bar;
 
     /**
-     * @param string $foo_bar
      * @param string $_foo_bar
-     */
-    public function __construct(string $foo_bar, string $_foo_bar)
-    {
-        $this->foo_bar = $foo_bar;
-        $this->_foo_bar = $_foo_bar;
-    }
-
-    /**
-     * @return string
-     */
-    public function getFooBar(): string
-    {
-        return $this->foo_bar;
-    }
-
-    /**
      * @param string $foo_bar
-     * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $foo_bar, bool $validate = true): self
+    public function __construct(string $_foo_bar, string $foo_bar)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->foo_bar = $foo_bar;
-
-        return $clone;
+        $this->_foo_bar = $_foo_bar;
+        $this->foo_bar = $foo_bar;
     }
 
     /**
@@ -92,7 +63,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo bar']);
+            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -100,6 +71,35 @@ class MyClass
 
         $clone = clone $this;
         $clone->_foo_bar = $_foo_bar;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFooBar(): string
+    {
+        return $this->foo_bar;
+    }
+
+    /**
+     * @param string $foo_bar
+     * @return self
+     * @param bool $validate
+     */
+    public function withFooBar(string $foo_bar, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar = $foo_bar;
 
         return $clone;
     }
@@ -119,10 +119,10 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo_bar = $input->{'foo-bar'};
-        $_foo_bar = $input->{'foo bar'};
+        $_foo_bar = $input->{'foo-bar'};
+        $foo_bar = $input->{'foo bar'};
 
-        $obj = new self($foo_bar, $_foo_bar);
+        $obj = new self($_foo_bar, $foo_bar);
 
         return $obj;
     }
@@ -135,8 +135,8 @@ class MyClass
     public function toArray(): array
     {
         $output = [];
-        $output['foo-bar'] = $this->foo_bar;
-        $output['foo bar'] = $this->_foo_bar;
+        $output['foo-bar'] = $this->_foo_bar;
+        $output['foo bar'] = $this->foo_bar;
 
         return $output;
     }
@@ -149,8 +149,8 @@ class MyClass
     public function toStdClass(): \stdClass
     {
         $output = new \stdClass();
-        $output->{'foo-bar'} = $this->foo_bar;
-        $output->{'foo bar'} = $this->_foo_bar;
+        $output->{'foo-bar'} = $this->_foo_bar;
+        $output->{'foo bar'} = $this->foo_bar;
 
         return $output;
     }

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-5.6/MyClass.php
@@ -26,52 +26,23 @@ class MyClass
     /**
      * @var string
      */
-    private $foo_bar;
+    private $_foo_bar;
 
     /**
      * @var string|null
      */
-    private $_foo_bar = null;
+    private $foo_bar = null;
 
     /**
-     * @param string $foo_bar
+     * @param string $_foo_bar
      */
-    public function __construct($foo_bar)
+    public function __construct($_foo_bar)
     {
-        $this->foo_bar = $foo_bar;
+        $this->_foo_bar = $_foo_bar;
     }
 
     /**
      * @return string
-     */
-    public function getFooBar()
-    {
-        return $this->foo_bar;
-    }
-
-    /**
-     * @param string $foo_bar
-     * @return self
-     * @param bool $validate
-     */
-    public function withFooBar($foo_bar, bool $validate = true)
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->foo_bar = $foo_bar;
-
-        return $clone;
-    }
-
-    /**
-     * @return string|null
      */
     public function get_FooBar()
     {
@@ -87,7 +58,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo bar']);
+            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -100,12 +71,41 @@ class MyClass
     }
 
     /**
+     * @return string|null
+     */
+    public function getFooBar()
+    {
+        return $this->foo_bar;
+    }
+
+    /**
+     * @param string $foo_bar
+     * @return self
+     * @param bool $validate
+     */
+    public function withFooBar($foo_bar, bool $validate = true)
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar = $foo_bar;
+
+        return $clone;
+    }
+
+    /**
      * @return self
      */
-    public function without_FooBar()
+    public function withoutFooBar()
     {
         $clone = clone $this;
-        unset($clone->_foo_bar);
+        unset($clone->foo_bar);
 
         return $clone;
     }
@@ -131,11 +131,11 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo_bar = $input->{'foo-bar'};
-        $_foo_bar = isset($input->{'foo bar'}) ? $input->{'foo bar'} : null;
+        $_foo_bar = $input->{'foo-bar'};
+        $foo_bar = isset($input->{'foo bar'}) ? $input->{'foo bar'} : null;
 
-        $obj = new self($foo_bar);
-        $obj->_foo_bar = $_foo_bar;
+        $obj = new self($_foo_bar);
+        $obj->foo_bar = $foo_bar;
         return $obj;
     }
 
@@ -147,9 +147,9 @@ class MyClass
     public function toArray()
     {
         $output = [];
-        $output['foo-bar'] = $this->foo_bar;
-        if (isset($this->_foo_bar)) {
-            $output['foo bar'] = $this->_foo_bar;
+        $output['foo-bar'] = $this->_foo_bar;
+        if (isset($this->foo_bar)) {
+            $output['foo bar'] = $this->foo_bar;
         }
 
         return $output;
@@ -163,9 +163,9 @@ class MyClass
     public function toStdClass()
     {
         $output = new \stdClass();
-        $output->{'foo-bar'} = $this->foo_bar;
-        if (isset($this->_foo_bar)) {
-            $output->{'foo bar'} = $this->_foo_bar;
+        $output->{'foo-bar'} = $this->_foo_bar;
+        if (isset($this->foo_bar)) {
+            $output->{'foo bar'} = $this->foo_bar;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-7.4/MyClass.php
@@ -28,56 +28,27 @@ class MyClass
     /**
      * @var string
      */
-    private string $foo_bar;
+    private string $_foo_bar;
 
     /**
      * @var string|null
      */
-    private ?string $_foo_bar = null;
+    private ?string $foo_bar = null;
 
     /**
-     * @param string $foo_bar
+     * @param string $_foo_bar
      */
-    public function __construct(string $foo_bar)
+    public function __construct(string $_foo_bar)
     {
-        $this->foo_bar = $foo_bar;
+        $this->_foo_bar = $_foo_bar;
     }
 
     /**
      * @return string
      */
-    public function getFooBar(): string
+    public function get_FooBar(): string
     {
-        return $this->foo_bar;
-    }
-
-    /**
-     * @param string $foo_bar
-     * @return self
-     * @param bool $validate
-     */
-    public function withFooBar(string $foo_bar, bool $validate = true): self
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->foo_bar = $foo_bar;
-
-        return $clone;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function get_FooBar(): ?string
-    {
-        return $this->_foo_bar ?? null;
+        return $this->_foo_bar;
     }
 
     /**
@@ -89,7 +60,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo bar']);
+            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -102,12 +73,41 @@ class MyClass
     }
 
     /**
+     * @return string|null
+     */
+    public function getFooBar(): ?string
+    {
+        return $this->foo_bar ?? null;
+    }
+
+    /**
+     * @param string $foo_bar
+     * @return self
+     * @param bool $validate
+     */
+    public function withFooBar(string $foo_bar, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar = $foo_bar;
+
+        return $clone;
+    }
+
+    /**
      * @return self
      */
-    public function without_FooBar(): self
+    public function withoutFooBar(): self
     {
         $clone = clone $this;
-        unset($clone->_foo_bar);
+        unset($clone->foo_bar);
 
         return $clone;
     }
@@ -133,11 +133,11 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo_bar = $input->{'foo-bar'};
-        $_foo_bar = isset($input->{'foo bar'}) ? $input->{'foo bar'} : null;
+        $_foo_bar = $input->{'foo-bar'};
+        $foo_bar = isset($input->{'foo bar'}) ? $input->{'foo bar'} : null;
 
-        $obj = new self($foo_bar);
-        $obj->_foo_bar = $_foo_bar;
+        $obj = new self($_foo_bar);
+        $obj->foo_bar = $foo_bar;
         return $obj;
     }
 
@@ -149,9 +149,9 @@ class MyClass
     public function toArray(): array
     {
         $output = [];
-        $output['foo-bar'] = $this->foo_bar;
-        if (isset($this->_foo_bar)) {
-            $output['foo bar'] = $this->_foo_bar;
+        $output['foo-bar'] = $this->_foo_bar;
+        if (isset($this->foo_bar)) {
+            $output['foo bar'] = $this->foo_bar;
         }
 
         return $output;
@@ -165,9 +165,9 @@ class MyClass
     public function toStdClass(): \stdClass
     {
         $output = new \stdClass();
-        $output->{'foo-bar'} = $this->foo_bar;
-        if (isset($this->_foo_bar)) {
-            $output->{'foo bar'} = $this->_foo_bar;
+        $output->{'foo-bar'} = $this->_foo_bar;
+        if (isset($this->foo_bar)) {
+            $output->{'foo bar'} = $this->foo_bar;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-8.4/MyClass.php
@@ -28,56 +28,27 @@ class MyClass
     /**
      * @var string
      */
-    private string $foo_bar;
+    private string $_foo_bar;
 
     /**
      * @var string|null
      */
-    private ?string $_foo_bar = null;
+    private ?string $foo_bar = null;
 
     /**
-     * @param string $foo_bar
+     * @param string $_foo_bar
      */
-    public function __construct(string $foo_bar)
+    public function __construct(string $_foo_bar)
     {
-        $this->foo_bar = $foo_bar;
+        $this->_foo_bar = $_foo_bar;
     }
 
     /**
      * @return string
      */
-    public function getFooBar(): string
+    public function get_FooBar(): string
     {
-        return $this->foo_bar;
-    }
-
-    /**
-     * @param string $foo_bar
-     * @return self
-     * @param bool $validate
-     */
-    public function withFooBar(string $foo_bar, bool $validate = true): self
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->foo_bar = $foo_bar;
-
-        return $clone;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function get_FooBar(): ?string
-    {
-        return $this->_foo_bar ?? null;
+        return $this->_foo_bar;
     }
 
     /**
@@ -89,7 +60,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo bar']);
+            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -102,12 +73,41 @@ class MyClass
     }
 
     /**
+     * @return string|null
+     */
+    public function getFooBar(): ?string
+    {
+        return $this->foo_bar ?? null;
+    }
+
+    /**
+     * @param string $foo_bar
+     * @return self
+     * @param bool $validate
+     */
+    public function withFooBar(string $foo_bar, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar = $foo_bar;
+
+        return $clone;
+    }
+
+    /**
      * @return self
      */
-    public function without_FooBar(): self
+    public function withoutFooBar(): self
     {
         $clone = clone $this;
-        unset($clone->_foo_bar);
+        unset($clone->foo_bar);
 
         return $clone;
     }
@@ -127,11 +127,11 @@ class MyClass
             static::validateInput($input);
         }
 
-        $foo_bar = $input->{'foo-bar'};
-        $_foo_bar = isset($input->{'foo bar'}) ? $input->{'foo bar'} : null;
+        $_foo_bar = $input->{'foo-bar'};
+        $foo_bar = isset($input->{'foo bar'}) ? $input->{'foo bar'} : null;
 
-        $obj = new self($foo_bar);
-        $obj->_foo_bar = $_foo_bar;
+        $obj = new self($_foo_bar);
+        $obj->foo_bar = $foo_bar;
         return $obj;
     }
 
@@ -143,9 +143,9 @@ class MyClass
     public function toArray(): array
     {
         $output = [];
-        $output['foo-bar'] = $this->foo_bar;
-        if (isset($this->_foo_bar)) {
-            $output['foo bar'] = $this->_foo_bar;
+        $output['foo-bar'] = $this->_foo_bar;
+        if (isset($this->foo_bar)) {
+            $output['foo bar'] = $this->foo_bar;
         }
 
         return $output;
@@ -159,9 +159,9 @@ class MyClass
     public function toStdClass(): \stdClass
     {
         $output = new \stdClass();
-        $output->{'foo-bar'} = $this->foo_bar;
-        if (isset($this->_foo_bar)) {
-            $output->{'foo bar'} = $this->_foo_bar;
+        $output->{'foo-bar'} = $this->_foo_bar;
+        if (isset($this->foo_bar)) {
+            $output->{'foo bar'} = $this->foo_bar;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-5.6/MyClass.php
@@ -37,7 +37,7 @@ class MyClass
     /**
      * @var string
      */
-    private $_fooBar_1;
+    private $fooBar;
 
     /**
      * @var string|null
@@ -46,38 +46,38 @@ class MyClass
     private $bar = null;
 
     /**
-     * @param string $_fooBar_1
+     * @param string $fooBar
      */
-    public function __construct($_fooBar_1)
+    public function __construct($fooBar)
     {
-        $this->_fooBar_1 = $_fooBar_1;
+        $this->fooBar = $fooBar;
     }
 
     /**
      * @return string
      */
-    public function getFooBar1()
+    public function getFooBar()
     {
-        return $this->_fooBar_1;
+        return $this->fooBar;
     }
 
     /**
-     * @param string $_fooBar_1
+     * @param string $fooBar
      * @return self
      * @param bool $validate
      */
-    public function withFooBar1($_fooBar_1, bool $validate = true)
+    public function withFooBar($fooBar, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_fooBar_1, self::$_schema['properties']['fooBar']);
+            $validator->validate($fooBar, self::$_schema['properties']['fooBar']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_fooBar_1 = $_fooBar_1;
+        $clone->fooBar = $fooBar;
 
         return $clone;
     }
@@ -146,10 +146,10 @@ class MyClass
         }
 
         $foobar = isset($input->{'foobar'}) ? $input->{'foobar'} : null;
-        $_fooBar_1 = $input->{'fooBar'};
+        $fooBar = $input->{'fooBar'};
         $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
 
-        $obj = new self($_fooBar_1);
+        $obj = new self($fooBar);
         $obj->foobar = $foobar;
         $obj->bar = $bar;
         return $obj;
@@ -166,7 +166,7 @@ class MyClass
         if (isset($this->foobar)) {
             $output['foobar'] = $this->foobar;
         }
-        $output['fooBar'] = $this->_fooBar_1;
+        $output['fooBar'] = $this->fooBar;
         if (isset($this->bar)) {
             $output['bar'] = $this->bar;
         }
@@ -185,7 +185,7 @@ class MyClass
         if (isset($this->foobar)) {
             $output->{'foobar'} = $this->foobar;
         }
-        $output->{'fooBar'} = $this->_fooBar_1;
+        $output->{'fooBar'} = $this->fooBar;
         if (isset($this->bar)) {
             $output->{'bar'} = $this->bar;
         }

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-7.4/MyClass.php
@@ -39,7 +39,7 @@ class MyClass
     /**
      * @var string
      */
-    private string $_fooBar_1;
+    private string $fooBar;
 
     /**
      * @var string|null
@@ -48,38 +48,38 @@ class MyClass
     private ?string $bar = null;
 
     /**
-     * @param string $_fooBar_1
+     * @param string $fooBar
      */
-    public function __construct(string $_fooBar_1)
+    public function __construct(string $fooBar)
     {
-        $this->_fooBar_1 = $_fooBar_1;
+        $this->fooBar = $fooBar;
     }
 
     /**
      * @return string
      */
-    public function getFooBar1(): string
+    public function getFooBar(): string
     {
-        return $this->_fooBar_1;
+        return $this->fooBar;
     }
 
     /**
-     * @param string $_fooBar_1
+     * @param string $fooBar
      * @return self
      * @param bool $validate
      */
-    public function withFooBar1(string $_fooBar_1, bool $validate = true): self
+    public function withFooBar(string $fooBar, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_fooBar_1, self::$_schema['properties']['fooBar']);
+            $validator->validate($fooBar, self::$_schema['properties']['fooBar']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_fooBar_1 = $_fooBar_1;
+        $clone->fooBar = $fooBar;
 
         return $clone;
     }
@@ -148,10 +148,10 @@ class MyClass
         }
 
         $foobar = isset($input->{'foobar'}) ? $input->{'foobar'} : null;
-        $_fooBar_1 = $input->{'fooBar'};
+        $fooBar = $input->{'fooBar'};
         $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
 
-        $obj = new self($_fooBar_1);
+        $obj = new self($fooBar);
         $obj->foobar = $foobar;
         $obj->bar = $bar;
         return $obj;
@@ -168,7 +168,7 @@ class MyClass
         if (isset($this->foobar)) {
             $output['foobar'] = $this->foobar;
         }
-        $output['fooBar'] = $this->_fooBar_1;
+        $output['fooBar'] = $this->fooBar;
         if (isset($this->bar)) {
             $output['bar'] = $this->bar;
         }
@@ -187,7 +187,7 @@ class MyClass
         if (isset($this->foobar)) {
             $output->{'foobar'} = $this->foobar;
         }
-        $output->{'fooBar'} = $this->_fooBar_1;
+        $output->{'fooBar'} = $this->fooBar;
         if (isset($this->bar)) {
             $output->{'bar'} = $this->bar;
         }

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-8.4/MyClass.php
@@ -39,7 +39,7 @@ class MyClass
     /**
      * @var string
      */
-    private string $_fooBar_1;
+    private string $fooBar;
 
     /**
      * @var string|null
@@ -48,38 +48,38 @@ class MyClass
     private ?string $bar = null;
 
     /**
-     * @param string $_fooBar_1
+     * @param string $fooBar
      */
-    public function __construct(string $_fooBar_1)
+    public function __construct(string $fooBar)
     {
-        $this->_fooBar_1 = $_fooBar_1;
+        $this->fooBar = $fooBar;
     }
 
     /**
      * @return string
      */
-    public function getFooBar1(): string
+    public function getFooBar(): string
     {
-        return $this->_fooBar_1;
+        return $this->fooBar;
     }
 
     /**
-     * @param string $_fooBar_1
+     * @param string $fooBar
      * @return self
      * @param bool $validate
      */
-    public function withFooBar1(string $_fooBar_1, bool $validate = true): self
+    public function withFooBar(string $fooBar, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_fooBar_1, self::$_schema['properties']['fooBar']);
+            $validator->validate($fooBar, self::$_schema['properties']['fooBar']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_fooBar_1 = $_fooBar_1;
+        $clone->fooBar = $fooBar;
 
         return $clone;
     }
@@ -142,10 +142,10 @@ class MyClass
         }
 
         $foobar = isset($input->{'foobar'}) ? $input->{'foobar'} : null;
-        $_fooBar_1 = $input->{'fooBar'};
+        $fooBar = $input->{'fooBar'};
         $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
 
-        $obj = new self($_fooBar_1);
+        $obj = new self($fooBar);
         $obj->foobar = $foobar;
         $obj->bar = $bar;
         return $obj;
@@ -162,7 +162,7 @@ class MyClass
         if (isset($this->foobar)) {
             $output['foobar'] = $this->foobar;
         }
-        $output['fooBar'] = $this->_fooBar_1;
+        $output['fooBar'] = $this->fooBar;
         if (isset($this->bar)) {
             $output['bar'] = $this->bar;
         }
@@ -181,7 +181,7 @@ class MyClass
         if (isset($this->foobar)) {
             $output->{'foobar'} = $this->foobar;
         }
-        $output->{'fooBar'} = $this->_fooBar_1;
+        $output->{'fooBar'} = $this->fooBar;
         if (isset($this->bar)) {
             $output->{'bar'} = $this->bar;
         }

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -294,77 +294,77 @@ class MyClass
     /**
      * @var string
      */
-    private $_GLOBALS_1;
+    private $_GLOBALS;
 
     /**
      * @var string
      */
-    private $_GLOBALS_2;
+    private $GLOBALS;
 
     /**
      * @var string
      */
-    private $_GLOBALS1_1;
+    private $GLOBALS1;
 
     /**
      * @var string
      */
-    private $_SERVER_1;
+    private $SERVER;
 
     /**
      * @var string
      */
-    private $_GET_1;
+    private $GET;
 
     /**
      * @var string
      */
-    private $_POST_1;
+    private $POST;
 
     /**
      * @var string
      */
-    private $_FILES_1;
+    private $FILES;
 
     /**
      * @var string
      */
-    private $_REQUEST_1;
+    private $REQUEST;
 
     /**
      * @var string
      */
-    private $_SESSION_1;
+    private $SESSION;
 
     /**
      * @var string
      */
-    private $_ENV_1;
+    private $ENV;
 
     /**
      * @var string
      */
-    private $_COOKIE_1;
+    private $COOKIE;
 
     /**
      * @var string
      */
-    private $_phpErrormsg;
+    private $phpErrormsg;
 
     /**
      * @var string
      */
-    private $_httpResponseHeader;
+    private $httpResponseHeader;
 
     /**
      * @var string
      */
-    private $_argc;
+    private $argc;
 
     /**
      * @var string
      */
-    private $_argv;
+    private $argv;
 
     /**
      * @var string
@@ -399,22 +399,27 @@ class MyClass
     /**
      * @var string
      */
-    private $_fromInput_1;
+    private $fromInput;
 
     /**
      * @var string
      */
-    private $_toArray_1;
+    private $toArray;
 
     /**
      * @var string
      */
-    private $_toStdClass_1;
+    private $toStdClass;
 
     /**
      * @var string
      */
-    private $_validateInput_1;
+    private $validateInput;
+
+    /**
+     * @var string
+     */
+    private $schema;
 
     /**
      * @var string
@@ -424,7 +429,7 @@ class MyClass
     /**
      * @var string
      */
-    private $_schema_2;
+    private $defaults;
 
     /**
      * @var string
@@ -434,87 +439,82 @@ class MyClass
     /**
      * @var string
      */
-    private $_defaults_2;
-
-    /**
-     * @var string
-     */
     private $_providedOptionals_1;
 
     /**
      * @var string|null
      */
-    private $_providedOptionals_2 = null;
+    private $providedOptionals = null;
 
     /**
      * @var string
      */
-    private $_clone_1;
+    private $_clone;
 
     /**
      * @var string
      */
-    private $_construct_1;
+    private $construct;
 
     /**
      * @var string
      */
-    private $_destruct_1;
+    private $destruct;
 
     /**
      * @var string
      */
-    private $_get_2;
+    private $get;
 
     /**
      * @var string
      */
-    private $_set_1;
+    private $set;
 
     /**
      * @var string
      */
-    private $_call_1;
+    private $call;
 
     /**
      * @var string
      */
-    private $_isset_1;
+    private $isset;
 
     /**
      * @var string
      */
-    private $_unset_1;
+    private $unset;
 
     /**
      * @var string
      */
-    private $_sleep_1;
+    private $sleep;
 
     /**
      * @var string
      */
-    private $_wakeup_1;
+    private $wakeup;
 
     /**
      * @var string
      */
-    private $_toString_1;
+    private $toString;
 
     /**
      * @var string
      */
-    private $_invoke_1;
+    private $invoke;
 
     /**
      * @var string
      */
-    private $_debugInfo_1;
+    private $debugInfo;
 
     /**
      * @var string
      */
-    private $_clone_2;
+    private $clone;
 
     /**
      * @var string
@@ -542,93 +542,93 @@ class MyClass
     private $ensureArgs3 = null;
 
     /**
-     * @param string $_GLOBALS_1
      * @param string $_GLOBALS_2
-     * @param string $_GLOBALS1_1
-     * @param string $_SERVER_1
-     * @param string $_GET_1
-     * @param string $_POST_1
-     * @param string $_FILES_1
-     * @param string $_REQUEST_1
-     * @param string $_SESSION_1
-     * @param string $_ENV_1
-     * @param string $_COOKIE_1
-     * @param string $_phpErrormsg
-     * @param string $_httpResponseHeader
+     * @param string $_GLOBALS_1
+     * @param string $GLOBALS1
+     * @param string $SERVER
+     * @param string $GET
+     * @param string $POST
+     * @param string $FILES
+     * @param string $REQUEST
+     * @param string $SESSION
+     * @param string $ENV
+     * @param string $COOKIE
+     * @param string $phpErrormsg
+     * @param string $httpResponseHeader
      * @param string $_argc
      * @param string $_argv
-     * @param string $input
-     * @param string $obj
+     * @param string $_input
+     * @param string $_obj
      * @param string $includeDefaults
-     * @param string $_fromInput_1
-     * @param string $_toArray_1
-     * @param string $_toStdClass_1
-     * @param string $_validateInput_1
+     * @param string $fromInput
+     * @param string $toArray
+     * @param string $toStdClass
+     * @param string $validateInput
+     * @param string $schema
      * @param string $_schema_1
-     * @param string $_schema_2
+     * @param string $defaults
      * @param string $_defaults_1
-     * @param string $_defaults_2
      * @param string $_providedOptionals_1
-     * @param string $_clone_1
-     * @param string $_construct_1
-     * @param string $_destruct_1
-     * @param string $_get_2
-     * @param string $_set_1
-     * @param string $_call_1
-     * @param string $_isset_1
-     * @param string $_unset_1
-     * @param string $_sleep_1
-     * @param string $_wakeup_1
-     * @param string $_toString_1
-     * @param string $_invoke_1
-     * @param string $_debugInfo_1
-     * @param string $_clone_2
+     * @param string $_clone
+     * @param string $construct
+     * @param string $destruct
+     * @param string $get
+     * @param string $set
+     * @param string $call
+     * @param string $isset
+     * @param string $unset
+     * @param string $sleep
+     * @param string $wakeup
+     * @param string $toString
+     * @param string $invoke
+     * @param string $debugInfo
+     * @param string $clone
      * @param string $files
      * @param string $_this
      */
-    public function __construct($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $input, $obj, $includeDefaults, $_fromInput_1, $_toArray_1, $_toStdClass_1, $_validateInput_1, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone_1, $_construct_1, $_destruct_1, $_get_2, $_set_1, $_call_1, $_isset_1, $_unset_1, $_sleep_1, $_wakeup_1, $_toString_1, $_invoke_1, $_debugInfo_1, $_clone_2, $files, $_this)
+    public function __construct($_GLOBALS_2, $_GLOBALS_1, $GLOBALS1, $SERVER, $GET, $POST, $FILES, $REQUEST, $SESSION, $ENV, $COOKIE, $phpErrormsg, $httpResponseHeader, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $schema, $_schema_1, $defaults, $_defaults_1, $_providedOptionals_1, $_clone, $construct, $destruct, $get, $set, $call, $isset, $unset, $sleep, $wakeup, $toString, $invoke, $debugInfo, $clone, $files, $_this)
     {
-        $this->_GLOBALS_1 = $_GLOBALS_1;
-        $this->_GLOBALS_2 = $_GLOBALS_2;
-        $this->_GLOBALS1_1 = $_GLOBALS1_1;
-        $this->_SERVER_1 = $_SERVER_1;
-        $this->_GET_1 = $_GET_1;
-        $this->_POST_1 = $_POST_1;
-        $this->_FILES_1 = $_FILES_1;
-        $this->_REQUEST_1 = $_REQUEST_1;
-        $this->_SESSION_1 = $_SESSION_1;
-        $this->_ENV_1 = $_ENV_1;
-        $this->_COOKIE_1 = $_COOKIE_1;
-        $this->_phpErrormsg = $_phpErrormsg;
-        $this->_httpResponseHeader = $_httpResponseHeader;
-        $this->_argc = $_argc;
-        $this->_argv = $_argv;
-        $this->input = $input;
-        $this->obj = $obj;
+        $this->_GLOBALS = $_GLOBALS_2;
+        $this->GLOBALS = $_GLOBALS_1;
+        $this->GLOBALS1 = $GLOBALS1;
+        $this->SERVER = $SERVER;
+        $this->GET = $GET;
+        $this->POST = $POST;
+        $this->FILES = $FILES;
+        $this->REQUEST = $REQUEST;
+        $this->SESSION = $SESSION;
+        $this->ENV = $ENV;
+        $this->COOKIE = $COOKIE;
+        $this->phpErrormsg = $phpErrormsg;
+        $this->httpResponseHeader = $httpResponseHeader;
+        $this->argc = $_argc;
+        $this->argv = $_argv;
+        $this->input = $_input;
+        $this->obj = $_obj;
         $this->includeDefaults = $includeDefaults;
-        $this->_fromInput_1 = $_fromInput_1;
-        $this->_toArray_1 = $_toArray_1;
-        $this->_toStdClass_1 = $_toStdClass_1;
-        $this->_validateInput_1 = $_validateInput_1;
+        $this->fromInput = $fromInput;
+        $this->toArray = $toArray;
+        $this->toStdClass = $toStdClass;
+        $this->validateInput = $validateInput;
+        $this->schema = $schema;
         $this->_schema_1 = $_schema_1;
-        $this->_schema_2 = $_schema_2;
+        $this->defaults = $defaults;
         $this->_defaults_1 = $_defaults_1;
-        $this->_defaults_2 = $_defaults_2;
         $this->_providedOptionals_1 = $_providedOptionals_1;
-        $this->_clone_1 = $_clone_1;
-        $this->_construct_1 = $_construct_1;
-        $this->_destruct_1 = $_destruct_1;
-        $this->_get_2 = $_get_2;
-        $this->_set_1 = $_set_1;
-        $this->_call_1 = $_call_1;
-        $this->_isset_1 = $_isset_1;
-        $this->_unset_1 = $_unset_1;
-        $this->_sleep_1 = $_sleep_1;
-        $this->_wakeup_1 = $_wakeup_1;
-        $this->_toString_1 = $_toString_1;
-        $this->_invoke_1 = $_invoke_1;
-        $this->_debugInfo_1 = $_debugInfo_1;
-        $this->_clone_2 = $_clone_2;
+        $this->_clone = $_clone;
+        $this->construct = $construct;
+        $this->destruct = $destruct;
+        $this->get = $get;
+        $this->set = $set;
+        $this->call = $call;
+        $this->isset = $isset;
+        $this->unset = $unset;
+        $this->sleep = $sleep;
+        $this->wakeup = $wakeup;
+        $this->toString = $toString;
+        $this->invoke = $invoke;
+        $this->debugInfo = $debugInfo;
+        $this->clone = $clone;
         $this->files = $files;
         $this->_this = $_this;
     }
@@ -636,38 +636,9 @@ class MyClass
     /**
      * @return string
      */
-    public function getGLOBALS1()
+    public function get_GLOBALS()
     {
-        return $this->_GLOBALS_1;
-    }
-
-    /**
-     * @param string $_GLOBALS_1
-     * @return self
-     * @param bool $validate
-     */
-    public function withGLOBALS1($_GLOBALS_1, bool $validate = true)
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_1, self::$_schema['properties']['_GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->_GLOBALS_1 = $_GLOBALS_1;
-
-        return $clone;
-    }
-
-    /**
-     * @return string
-     */
-    public function getGLOBALS2()
-    {
-        return $this->_GLOBALS_2;
+        return $this->_GLOBALS;
     }
 
     /**
@@ -675,18 +646,18 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function withGLOBALS2($_GLOBALS_2, bool $validate = true)
+    public function with_GLOBALS($_GLOBALS_2, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_2, self::$_schema['properties']['GLOBALS']);
+            $validator->validate($_GLOBALS_2, self::$_schema['properties']['_GLOBALS']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_GLOBALS_2 = $_GLOBALS_2;
+        $clone->_GLOBALS = $_GLOBALS_2;
 
         return $clone;
     }
@@ -694,28 +665,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getGLOBALS11()
+    public function getGLOBALS()
     {
-        return $this->_GLOBALS1_1;
+        return $this->GLOBALS;
     }
 
     /**
-     * @param string $_GLOBALS1_1
+     * @param string $_GLOBALS_1
      * @return self
      * @param bool $validate
      */
-    public function withGLOBALS11($_GLOBALS1_1, bool $validate = true)
+    public function withGLOBALS($_GLOBALS_1, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS1_1, self::$_schema['properties']['GLOBALS_1']);
+            $validator->validate($_GLOBALS_1, self::$_schema['properties']['GLOBALS']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_GLOBALS1_1 = $_GLOBALS1_1;
+        $clone->GLOBALS = $_GLOBALS_1;
 
         return $clone;
     }
@@ -723,28 +694,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSERVER1()
+    public function getGLOBALS1()
     {
-        return $this->_SERVER_1;
+        return $this->GLOBALS1;
     }
 
     /**
-     * @param string $_SERVER_1
+     * @param string $GLOBALS1
      * @return self
      * @param bool $validate
      */
-    public function withSERVER1($_SERVER_1, bool $validate = true)
+    public function withGLOBALS1($GLOBALS1, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_SERVER_1, self::$_schema['properties']['_SERVER']);
+            $validator->validate($GLOBALS1, self::$_schema['properties']['GLOBALS_1']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_SERVER_1 = $_SERVER_1;
+        $clone->GLOBALS1 = $GLOBALS1;
 
         return $clone;
     }
@@ -752,28 +723,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getGET1()
+    public function getSERVER()
     {
-        return $this->_GET_1;
+        return $this->SERVER;
     }
 
     /**
-     * @param string $_GET_1
+     * @param string $SERVER
      * @return self
      * @param bool $validate
      */
-    public function withGET1($_GET_1, bool $validate = true)
+    public function withSERVER($SERVER, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_GET_1, self::$_schema['properties']['_GET']);
+            $validator->validate($SERVER, self::$_schema['properties']['_SERVER']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_GET_1 = $_GET_1;
+        $clone->SERVER = $SERVER;
 
         return $clone;
     }
@@ -781,28 +752,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getPOST1()
+    public function getGET()
     {
-        return $this->_POST_1;
+        return $this->GET;
     }
 
     /**
-     * @param string $_POST_1
+     * @param string $GET
      * @return self
      * @param bool $validate
      */
-    public function withPOST1($_POST_1, bool $validate = true)
+    public function withGET($GET, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_POST_1, self::$_schema['properties']['_POST']);
+            $validator->validate($GET, self::$_schema['properties']['_GET']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_POST_1 = $_POST_1;
+        $clone->GET = $GET;
 
         return $clone;
     }
@@ -810,28 +781,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getFILES1()
+    public function getPOST()
     {
-        return $this->_FILES_1;
+        return $this->POST;
     }
 
     /**
-     * @param string $_FILES_1
+     * @param string $POST
      * @return self
      * @param bool $validate
      */
-    public function withFILES1($_FILES_1, bool $validate = true)
+    public function withPOST($POST, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_FILES_1, self::$_schema['properties']['_FILES']);
+            $validator->validate($POST, self::$_schema['properties']['_POST']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_FILES_1 = $_FILES_1;
+        $clone->POST = $POST;
 
         return $clone;
     }
@@ -839,28 +810,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getREQUEST1()
+    public function getFILES()
     {
-        return $this->_REQUEST_1;
+        return $this->FILES;
     }
 
     /**
-     * @param string $_REQUEST_1
+     * @param string $FILES
      * @return self
      * @param bool $validate
      */
-    public function withREQUEST1($_REQUEST_1, bool $validate = true)
+    public function withFILES($FILES, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_REQUEST_1, self::$_schema['properties']['_REQUEST']);
+            $validator->validate($FILES, self::$_schema['properties']['_FILES']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_REQUEST_1 = $_REQUEST_1;
+        $clone->FILES = $FILES;
 
         return $clone;
     }
@@ -868,28 +839,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSESSION1()
+    public function getREQUEST()
     {
-        return $this->_SESSION_1;
+        return $this->REQUEST;
     }
 
     /**
-     * @param string $_SESSION_1
+     * @param string $REQUEST
      * @return self
      * @param bool $validate
      */
-    public function withSESSION1($_SESSION_1, bool $validate = true)
+    public function withREQUEST($REQUEST, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_SESSION_1, self::$_schema['properties']['_SESSION']);
+            $validator->validate($REQUEST, self::$_schema['properties']['_REQUEST']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_SESSION_1 = $_SESSION_1;
+        $clone->REQUEST = $REQUEST;
 
         return $clone;
     }
@@ -897,28 +868,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getENV1()
+    public function getSESSION()
     {
-        return $this->_ENV_1;
+        return $this->SESSION;
     }
 
     /**
-     * @param string $_ENV_1
+     * @param string $SESSION
      * @return self
      * @param bool $validate
      */
-    public function withENV1($_ENV_1, bool $validate = true)
+    public function withSESSION($SESSION, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_ENV_1, self::$_schema['properties']['_ENV']);
+            $validator->validate($SESSION, self::$_schema['properties']['_SESSION']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_ENV_1 = $_ENV_1;
+        $clone->SESSION = $SESSION;
 
         return $clone;
     }
@@ -926,28 +897,57 @@ class MyClass
     /**
      * @return string
      */
-    public function getCOOKIE1()
+    public function getENV()
     {
-        return $this->_COOKIE_1;
+        return $this->ENV;
     }
 
     /**
-     * @param string $_COOKIE_1
+     * @param string $ENV
      * @return self
      * @param bool $validate
      */
-    public function withCOOKIE1($_COOKIE_1, bool $validate = true)
+    public function withENV($ENV, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_COOKIE_1, self::$_schema['properties']['_COOKIE']);
+            $validator->validate($ENV, self::$_schema['properties']['_ENV']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_COOKIE_1 = $_COOKIE_1;
+        $clone->ENV = $ENV;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCOOKIE()
+    {
+        return $this->COOKIE;
+    }
+
+    /**
+     * @param string $COOKIE
+     * @return self
+     * @param bool $validate
+     */
+    public function withCOOKIE($COOKIE, bool $validate = true)
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($COOKIE, self::$_schema['properties']['_COOKIE']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->COOKIE = $COOKIE;
 
         return $clone;
     }
@@ -957,26 +957,26 @@ class MyClass
      */
     public function getPhpErrormsg()
     {
-        return $this->_phpErrormsg;
+        return $this->phpErrormsg;
     }
 
     /**
-     * @param string $_phpErrormsg
+     * @param string $phpErrormsg
      * @return self
      * @param bool $validate
      */
-    public function withPhpErrormsg($_phpErrormsg, bool $validate = true)
+    public function withPhpErrormsg($phpErrormsg, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_phpErrormsg, self::$_schema['properties']['php_errormsg']);
+            $validator->validate($phpErrormsg, self::$_schema['properties']['php_errormsg']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_phpErrormsg = $_phpErrormsg;
+        $clone->phpErrormsg = $phpErrormsg;
 
         return $clone;
     }
@@ -986,26 +986,26 @@ class MyClass
      */
     public function getHttpResponseHeader()
     {
-        return $this->_httpResponseHeader;
+        return $this->httpResponseHeader;
     }
 
     /**
-     * @param string $_httpResponseHeader
+     * @param string $httpResponseHeader
      * @return self
      * @param bool $validate
      */
-    public function withHttpResponseHeader($_httpResponseHeader, bool $validate = true)
+    public function withHttpResponseHeader($httpResponseHeader, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_httpResponseHeader, self::$_schema['properties']['http_response_header']);
+            $validator->validate($httpResponseHeader, self::$_schema['properties']['http_response_header']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_httpResponseHeader = $_httpResponseHeader;
+        $clone->httpResponseHeader = $httpResponseHeader;
 
         return $clone;
     }
@@ -1015,7 +1015,7 @@ class MyClass
      */
     public function getArgc()
     {
-        return $this->_argc;
+        return $this->argc;
     }
 
     /**
@@ -1034,7 +1034,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_argc = $_argc;
+        $clone->argc = $_argc;
 
         return $clone;
     }
@@ -1044,7 +1044,7 @@ class MyClass
      */
     public function getArgv()
     {
-        return $this->_argv;
+        return $this->argv;
     }
 
     /**
@@ -1063,7 +1063,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_argv = $_argv;
+        $clone->argv = $_argv;
 
         return $clone;
     }
@@ -1077,22 +1077,22 @@ class MyClass
     }
 
     /**
-     * @param string $input
+     * @param string $_input
      * @return self
      * @param bool $validate
      */
-    public function withInput($input, bool $validate = true)
+    public function withInput($_input, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($input, self::$_schema['properties']['input']);
+            $validator->validate($_input, self::$_schema['properties']['input']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->input = $input;
+        $clone->input = $_input;
 
         return $clone;
     }
@@ -1106,22 +1106,22 @@ class MyClass
     }
 
     /**
-     * @param string $validate
+     * @param string $_validate
      * @return self
      * @param bool $validate
      */
-    public function withValidate(bool $validate = true)
+    public function withValidate($_validate, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($validate, self::$_schema['properties']['validate']);
+            $validator->validate($_validate, self::$_schema['properties']['validate']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->validate = $validate;
+        $clone->validate = $_validate;
 
         return $clone;
     }
@@ -1146,22 +1146,22 @@ class MyClass
     }
 
     /**
-     * @param string $materializeDefaults
+     * @param string $_materializeDefaults
      * @return self
      * @param bool $validate
      */
-    public function withMaterializeDefaults($materializeDefaults, bool $validate = true)
+    public function withMaterializeDefaults($_materializeDefaults, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($materializeDefaults, self::$_schema['properties']['materializeDefaults']);
+            $validator->validate($_materializeDefaults, self::$_schema['properties']['materializeDefaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->materializeDefaults = $materializeDefaults;
+        $clone->materializeDefaults = $_materializeDefaults;
         $clone->_providedOptionals['materializeDefaults'] = true;
 
         return $clone;
@@ -1188,22 +1188,22 @@ class MyClass
     }
 
     /**
-     * @param string $obj
+     * @param string $_obj
      * @return self
      * @param bool $validate
      */
-    public function withObj($obj, bool $validate = true)
+    public function withObj($_obj, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($obj, self::$_schema['properties']['obj']);
+            $validator->validate($_obj, self::$_schema['properties']['obj']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->obj = $obj;
+        $clone->obj = $_obj;
 
         return $clone;
     }
@@ -1271,28 +1271,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getFromInput1()
+    public function getFromInput()
     {
-        return $this->_fromInput_1;
+        return $this->fromInput;
     }
 
     /**
-     * @param string $_fromInput_1
+     * @param string $fromInput
      * @return self
      * @param bool $validate
      */
-    public function withFromInput1($_fromInput_1, bool $validate = true)
+    public function withFromInput($fromInput, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_fromInput_1, self::$_schema['properties']['fromInput']);
+            $validator->validate($fromInput, self::$_schema['properties']['fromInput']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_fromInput_1 = $_fromInput_1;
+        $clone->fromInput = $fromInput;
 
         return $clone;
     }
@@ -1300,28 +1300,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getToArray1()
+    public function getToArray()
     {
-        return $this->_toArray_1;
+        return $this->toArray;
     }
 
     /**
-     * @param string $_toArray_1
+     * @param string $toArray
      * @return self
      * @param bool $validate
      */
-    public function withToArray1($_toArray_1, bool $validate = true)
+    public function withToArray($toArray, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toArray_1, self::$_schema['properties']['toArray']);
+            $validator->validate($toArray, self::$_schema['properties']['toArray']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toArray_1 = $_toArray_1;
+        $clone->toArray = $toArray;
 
         return $clone;
     }
@@ -1329,28 +1329,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getToStdClass1()
+    public function getToStdClass()
     {
-        return $this->_toStdClass_1;
+        return $this->toStdClass;
     }
 
     /**
-     * @param string $_toStdClass_1
+     * @param string $toStdClass
      * @return self
      * @param bool $validate
      */
-    public function withToStdClass1($_toStdClass_1, bool $validate = true)
+    public function withToStdClass($toStdClass, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toStdClass_1, self::$_schema['properties']['toStdClass']);
+            $validator->validate($toStdClass, self::$_schema['properties']['toStdClass']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toStdClass_1 = $_toStdClass_1;
+        $clone->toStdClass = $toStdClass;
 
         return $clone;
     }
@@ -1358,28 +1358,57 @@ class MyClass
     /**
      * @return string
      */
-    public function getValidateInput1()
+    public function getValidateInput()
     {
-        return $this->_validateInput_1;
+        return $this->validateInput;
     }
 
     /**
-     * @param string $_validateInput_1
+     * @param string $validateInput
      * @return self
      * @param bool $validate
      */
-    public function withValidateInput1($_validateInput_1, bool $validate = true)
+    public function withValidateInput($validateInput, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_validateInput_1, self::$_schema['properties']['validateInput']);
+            $validator->validate($validateInput, self::$_schema['properties']['validateInput']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_validateInput_1 = $_validateInput_1;
+        $clone->validateInput = $validateInput;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSchema()
+    {
+        return $this->schema;
+    }
+
+    /**
+     * @param string $schema
+     * @return self
+     * @param bool $validate
+     */
+    public function withSchema($schema, bool $validate = true)
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($schema, self::$_schema['properties']['_schema']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->schema = $schema;
 
         return $clone;
     }
@@ -1401,7 +1430,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_1, self::$_schema['properties']['_schema']);
+            $validator->validate($_schema_1, self::$_schema['properties']['schema']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -1416,28 +1445,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSchema2()
+    public function getDefaults()
     {
-        return $this->_schema_2;
+        return $this->defaults;
     }
 
     /**
-     * @param string $_schema_2
+     * @param string $defaults
      * @return self
      * @param bool $validate
      */
-    public function withSchema2($_schema_2, bool $validate = true)
+    public function withDefaults($defaults, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_2, self::$_schema['properties']['schema']);
+            $validator->validate($defaults, self::$_schema['properties']['_defaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_schema_2 = $_schema_2;
+        $clone->defaults = $defaults;
 
         return $clone;
     }
@@ -1459,7 +1488,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_1, self::$_schema['properties']['_defaults']);
+            $validator->validate($_defaults_1, self::$_schema['properties']['defaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -1467,35 +1496,6 @@ class MyClass
 
         $clone = clone $this;
         $clone->_defaults_1 = $_defaults_1;
-
-        return $clone;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDefaults2()
-    {
-        return $this->_defaults_2;
-    }
-
-    /**
-     * @param string $_defaults_2
-     * @return self
-     * @param bool $validate
-     */
-    public function withDefaults2($_defaults_2, bool $validate = true)
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_2, self::$_schema['properties']['defaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->_defaults_2 = $_defaults_2;
 
         return $clone;
     }
@@ -1532,28 +1532,28 @@ class MyClass
     /**
      * @return string|null
      */
-    public function getProvidedOptionals2()
+    public function getProvidedOptionals()
     {
-        return $this->_providedOptionals_2;
+        return $this->providedOptionals;
     }
 
     /**
-     * @param string $_providedOptionals_2
+     * @param string $providedOptionals
      * @return self
      * @param bool $validate
      */
-    public function withProvidedOptionals2($_providedOptionals_2, bool $validate = true)
+    public function withProvidedOptionals($providedOptionals, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_providedOptionals_2, self::$_schema['properties']['__providedOptionals']);
+            $validator->validate($providedOptionals, self::$_schema['properties']['__providedOptionals']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_providedOptionals_2 = $_providedOptionals_2;
+        $clone->providedOptionals = $providedOptionals;
 
         return $clone;
     }
@@ -1561,10 +1561,10 @@ class MyClass
     /**
      * @return self
      */
-    public function withoutProvidedOptionals2()
+    public function withoutProvidedOptionals()
     {
         $clone = clone $this;
-        unset($clone->_providedOptionals_2);
+        unset($clone->providedOptionals);
 
         return $clone;
     }
@@ -1572,28 +1572,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getClone1()
+    public function get_Clone()
     {
-        return $this->_clone_1;
+        return $this->_clone;
     }
 
     /**
-     * @param string $_clone_1
+     * @param string $_clone
      * @return self
      * @param bool $validate
      */
-    public function withClone1($_clone_1, bool $validate = true)
+    public function with_Clone($_clone, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone_1, self::$_schema['properties']['clone']);
+            $validator->validate($_clone, self::$_schema['properties']['clone']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_clone_1 = $_clone_1;
+        $clone->_clone = $_clone;
 
         return $clone;
     }
@@ -1601,28 +1601,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getConstruct1()
+    public function getConstruct()
     {
-        return $this->_construct_1;
+        return $this->construct;
     }
 
     /**
-     * @param string $_construct_1
+     * @param string $construct
      * @return self
      * @param bool $validate
      */
-    public function withConstruct1($_construct_1, bool $validate = true)
+    public function withConstruct($construct, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_construct_1, self::$_schema['properties']['__construct']);
+            $validator->validate($construct, self::$_schema['properties']['__construct']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_construct_1 = $_construct_1;
+        $clone->construct = $construct;
 
         return $clone;
     }
@@ -1630,28 +1630,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getDestruct1()
+    public function getDestruct()
     {
-        return $this->_destruct_1;
+        return $this->destruct;
     }
 
     /**
-     * @param string $_destruct_1
+     * @param string $destruct
      * @return self
      * @param bool $validate
      */
-    public function withDestruct1($_destruct_1, bool $validate = true)
+    public function withDestruct($destruct, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_destruct_1, self::$_schema['properties']['__destruct']);
+            $validator->validate($destruct, self::$_schema['properties']['__destruct']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_destruct_1 = $_destruct_1;
+        $clone->destruct = $destruct;
 
         return $clone;
     }
@@ -1659,28 +1659,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getGet2()
+    public function get_Get()
     {
-        return $this->_get_2;
+        return $this->get;
     }
 
     /**
-     * @param string $_get_2
+     * @param string $get
      * @return self
      * @param bool $validate
      */
-    public function withGet2($_get_2, bool $validate = true)
+    public function with_Get($get, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_get_2, self::$_schema['properties']['__get']);
+            $validator->validate($get, self::$_schema['properties']['__get']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_get_2 = $_get_2;
+        $clone->get = $get;
 
         return $clone;
     }
@@ -1688,28 +1688,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSet1()
+    public function getSet()
     {
-        return $this->_set_1;
+        return $this->set;
     }
 
     /**
-     * @param string $_set_1
+     * @param string $set
      * @return self
      * @param bool $validate
      */
-    public function withSet1($_set_1, bool $validate = true)
+    public function withSet($set, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_set_1, self::$_schema['properties']['__set']);
+            $validator->validate($set, self::$_schema['properties']['__set']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_set_1 = $_set_1;
+        $clone->set = $set;
 
         return $clone;
     }
@@ -1717,28 +1717,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getCall1()
+    public function getCall()
     {
-        return $this->_call_1;
+        return $this->call;
     }
 
     /**
-     * @param string $_call_1
+     * @param string $call
      * @return self
      * @param bool $validate
      */
-    public function withCall1($_call_1, bool $validate = true)
+    public function withCall($call, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_call_1, self::$_schema['properties']['__call']);
+            $validator->validate($call, self::$_schema['properties']['__call']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_call_1 = $_call_1;
+        $clone->call = $call;
 
         return $clone;
     }
@@ -1746,28 +1746,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getIsset1()
+    public function getIsset()
     {
-        return $this->_isset_1;
+        return $this->isset;
     }
 
     /**
-     * @param string $_isset_1
+     * @param string $isset
      * @return self
      * @param bool $validate
      */
-    public function withIsset1($_isset_1, bool $validate = true)
+    public function withIsset($isset, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_isset_1, self::$_schema['properties']['__isset']);
+            $validator->validate($isset, self::$_schema['properties']['__isset']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_isset_1 = $_isset_1;
+        $clone->isset = $isset;
 
         return $clone;
     }
@@ -1775,28 +1775,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getUnset1()
+    public function getUnset()
     {
-        return $this->_unset_1;
+        return $this->unset;
     }
 
     /**
-     * @param string $_unset_1
+     * @param string $unset
      * @return self
      * @param bool $validate
      */
-    public function withUnset1($_unset_1, bool $validate = true)
+    public function withUnset($unset, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_unset_1, self::$_schema['properties']['__unset']);
+            $validator->validate($unset, self::$_schema['properties']['__unset']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_unset_1 = $_unset_1;
+        $clone->unset = $unset;
 
         return $clone;
     }
@@ -1804,28 +1804,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSleep1()
+    public function getSleep()
     {
-        return $this->_sleep_1;
+        return $this->sleep;
     }
 
     /**
-     * @param string $_sleep_1
+     * @param string $sleep
      * @return self
      * @param bool $validate
      */
-    public function withSleep1($_sleep_1, bool $validate = true)
+    public function withSleep($sleep, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_sleep_1, self::$_schema['properties']['__sleep']);
+            $validator->validate($sleep, self::$_schema['properties']['__sleep']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_sleep_1 = $_sleep_1;
+        $clone->sleep = $sleep;
 
         return $clone;
     }
@@ -1833,28 +1833,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getWakeup1()
+    public function getWakeup()
     {
-        return $this->_wakeup_1;
+        return $this->wakeup;
     }
 
     /**
-     * @param string $_wakeup_1
+     * @param string $wakeup
      * @return self
      * @param bool $validate
      */
-    public function withWakeup1($_wakeup_1, bool $validate = true)
+    public function withWakeup($wakeup, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_wakeup_1, self::$_schema['properties']['__wakeup']);
+            $validator->validate($wakeup, self::$_schema['properties']['__wakeup']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_wakeup_1 = $_wakeup_1;
+        $clone->wakeup = $wakeup;
 
         return $clone;
     }
@@ -1862,28 +1862,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getToString1()
+    public function getToString()
     {
-        return $this->_toString_1;
+        return $this->toString;
     }
 
     /**
-     * @param string $_toString_1
+     * @param string $toString
      * @return self
      * @param bool $validate
      */
-    public function withToString1($_toString_1, bool $validate = true)
+    public function withToString($toString, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toString_1, self::$_schema['properties']['__toString']);
+            $validator->validate($toString, self::$_schema['properties']['__toString']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toString_1 = $_toString_1;
+        $clone->toString = $toString;
 
         return $clone;
     }
@@ -1891,28 +1891,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getInvoke1()
+    public function getInvoke()
     {
-        return $this->_invoke_1;
+        return $this->invoke;
     }
 
     /**
-     * @param string $_invoke_1
+     * @param string $invoke
      * @return self
      * @param bool $validate
      */
-    public function withInvoke1($_invoke_1, bool $validate = true)
+    public function withInvoke($invoke, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_invoke_1, self::$_schema['properties']['__invoke']);
+            $validator->validate($invoke, self::$_schema['properties']['__invoke']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_invoke_1 = $_invoke_1;
+        $clone->invoke = $invoke;
 
         return $clone;
     }
@@ -1920,28 +1920,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getDebugInfo1()
+    public function getDebugInfo()
     {
-        return $this->_debugInfo_1;
+        return $this->debugInfo;
     }
 
     /**
-     * @param string $_debugInfo_1
+     * @param string $debugInfo
      * @return self
      * @param bool $validate
      */
-    public function withDebugInfo1($_debugInfo_1, bool $validate = true)
+    public function withDebugInfo($debugInfo, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_debugInfo_1, self::$_schema['properties']['__debugInfo']);
+            $validator->validate($debugInfo, self::$_schema['properties']['__debugInfo']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_debugInfo_1 = $_debugInfo_1;
+        $clone->debugInfo = $debugInfo;
 
         return $clone;
     }
@@ -1949,28 +1949,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getClone2()
+    public function getClone()
     {
-        return $this->_clone_2;
+        return $this->clone;
     }
 
     /**
-     * @param string $_clone_2
+     * @param string $clone
      * @return self
      * @param bool $validate
      */
-    public function withClone2($_clone_2, bool $validate = true)
+    public function withClone($clone, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone_2, self::$_schema['properties']['__clone']);
+            $validator->validate($clone, self::$_schema['properties']['__clone']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_clone_2 = $_clone_2;
+        $clone->clone = $clone;
 
         return $clone;
     }
@@ -1978,7 +1978,7 @@ class MyClass
     /**
      * @return string
      */
-    public function getFiles()
+    public function get_Files()
     {
         return $this->files;
     }
@@ -1988,7 +1988,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function withFiles($files, bool $validate = true)
+    public function with_Files($files, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -2171,19 +2171,19 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $_GLOBALS_1 = $input->{'_GLOBALS'};
-        $_GLOBALS_2 = $input->{'GLOBALS'};
-        $_GLOBALS1_1 = $input->{'GLOBALS_1'};
-        $_SERVER_1 = $input->{'_SERVER'};
-        $_GET_1 = $input->{'_GET'};
-        $_POST_1 = $input->{'_POST'};
-        $_FILES_1 = $input->{'_FILES'};
-        $_REQUEST_1 = $input->{'_REQUEST'};
-        $_SESSION_1 = $input->{'_SESSION'};
-        $_ENV_1 = $input->{'_ENV'};
-        $_COOKIE_1 = $input->{'_COOKIE'};
-        $_phpErrormsg = $input->{'php_errormsg'};
-        $_httpResponseHeader = $input->{'http_response_header'};
+        $_GLOBALS_2 = $input->{'_GLOBALS'};
+        $_GLOBALS_1 = $input->{'GLOBALS'};
+        $GLOBALS1 = $input->{'GLOBALS_1'};
+        $SERVER = $input->{'_SERVER'};
+        $GET = $input->{'_GET'};
+        $POST = $input->{'_POST'};
+        $FILES = $input->{'_FILES'};
+        $REQUEST = $input->{'_REQUEST'};
+        $SESSION = $input->{'_SESSION'};
+        $ENV = $input->{'_ENV'};
+        $COOKIE = $input->{'_COOKIE'};
+        $phpErrormsg = $input->{'php_errormsg'};
+        $httpResponseHeader = $input->{'http_response_header'};
         $_argc = $input->{'argc'};
         $_argv = $input->{'argv'};
         $_input = $input->{'input'};
@@ -2195,41 +2195,41 @@ class MyClass
         $_obj = $input->{'obj'};
         $includeDefaults = $input->{'includeDefaults'};
         $testObj = isset($input->{'testObj'}) ? MyClassTestObj::fromInput($input->{'testObj'}, $validate, $materializeDefaults) : null;
-        $_fromInput_1 = $input->{'fromInput'};
-        $_toArray_1 = $input->{'toArray'};
-        $_toStdClass_1 = $input->{'toStdClass'};
-        $_validateInput_1 = $input->{'validateInput'};
-        $_schema_1 = $input->{'_schema'};
-        $_schema_2 = $input->{'schema'};
-        $_defaults_1 = $input->{'_defaults'};
-        $_defaults_2 = $input->{'defaults'};
+        $fromInput = $input->{'fromInput'};
+        $toArray = $input->{'toArray'};
+        $toStdClass = $input->{'toStdClass'};
+        $validateInput = $input->{'validateInput'};
+        $schema = $input->{'_schema'};
+        $_schema_1 = $input->{'schema'};
+        $defaults = $input->{'_defaults'};
+        $_defaults_1 = $input->{'defaults'};
         $_providedOptionals_1 = $input->{'_providedOptionals'};
-        $_providedOptionals_2 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
-        $_clone_1 = $input->{'clone'};
-        $_construct_1 = $input->{'__construct'};
-        $_destruct_1 = $input->{'__destruct'};
-        $_get_2 = $input->{'__get'};
-        $_set_1 = $input->{'__set'};
-        $_call_1 = $input->{'__call'};
-        $_isset_1 = $input->{'__isset'};
-        $_unset_1 = $input->{'__unset'};
-        $_sleep_1 = $input->{'__sleep'};
-        $_wakeup_1 = $input->{'__wakeup'};
-        $_toString_1 = $input->{'__toString'};
-        $_invoke_1 = $input->{'__invoke'};
-        $_debugInfo_1 = $input->{'__debugInfo'};
-        $_clone_2 = $input->{'__clone'};
+        $providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
+        $_clone = $input->{'clone'};
+        $construct = $input->{'__construct'};
+        $destruct = $input->{'__destruct'};
+        $get = $input->{'__get'};
+        $set = $input->{'__set'};
+        $call = $input->{'__call'};
+        $isset = $input->{'__isset'};
+        $unset = $input->{'__unset'};
+        $sleep = $input->{'__sleep'};
+        $wakeup = $input->{'__wakeup'};
+        $toString = $input->{'__toString'};
+        $invoke = $input->{'__invoke'};
+        $debugInfo = $input->{'__debugInfo'};
+        $clone = $input->{'__clone'};
         $files = $input->{'files'};
         $_this = $input->{'this'};
         $ensureArgs1 = isset($input->{'ensureArgs1'}) ? ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : (((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (null)))))) : null;
         $ensureArgs2 = isset($input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($input->{'ensureArgs2'}, $validate, $materializeDefaults) : null;
         $ensureArgs3 = isset($input->{'ensureArgs3'}) ? array_map(function($i) use ($validate, $materializeDefaults) { return MyClassEnsureArgs3Item::fromInput($i, $validate, $materializeDefaults); }, $input->{'ensureArgs3'}) : null;
 
-        $obj = new self($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $_input, $_obj, $includeDefaults, $_fromInput_1, $_toArray_1, $_toStdClass_1, $_validateInput_1, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone_1, $_construct_1, $_destruct_1, $_get_2, $_set_1, $_call_1, $_isset_1, $_unset_1, $_sleep_1, $_wakeup_1, $_toString_1, $_invoke_1, $_debugInfo_1, $_clone_2, $files, $_this);
+        $obj = new self($_GLOBALS_2, $_GLOBALS_1, $GLOBALS1, $SERVER, $GET, $POST, $FILES, $REQUEST, $SESSION, $ENV, $COOKIE, $phpErrormsg, $httpResponseHeader, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $schema, $_schema_1, $defaults, $_defaults_1, $_providedOptionals_1, $_clone, $construct, $destruct, $get, $set, $call, $isset, $unset, $sleep, $wakeup, $toString, $invoke, $debugInfo, $clone, $files, $_this);
         $obj->validate = $_validate;
         $obj->materializeDefaults = $_materializeDefaults;
         $obj->testObj = $testObj;
-        $obj->_providedOptionals_2 = $_providedOptionals_2;
+        $obj->providedOptionals = $providedOptionals;
         $obj->ensureArgs1 = $ensureArgs1;
         $obj->ensureArgs2 = $ensureArgs2;
         $obj->ensureArgs3 = $ensureArgs3;
@@ -2246,21 +2246,21 @@ class MyClass
     public function toArray(bool $includeDefaults = false)
     {
         $output = [];
-        $output['_GLOBALS'] = $this->_GLOBALS_1;
-        $output['GLOBALS'] = $this->_GLOBALS_2;
-        $output['GLOBALS_1'] = $this->_GLOBALS1_1;
-        $output['_SERVER'] = $this->_SERVER_1;
-        $output['_GET'] = $this->_GET_1;
-        $output['_POST'] = $this->_POST_1;
-        $output['_FILES'] = $this->_FILES_1;
-        $output['_REQUEST'] = $this->_REQUEST_1;
-        $output['_SESSION'] = $this->_SESSION_1;
-        $output['_ENV'] = $this->_ENV_1;
-        $output['_COOKIE'] = $this->_COOKIE_1;
-        $output['php_errormsg'] = $this->_phpErrormsg;
-        $output['http_response_header'] = $this->_httpResponseHeader;
-        $output['argc'] = $this->_argc;
-        $output['argv'] = $this->_argv;
+        $output['_GLOBALS'] = $this->_GLOBALS;
+        $output['GLOBALS'] = $this->GLOBALS;
+        $output['GLOBALS_1'] = $this->GLOBALS1;
+        $output['_SERVER'] = $this->SERVER;
+        $output['_GET'] = $this->GET;
+        $output['_POST'] = $this->POST;
+        $output['_FILES'] = $this->FILES;
+        $output['_REQUEST'] = $this->REQUEST;
+        $output['_SESSION'] = $this->SESSION;
+        $output['_ENV'] = $this->ENV;
+        $output['_COOKIE'] = $this->COOKIE;
+        $output['php_errormsg'] = $this->phpErrormsg;
+        $output['http_response_header'] = $this->httpResponseHeader;
+        $output['argc'] = $this->argc;
+        $output['argv'] = $this->argv;
         $output['input'] = $this->input;
         if (isset($this->validate)) {
             $output['validate'] = $this->validate;
@@ -2273,32 +2273,32 @@ class MyClass
         if (isset($this->testObj)) {
             $output['testObj'] = ($this->testObj)->toArray($includeDefaults);
         }
-        $output['fromInput'] = $this->_fromInput_1;
-        $output['toArray'] = $this->_toArray_1;
-        $output['toStdClass'] = $this->_toStdClass_1;
-        $output['validateInput'] = $this->_validateInput_1;
-        $output['_schema'] = $this->_schema_1;
-        $output['schema'] = $this->_schema_2;
-        $output['_defaults'] = $this->_defaults_1;
-        $output['defaults'] = $this->_defaults_2;
+        $output['fromInput'] = $this->fromInput;
+        $output['toArray'] = $this->toArray;
+        $output['toStdClass'] = $this->toStdClass;
+        $output['validateInput'] = $this->validateInput;
+        $output['_schema'] = $this->schema;
+        $output['schema'] = $this->_schema_1;
+        $output['_defaults'] = $this->defaults;
+        $output['defaults'] = $this->_defaults_1;
         $output['_providedOptionals'] = $this->_providedOptionals_1;
-        if (isset($this->_providedOptionals_2)) {
-            $output['__providedOptionals'] = $this->_providedOptionals_2;
+        if (isset($this->providedOptionals)) {
+            $output['__providedOptionals'] = $this->providedOptionals;
         }
-        $output['clone'] = $this->_clone_1;
-        $output['__construct'] = $this->_construct_1;
-        $output['__destruct'] = $this->_destruct_1;
-        $output['__get'] = $this->_get_2;
-        $output['__set'] = $this->_set_1;
-        $output['__call'] = $this->_call_1;
-        $output['__isset'] = $this->_isset_1;
-        $output['__unset'] = $this->_unset_1;
-        $output['__sleep'] = $this->_sleep_1;
-        $output['__wakeup'] = $this->_wakeup_1;
-        $output['__toString'] = $this->_toString_1;
-        $output['__invoke'] = $this->_invoke_1;
-        $output['__debugInfo'] = $this->_debugInfo_1;
-        $output['__clone'] = $this->_clone_2;
+        $output['clone'] = $this->_clone;
+        $output['__construct'] = $this->construct;
+        $output['__destruct'] = $this->destruct;
+        $output['__get'] = $this->get;
+        $output['__set'] = $this->set;
+        $output['__call'] = $this->call;
+        $output['__isset'] = $this->isset;
+        $output['__unset'] = $this->unset;
+        $output['__sleep'] = $this->sleep;
+        $output['__wakeup'] = $this->wakeup;
+        $output['__toString'] = $this->toString;
+        $output['__invoke'] = $this->invoke;
+        $output['__debugInfo'] = $this->debugInfo;
+        $output['__clone'] = $this->clone;
         $output['files'] = $this->files;
         $output['this'] = $this->_this;
         if (isset($this->ensureArgs1)) {
@@ -2335,21 +2335,21 @@ class MyClass
     public function toStdClass(bool $includeDefaults = false)
     {
         $output = new \stdClass();
-        $output->{'_GLOBALS'} = $this->_GLOBALS_1;
-        $output->{'GLOBALS'} = $this->_GLOBALS_2;
-        $output->{'GLOBALS_1'} = $this->_GLOBALS1_1;
-        $output->{'_SERVER'} = $this->_SERVER_1;
-        $output->{'_GET'} = $this->_GET_1;
-        $output->{'_POST'} = $this->_POST_1;
-        $output->{'_FILES'} = $this->_FILES_1;
-        $output->{'_REQUEST'} = $this->_REQUEST_1;
-        $output->{'_SESSION'} = $this->_SESSION_1;
-        $output->{'_ENV'} = $this->_ENV_1;
-        $output->{'_COOKIE'} = $this->_COOKIE_1;
-        $output->{'php_errormsg'} = $this->_phpErrormsg;
-        $output->{'http_response_header'} = $this->_httpResponseHeader;
-        $output->{'argc'} = $this->_argc;
-        $output->{'argv'} = $this->_argv;
+        $output->{'_GLOBALS'} = $this->_GLOBALS;
+        $output->{'GLOBALS'} = $this->GLOBALS;
+        $output->{'GLOBALS_1'} = $this->GLOBALS1;
+        $output->{'_SERVER'} = $this->SERVER;
+        $output->{'_GET'} = $this->GET;
+        $output->{'_POST'} = $this->POST;
+        $output->{'_FILES'} = $this->FILES;
+        $output->{'_REQUEST'} = $this->REQUEST;
+        $output->{'_SESSION'} = $this->SESSION;
+        $output->{'_ENV'} = $this->ENV;
+        $output->{'_COOKIE'} = $this->COOKIE;
+        $output->{'php_errormsg'} = $this->phpErrormsg;
+        $output->{'http_response_header'} = $this->httpResponseHeader;
+        $output->{'argc'} = $this->argc;
+        $output->{'argv'} = $this->argv;
         $output->{'input'} = $this->input;
         if (isset($this->validate)) {
             $output->{'validate'} = $this->validate;
@@ -2362,32 +2362,32 @@ class MyClass
         if (isset($this->testObj)) {
             $output->{'testObj'} = ($this->testObj)->toStdClass($includeDefaults);
         }
-        $output->{'fromInput'} = $this->_fromInput_1;
-        $output->{'toArray'} = $this->_toArray_1;
-        $output->{'toStdClass'} = $this->_toStdClass_1;
-        $output->{'validateInput'} = $this->_validateInput_1;
-        $output->{'_schema'} = $this->_schema_1;
-        $output->{'schema'} = $this->_schema_2;
-        $output->{'_defaults'} = $this->_defaults_1;
-        $output->{'defaults'} = $this->_defaults_2;
+        $output->{'fromInput'} = $this->fromInput;
+        $output->{'toArray'} = $this->toArray;
+        $output->{'toStdClass'} = $this->toStdClass;
+        $output->{'validateInput'} = $this->validateInput;
+        $output->{'_schema'} = $this->schema;
+        $output->{'schema'} = $this->_schema_1;
+        $output->{'_defaults'} = $this->defaults;
+        $output->{'defaults'} = $this->_defaults_1;
         $output->{'_providedOptionals'} = $this->_providedOptionals_1;
-        if (isset($this->_providedOptionals_2)) {
-            $output->{'__providedOptionals'} = $this->_providedOptionals_2;
+        if (isset($this->providedOptionals)) {
+            $output->{'__providedOptionals'} = $this->providedOptionals;
         }
-        $output->{'clone'} = $this->_clone_1;
-        $output->{'__construct'} = $this->_construct_1;
-        $output->{'__destruct'} = $this->_destruct_1;
-        $output->{'__get'} = $this->_get_2;
-        $output->{'__set'} = $this->_set_1;
-        $output->{'__call'} = $this->_call_1;
-        $output->{'__isset'} = $this->_isset_1;
-        $output->{'__unset'} = $this->_unset_1;
-        $output->{'__sleep'} = $this->_sleep_1;
-        $output->{'__wakeup'} = $this->_wakeup_1;
-        $output->{'__toString'} = $this->_toString_1;
-        $output->{'__invoke'} = $this->_invoke_1;
-        $output->{'__debugInfo'} = $this->_debugInfo_1;
-        $output->{'__clone'} = $this->_clone_2;
+        $output->{'clone'} = $this->_clone;
+        $output->{'__construct'} = $this->construct;
+        $output->{'__destruct'} = $this->destruct;
+        $output->{'__get'} = $this->get;
+        $output->{'__set'} = $this->set;
+        $output->{'__call'} = $this->call;
+        $output->{'__isset'} = $this->isset;
+        $output->{'__unset'} = $this->unset;
+        $output->{'__sleep'} = $this->sleep;
+        $output->{'__wakeup'} = $this->wakeup;
+        $output->{'__toString'} = $this->toString;
+        $output->{'__invoke'} = $this->invoke;
+        $output->{'__debugInfo'} = $this->debugInfo;
+        $output->{'__clone'} = $this->clone;
         $output->{'files'} = $this->files;
         $output->{'this'} = $this->_this;
         if (isset($this->ensureArgs1)) {

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -296,77 +296,77 @@ class MyClass
     /**
      * @var string
      */
-    private string $_GLOBALS_1;
+    private string $_GLOBALS;
 
     /**
      * @var string
      */
-    private string $_GLOBALS_2;
+    private string $GLOBALS;
 
     /**
      * @var string
      */
-    private string $_GLOBALS1_1;
+    private string $GLOBALS1;
 
     /**
      * @var string
      */
-    private string $_SERVER_1;
+    private string $SERVER;
 
     /**
      * @var string
      */
-    private string $_GET_1;
+    private string $GET;
 
     /**
      * @var string
      */
-    private string $_POST_1;
+    private string $POST;
 
     /**
      * @var string
      */
-    private string $_FILES_1;
+    private string $FILES;
 
     /**
      * @var string
      */
-    private string $_REQUEST_1;
+    private string $REQUEST;
 
     /**
      * @var string
      */
-    private string $_SESSION_1;
+    private string $SESSION;
 
     /**
      * @var string
      */
-    private string $_ENV_1;
+    private string $ENV;
 
     /**
      * @var string
      */
-    private string $_COOKIE_1;
+    private string $COOKIE;
 
     /**
      * @var string
      */
-    private string $_phpErrormsg;
+    private string $phpErrormsg;
 
     /**
      * @var string
      */
-    private string $_httpResponseHeader;
+    private string $httpResponseHeader;
 
     /**
      * @var string
      */
-    private string $_argc;
+    private string $argc;
 
     /**
      * @var string
      */
-    private string $_argv;
+    private string $argv;
 
     /**
      * @var string
@@ -401,22 +401,27 @@ class MyClass
     /**
      * @var string
      */
-    private string $_fromInput_1;
+    private string $fromInput;
 
     /**
      * @var string
      */
-    private string $_toArray_1;
+    private string $toArray;
 
     /**
      * @var string
      */
-    private string $_toStdClass_1;
+    private string $toStdClass;
 
     /**
      * @var string
      */
-    private string $_validateInput_1;
+    private string $validateInput;
+
+    /**
+     * @var string
+     */
+    private string $schema;
 
     /**
      * @var string
@@ -426,7 +431,7 @@ class MyClass
     /**
      * @var string
      */
-    private string $_schema_2;
+    private string $defaults;
 
     /**
      * @var string
@@ -436,87 +441,82 @@ class MyClass
     /**
      * @var string
      */
-    private string $_defaults_2;
-
-    /**
-     * @var string
-     */
     private string $_providedOptionals_1;
 
     /**
      * @var string|null
      */
-    private ?string $_providedOptionals_2 = null;
+    private ?string $providedOptionals = null;
 
     /**
      * @var string
      */
-    private string $_clone_1;
+    private string $_clone;
 
     /**
      * @var string
      */
-    private string $_construct_1;
+    private string $construct;
 
     /**
      * @var string
      */
-    private string $_destruct_1;
+    private string $destruct;
 
     /**
      * @var string
      */
-    private string $_get_2;
+    private string $get;
 
     /**
      * @var string
      */
-    private string $_set_1;
+    private string $set;
 
     /**
      * @var string
      */
-    private string $_call_1;
+    private string $call;
 
     /**
      * @var string
      */
-    private string $_isset_1;
+    private string $isset;
 
     /**
      * @var string
      */
-    private string $_unset_1;
+    private string $unset;
 
     /**
      * @var string
      */
-    private string $_sleep_1;
+    private string $sleep;
 
     /**
      * @var string
      */
-    private string $_wakeup_1;
+    private string $wakeup;
 
     /**
      * @var string
      */
-    private string $_toString_1;
+    private string $toString;
 
     /**
      * @var string
      */
-    private string $_invoke_1;
+    private string $invoke;
 
     /**
      * @var string
      */
-    private string $_debugInfo_1;
+    private string $debugInfo;
 
     /**
      * @var string
      */
-    private string $_clone_2;
+    private string $clone;
 
     /**
      * @var string
@@ -544,93 +544,93 @@ class MyClass
     private ?array $ensureArgs3 = null;
 
     /**
-     * @param string $_GLOBALS_1
      * @param string $_GLOBALS_2
-     * @param string $_GLOBALS1_1
-     * @param string $_SERVER_1
-     * @param string $_GET_1
-     * @param string $_POST_1
-     * @param string $_FILES_1
-     * @param string $_REQUEST_1
-     * @param string $_SESSION_1
-     * @param string $_ENV_1
-     * @param string $_COOKIE_1
-     * @param string $_phpErrormsg
-     * @param string $_httpResponseHeader
+     * @param string $_GLOBALS_1
+     * @param string $GLOBALS1
+     * @param string $SERVER
+     * @param string $GET
+     * @param string $POST
+     * @param string $FILES
+     * @param string $REQUEST
+     * @param string $SESSION
+     * @param string $ENV
+     * @param string $COOKIE
+     * @param string $phpErrormsg
+     * @param string $httpResponseHeader
      * @param string $_argc
      * @param string $_argv
-     * @param string $input
-     * @param string $obj
+     * @param string $_input
+     * @param string $_obj
      * @param string $includeDefaults
-     * @param string $_fromInput_1
-     * @param string $_toArray_1
-     * @param string $_toStdClass_1
-     * @param string $_validateInput_1
+     * @param string $fromInput
+     * @param string $toArray
+     * @param string $toStdClass
+     * @param string $validateInput
+     * @param string $schema
      * @param string $_schema_1
-     * @param string $_schema_2
+     * @param string $defaults
      * @param string $_defaults_1
-     * @param string $_defaults_2
      * @param string $_providedOptionals_1
-     * @param string $_clone_1
-     * @param string $_construct_1
-     * @param string $_destruct_1
-     * @param string $_get_2
-     * @param string $_set_1
-     * @param string $_call_1
-     * @param string $_isset_1
-     * @param string $_unset_1
-     * @param string $_sleep_1
-     * @param string $_wakeup_1
-     * @param string $_toString_1
-     * @param string $_invoke_1
-     * @param string $_debugInfo_1
-     * @param string $_clone_2
+     * @param string $_clone
+     * @param string $construct
+     * @param string $destruct
+     * @param string $get
+     * @param string $set
+     * @param string $call
+     * @param string $isset
+     * @param string $unset
+     * @param string $sleep
+     * @param string $wakeup
+     * @param string $toString
+     * @param string $invoke
+     * @param string $debugInfo
+     * @param string $clone
      * @param string $files
      * @param string $_this
      */
-    public function __construct(string $_GLOBALS_1, string $_GLOBALS_2, string $_GLOBALS1_1, string $_SERVER_1, string $_GET_1, string $_POST_1, string $_FILES_1, string $_REQUEST_1, string $_SESSION_1, string $_ENV_1, string $_COOKIE_1, string $_phpErrormsg, string $_httpResponseHeader, string $_argc, string $_argv, string $input, string $obj, string $includeDefaults, string $_fromInput_1, string $_toArray_1, string $_toStdClass_1, string $_validateInput_1, string $_schema_1, string $_schema_2, string $_defaults_1, string $_defaults_2, string $_providedOptionals_1, string $_clone_1, string $_construct_1, string $_destruct_1, string $_get_2, string $_set_1, string $_call_1, string $_isset_1, string $_unset_1, string $_sleep_1, string $_wakeup_1, string $_toString_1, string $_invoke_1, string $_debugInfo_1, string $_clone_2, string $files, string $_this)
+    public function __construct(string $_GLOBALS_2, string $_GLOBALS_1, string $GLOBALS1, string $SERVER, string $GET, string $POST, string $FILES, string $REQUEST, string $SESSION, string $ENV, string $COOKIE, string $phpErrormsg, string $httpResponseHeader, string $_argc, string $_argv, string $_input, string $_obj, string $includeDefaults, string $fromInput, string $toArray, string $toStdClass, string $validateInput, string $schema, string $_schema_1, string $defaults, string $_defaults_1, string $_providedOptionals_1, string $_clone, string $construct, string $destruct, string $get, string $set, string $call, string $isset, string $unset, string $sleep, string $wakeup, string $toString, string $invoke, string $debugInfo, string $clone, string $files, string $_this)
     {
-        $this->_GLOBALS_1 = $_GLOBALS_1;
-        $this->_GLOBALS_2 = $_GLOBALS_2;
-        $this->_GLOBALS1_1 = $_GLOBALS1_1;
-        $this->_SERVER_1 = $_SERVER_1;
-        $this->_GET_1 = $_GET_1;
-        $this->_POST_1 = $_POST_1;
-        $this->_FILES_1 = $_FILES_1;
-        $this->_REQUEST_1 = $_REQUEST_1;
-        $this->_SESSION_1 = $_SESSION_1;
-        $this->_ENV_1 = $_ENV_1;
-        $this->_COOKIE_1 = $_COOKIE_1;
-        $this->_phpErrormsg = $_phpErrormsg;
-        $this->_httpResponseHeader = $_httpResponseHeader;
-        $this->_argc = $_argc;
-        $this->_argv = $_argv;
-        $this->input = $input;
-        $this->obj = $obj;
+        $this->_GLOBALS = $_GLOBALS_2;
+        $this->GLOBALS = $_GLOBALS_1;
+        $this->GLOBALS1 = $GLOBALS1;
+        $this->SERVER = $SERVER;
+        $this->GET = $GET;
+        $this->POST = $POST;
+        $this->FILES = $FILES;
+        $this->REQUEST = $REQUEST;
+        $this->SESSION = $SESSION;
+        $this->ENV = $ENV;
+        $this->COOKIE = $COOKIE;
+        $this->phpErrormsg = $phpErrormsg;
+        $this->httpResponseHeader = $httpResponseHeader;
+        $this->argc = $_argc;
+        $this->argv = $_argv;
+        $this->input = $_input;
+        $this->obj = $_obj;
         $this->includeDefaults = $includeDefaults;
-        $this->_fromInput_1 = $_fromInput_1;
-        $this->_toArray_1 = $_toArray_1;
-        $this->_toStdClass_1 = $_toStdClass_1;
-        $this->_validateInput_1 = $_validateInput_1;
+        $this->fromInput = $fromInput;
+        $this->toArray = $toArray;
+        $this->toStdClass = $toStdClass;
+        $this->validateInput = $validateInput;
+        $this->schema = $schema;
         $this->_schema_1 = $_schema_1;
-        $this->_schema_2 = $_schema_2;
+        $this->defaults = $defaults;
         $this->_defaults_1 = $_defaults_1;
-        $this->_defaults_2 = $_defaults_2;
         $this->_providedOptionals_1 = $_providedOptionals_1;
-        $this->_clone_1 = $_clone_1;
-        $this->_construct_1 = $_construct_1;
-        $this->_destruct_1 = $_destruct_1;
-        $this->_get_2 = $_get_2;
-        $this->_set_1 = $_set_1;
-        $this->_call_1 = $_call_1;
-        $this->_isset_1 = $_isset_1;
-        $this->_unset_1 = $_unset_1;
-        $this->_sleep_1 = $_sleep_1;
-        $this->_wakeup_1 = $_wakeup_1;
-        $this->_toString_1 = $_toString_1;
-        $this->_invoke_1 = $_invoke_1;
-        $this->_debugInfo_1 = $_debugInfo_1;
-        $this->_clone_2 = $_clone_2;
+        $this->_clone = $_clone;
+        $this->construct = $construct;
+        $this->destruct = $destruct;
+        $this->get = $get;
+        $this->set = $set;
+        $this->call = $call;
+        $this->isset = $isset;
+        $this->unset = $unset;
+        $this->sleep = $sleep;
+        $this->wakeup = $wakeup;
+        $this->toString = $toString;
+        $this->invoke = $invoke;
+        $this->debugInfo = $debugInfo;
+        $this->clone = $clone;
         $this->files = $files;
         $this->_this = $_this;
     }
@@ -638,38 +638,9 @@ class MyClass
     /**
      * @return string
      */
-    public function getGLOBALS1(): string
+    public function get_GLOBALS(): string
     {
-        return $this->_GLOBALS_1;
-    }
-
-    /**
-     * @param string $_GLOBALS_1
-     * @return self
-     * @param bool $validate
-     */
-    public function withGLOBALS1(string $_GLOBALS_1, bool $validate = true): self
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_1, self::$_schema['properties']['_GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->_GLOBALS_1 = $_GLOBALS_1;
-
-        return $clone;
-    }
-
-    /**
-     * @return string
-     */
-    public function getGLOBALS2(): string
-    {
-        return $this->_GLOBALS_2;
+        return $this->_GLOBALS;
     }
 
     /**
@@ -677,18 +648,18 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function withGLOBALS2(string $_GLOBALS_2, bool $validate = true): self
+    public function with_GLOBALS(string $_GLOBALS_2, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_2, self::$_schema['properties']['GLOBALS']);
+            $validator->validate($_GLOBALS_2, self::$_schema['properties']['_GLOBALS']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_GLOBALS_2 = $_GLOBALS_2;
+        $clone->_GLOBALS = $_GLOBALS_2;
 
         return $clone;
     }
@@ -696,28 +667,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getGLOBALS11(): string
+    public function getGLOBALS(): string
     {
-        return $this->_GLOBALS1_1;
+        return $this->GLOBALS;
     }
 
     /**
-     * @param string $_GLOBALS1_1
+     * @param string $_GLOBALS_1
      * @return self
      * @param bool $validate
      */
-    public function withGLOBALS11(string $_GLOBALS1_1, bool $validate = true): self
+    public function withGLOBALS(string $_GLOBALS_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS1_1, self::$_schema['properties']['GLOBALS_1']);
+            $validator->validate($_GLOBALS_1, self::$_schema['properties']['GLOBALS']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_GLOBALS1_1 = $_GLOBALS1_1;
+        $clone->GLOBALS = $_GLOBALS_1;
 
         return $clone;
     }
@@ -725,28 +696,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSERVER1(): string
+    public function getGLOBALS1(): string
     {
-        return $this->_SERVER_1;
+        return $this->GLOBALS1;
     }
 
     /**
-     * @param string $_SERVER_1
+     * @param string $GLOBALS1
      * @return self
      * @param bool $validate
      */
-    public function withSERVER1(string $_SERVER_1, bool $validate = true): self
+    public function withGLOBALS1(string $GLOBALS1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_SERVER_1, self::$_schema['properties']['_SERVER']);
+            $validator->validate($GLOBALS1, self::$_schema['properties']['GLOBALS_1']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_SERVER_1 = $_SERVER_1;
+        $clone->GLOBALS1 = $GLOBALS1;
 
         return $clone;
     }
@@ -754,28 +725,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getGET1(): string
+    public function getSERVER(): string
     {
-        return $this->_GET_1;
+        return $this->SERVER;
     }
 
     /**
-     * @param string $_GET_1
+     * @param string $SERVER
      * @return self
      * @param bool $validate
      */
-    public function withGET1(string $_GET_1, bool $validate = true): self
+    public function withSERVER(string $SERVER, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_GET_1, self::$_schema['properties']['_GET']);
+            $validator->validate($SERVER, self::$_schema['properties']['_SERVER']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_GET_1 = $_GET_1;
+        $clone->SERVER = $SERVER;
 
         return $clone;
     }
@@ -783,28 +754,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getPOST1(): string
+    public function getGET(): string
     {
-        return $this->_POST_1;
+        return $this->GET;
     }
 
     /**
-     * @param string $_POST_1
+     * @param string $GET
      * @return self
      * @param bool $validate
      */
-    public function withPOST1(string $_POST_1, bool $validate = true): self
+    public function withGET(string $GET, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_POST_1, self::$_schema['properties']['_POST']);
+            $validator->validate($GET, self::$_schema['properties']['_GET']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_POST_1 = $_POST_1;
+        $clone->GET = $GET;
 
         return $clone;
     }
@@ -812,28 +783,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getFILES1(): string
+    public function getPOST(): string
     {
-        return $this->_FILES_1;
+        return $this->POST;
     }
 
     /**
-     * @param string $_FILES_1
+     * @param string $POST
      * @return self
      * @param bool $validate
      */
-    public function withFILES1(string $_FILES_1, bool $validate = true): self
+    public function withPOST(string $POST, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_FILES_1, self::$_schema['properties']['_FILES']);
+            $validator->validate($POST, self::$_schema['properties']['_POST']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_FILES_1 = $_FILES_1;
+        $clone->POST = $POST;
 
         return $clone;
     }
@@ -841,28 +812,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getREQUEST1(): string
+    public function getFILES(): string
     {
-        return $this->_REQUEST_1;
+        return $this->FILES;
     }
 
     /**
-     * @param string $_REQUEST_1
+     * @param string $FILES
      * @return self
      * @param bool $validate
      */
-    public function withREQUEST1(string $_REQUEST_1, bool $validate = true): self
+    public function withFILES(string $FILES, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_REQUEST_1, self::$_schema['properties']['_REQUEST']);
+            $validator->validate($FILES, self::$_schema['properties']['_FILES']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_REQUEST_1 = $_REQUEST_1;
+        $clone->FILES = $FILES;
 
         return $clone;
     }
@@ -870,28 +841,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSESSION1(): string
+    public function getREQUEST(): string
     {
-        return $this->_SESSION_1;
+        return $this->REQUEST;
     }
 
     /**
-     * @param string $_SESSION_1
+     * @param string $REQUEST
      * @return self
      * @param bool $validate
      */
-    public function withSESSION1(string $_SESSION_1, bool $validate = true): self
+    public function withREQUEST(string $REQUEST, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_SESSION_1, self::$_schema['properties']['_SESSION']);
+            $validator->validate($REQUEST, self::$_schema['properties']['_REQUEST']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_SESSION_1 = $_SESSION_1;
+        $clone->REQUEST = $REQUEST;
 
         return $clone;
     }
@@ -899,28 +870,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getENV1(): string
+    public function getSESSION(): string
     {
-        return $this->_ENV_1;
+        return $this->SESSION;
     }
 
     /**
-     * @param string $_ENV_1
+     * @param string $SESSION
      * @return self
      * @param bool $validate
      */
-    public function withENV1(string $_ENV_1, bool $validate = true): self
+    public function withSESSION(string $SESSION, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_ENV_1, self::$_schema['properties']['_ENV']);
+            $validator->validate($SESSION, self::$_schema['properties']['_SESSION']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_ENV_1 = $_ENV_1;
+        $clone->SESSION = $SESSION;
 
         return $clone;
     }
@@ -928,28 +899,57 @@ class MyClass
     /**
      * @return string
      */
-    public function getCOOKIE1(): string
+    public function getENV(): string
     {
-        return $this->_COOKIE_1;
+        return $this->ENV;
     }
 
     /**
-     * @param string $_COOKIE_1
+     * @param string $ENV
      * @return self
      * @param bool $validate
      */
-    public function withCOOKIE1(string $_COOKIE_1, bool $validate = true): self
+    public function withENV(string $ENV, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_COOKIE_1, self::$_schema['properties']['_COOKIE']);
+            $validator->validate($ENV, self::$_schema['properties']['_ENV']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_COOKIE_1 = $_COOKIE_1;
+        $clone->ENV = $ENV;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCOOKIE(): string
+    {
+        return $this->COOKIE;
+    }
+
+    /**
+     * @param string $COOKIE
+     * @return self
+     * @param bool $validate
+     */
+    public function withCOOKIE(string $COOKIE, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($COOKIE, self::$_schema['properties']['_COOKIE']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->COOKIE = $COOKIE;
 
         return $clone;
     }
@@ -959,26 +959,26 @@ class MyClass
      */
     public function getPhpErrormsg(): string
     {
-        return $this->_phpErrormsg;
+        return $this->phpErrormsg;
     }
 
     /**
-     * @param string $_phpErrormsg
+     * @param string $phpErrormsg
      * @return self
      * @param bool $validate
      */
-    public function withPhpErrormsg(string $_phpErrormsg, bool $validate = true): self
+    public function withPhpErrormsg(string $phpErrormsg, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_phpErrormsg, self::$_schema['properties']['php_errormsg']);
+            $validator->validate($phpErrormsg, self::$_schema['properties']['php_errormsg']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_phpErrormsg = $_phpErrormsg;
+        $clone->phpErrormsg = $phpErrormsg;
 
         return $clone;
     }
@@ -988,26 +988,26 @@ class MyClass
      */
     public function getHttpResponseHeader(): string
     {
-        return $this->_httpResponseHeader;
+        return $this->httpResponseHeader;
     }
 
     /**
-     * @param string $_httpResponseHeader
+     * @param string $httpResponseHeader
      * @return self
      * @param bool $validate
      */
-    public function withHttpResponseHeader(string $_httpResponseHeader, bool $validate = true): self
+    public function withHttpResponseHeader(string $httpResponseHeader, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_httpResponseHeader, self::$_schema['properties']['http_response_header']);
+            $validator->validate($httpResponseHeader, self::$_schema['properties']['http_response_header']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_httpResponseHeader = $_httpResponseHeader;
+        $clone->httpResponseHeader = $httpResponseHeader;
 
         return $clone;
     }
@@ -1017,7 +1017,7 @@ class MyClass
      */
     public function getArgc(): string
     {
-        return $this->_argc;
+        return $this->argc;
     }
 
     /**
@@ -1036,7 +1036,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_argc = $_argc;
+        $clone->argc = $_argc;
 
         return $clone;
     }
@@ -1046,7 +1046,7 @@ class MyClass
      */
     public function getArgv(): string
     {
-        return $this->_argv;
+        return $this->argv;
     }
 
     /**
@@ -1065,7 +1065,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_argv = $_argv;
+        $clone->argv = $_argv;
 
         return $clone;
     }
@@ -1079,22 +1079,22 @@ class MyClass
     }
 
     /**
-     * @param string $input
+     * @param string $_input
      * @return self
      * @param bool $validate
      */
-    public function withInput(string $input, bool $validate = true): self
+    public function withInput(string $_input, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($input, self::$_schema['properties']['input']);
+            $validator->validate($_input, self::$_schema['properties']['input']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->input = $input;
+        $clone->input = $_input;
 
         return $clone;
     }
@@ -1108,22 +1108,22 @@ class MyClass
     }
 
     /**
-     * @param string $validate
+     * @param string $_validate
      * @return self
      * @param bool $validate
      */
-    public function withValidate(bool $validate = true): self
+    public function withValidate(string $_validate, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($validate, self::$_schema['properties']['validate']);
+            $validator->validate($_validate, self::$_schema['properties']['validate']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->validate = $validate;
+        $clone->validate = $_validate;
 
         return $clone;
     }
@@ -1148,22 +1148,22 @@ class MyClass
     }
 
     /**
-     * @param string $materializeDefaults
+     * @param string $_materializeDefaults
      * @return self
      * @param bool $validate
      */
-    public function withMaterializeDefaults(string $materializeDefaults, bool $validate = true): self
+    public function withMaterializeDefaults(string $_materializeDefaults, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($materializeDefaults, self::$_schema['properties']['materializeDefaults']);
+            $validator->validate($_materializeDefaults, self::$_schema['properties']['materializeDefaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->materializeDefaults = $materializeDefaults;
+        $clone->materializeDefaults = $_materializeDefaults;
         $clone->_providedOptionals['materializeDefaults'] = true;
 
         return $clone;
@@ -1190,22 +1190,22 @@ class MyClass
     }
 
     /**
-     * @param string $obj
+     * @param string $_obj
      * @return self
      * @param bool $validate
      */
-    public function withObj(string $obj, bool $validate = true): self
+    public function withObj(string $_obj, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($obj, self::$_schema['properties']['obj']);
+            $validator->validate($_obj, self::$_schema['properties']['obj']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->obj = $obj;
+        $clone->obj = $_obj;
 
         return $clone;
     }
@@ -1273,28 +1273,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getFromInput1(): string
+    public function getFromInput(): string
     {
-        return $this->_fromInput_1;
+        return $this->fromInput;
     }
 
     /**
-     * @param string $_fromInput_1
+     * @param string $fromInput
      * @return self
      * @param bool $validate
      */
-    public function withFromInput1(string $_fromInput_1, bool $validate = true): self
+    public function withFromInput(string $fromInput, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_fromInput_1, self::$_schema['properties']['fromInput']);
+            $validator->validate($fromInput, self::$_schema['properties']['fromInput']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_fromInput_1 = $_fromInput_1;
+        $clone->fromInput = $fromInput;
 
         return $clone;
     }
@@ -1302,28 +1302,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getToArray1(): string
+    public function getToArray(): string
     {
-        return $this->_toArray_1;
+        return $this->toArray;
     }
 
     /**
-     * @param string $_toArray_1
+     * @param string $toArray
      * @return self
      * @param bool $validate
      */
-    public function withToArray1(string $_toArray_1, bool $validate = true): self
+    public function withToArray(string $toArray, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toArray_1, self::$_schema['properties']['toArray']);
+            $validator->validate($toArray, self::$_schema['properties']['toArray']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toArray_1 = $_toArray_1;
+        $clone->toArray = $toArray;
 
         return $clone;
     }
@@ -1331,28 +1331,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getToStdClass1(): string
+    public function getToStdClass(): string
     {
-        return $this->_toStdClass_1;
+        return $this->toStdClass;
     }
 
     /**
-     * @param string $_toStdClass_1
+     * @param string $toStdClass
      * @return self
      * @param bool $validate
      */
-    public function withToStdClass1(string $_toStdClass_1, bool $validate = true): self
+    public function withToStdClass(string $toStdClass, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toStdClass_1, self::$_schema['properties']['toStdClass']);
+            $validator->validate($toStdClass, self::$_schema['properties']['toStdClass']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toStdClass_1 = $_toStdClass_1;
+        $clone->toStdClass = $toStdClass;
 
         return $clone;
     }
@@ -1360,28 +1360,57 @@ class MyClass
     /**
      * @return string
      */
-    public function getValidateInput1(): string
+    public function getValidateInput(): string
     {
-        return $this->_validateInput_1;
+        return $this->validateInput;
     }
 
     /**
-     * @param string $_validateInput_1
+     * @param string $validateInput
      * @return self
      * @param bool $validate
      */
-    public function withValidateInput1(string $_validateInput_1, bool $validate = true): self
+    public function withValidateInput(string $validateInput, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_validateInput_1, self::$_schema['properties']['validateInput']);
+            $validator->validate($validateInput, self::$_schema['properties']['validateInput']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_validateInput_1 = $_validateInput_1;
+        $clone->validateInput = $validateInput;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSchema(): string
+    {
+        return $this->schema;
+    }
+
+    /**
+     * @param string $schema
+     * @return self
+     * @param bool $validate
+     */
+    public function withSchema(string $schema, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($schema, self::$_schema['properties']['_schema']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->schema = $schema;
 
         return $clone;
     }
@@ -1403,7 +1432,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_1, self::$_schema['properties']['_schema']);
+            $validator->validate($_schema_1, self::$_schema['properties']['schema']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -1418,28 +1447,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSchema2(): string
+    public function getDefaults(): string
     {
-        return $this->_schema_2;
+        return $this->defaults;
     }
 
     /**
-     * @param string $_schema_2
+     * @param string $defaults
      * @return self
      * @param bool $validate
      */
-    public function withSchema2(string $_schema_2, bool $validate = true): self
+    public function withDefaults(string $defaults, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_2, self::$_schema['properties']['schema']);
+            $validator->validate($defaults, self::$_schema['properties']['_defaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_schema_2 = $_schema_2;
+        $clone->defaults = $defaults;
 
         return $clone;
     }
@@ -1461,7 +1490,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_1, self::$_schema['properties']['_defaults']);
+            $validator->validate($_defaults_1, self::$_schema['properties']['defaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -1469,35 +1498,6 @@ class MyClass
 
         $clone = clone $this;
         $clone->_defaults_1 = $_defaults_1;
-
-        return $clone;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDefaults2(): string
-    {
-        return $this->_defaults_2;
-    }
-
-    /**
-     * @param string $_defaults_2
-     * @return self
-     * @param bool $validate
-     */
-    public function withDefaults2(string $_defaults_2, bool $validate = true): self
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_2, self::$_schema['properties']['defaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->_defaults_2 = $_defaults_2;
 
         return $clone;
     }
@@ -1534,28 +1534,28 @@ class MyClass
     /**
      * @return string|null
      */
-    public function getProvidedOptionals2(): ?string
+    public function getProvidedOptionals(): ?string
     {
-        return $this->_providedOptionals_2 ?? null;
+        return $this->providedOptionals ?? null;
     }
 
     /**
-     * @param string $_providedOptionals_2
+     * @param string $providedOptionals
      * @return self
      * @param bool $validate
      */
-    public function withProvidedOptionals2(string $_providedOptionals_2, bool $validate = true): self
+    public function withProvidedOptionals(string $providedOptionals, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_providedOptionals_2, self::$_schema['properties']['__providedOptionals']);
+            $validator->validate($providedOptionals, self::$_schema['properties']['__providedOptionals']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_providedOptionals_2 = $_providedOptionals_2;
+        $clone->providedOptionals = $providedOptionals;
 
         return $clone;
     }
@@ -1563,10 +1563,10 @@ class MyClass
     /**
      * @return self
      */
-    public function withoutProvidedOptionals2(): self
+    public function withoutProvidedOptionals(): self
     {
         $clone = clone $this;
-        unset($clone->_providedOptionals_2);
+        unset($clone->providedOptionals);
 
         return $clone;
     }
@@ -1574,28 +1574,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getClone1(): string
+    public function get_Clone(): string
     {
-        return $this->_clone_1;
+        return $this->_clone;
     }
 
     /**
-     * @param string $_clone_1
+     * @param string $_clone
      * @return self
      * @param bool $validate
      */
-    public function withClone1(string $_clone_1, bool $validate = true): self
+    public function with_Clone(string $_clone, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone_1, self::$_schema['properties']['clone']);
+            $validator->validate($_clone, self::$_schema['properties']['clone']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_clone_1 = $_clone_1;
+        $clone->_clone = $_clone;
 
         return $clone;
     }
@@ -1603,28 +1603,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getConstruct1(): string
+    public function getConstruct(): string
     {
-        return $this->_construct_1;
+        return $this->construct;
     }
 
     /**
-     * @param string $_construct_1
+     * @param string $construct
      * @return self
      * @param bool $validate
      */
-    public function withConstruct1(string $_construct_1, bool $validate = true): self
+    public function withConstruct(string $construct, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_construct_1, self::$_schema['properties']['__construct']);
+            $validator->validate($construct, self::$_schema['properties']['__construct']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_construct_1 = $_construct_1;
+        $clone->construct = $construct;
 
         return $clone;
     }
@@ -1632,28 +1632,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getDestruct1(): string
+    public function getDestruct(): string
     {
-        return $this->_destruct_1;
+        return $this->destruct;
     }
 
     /**
-     * @param string $_destruct_1
+     * @param string $destruct
      * @return self
      * @param bool $validate
      */
-    public function withDestruct1(string $_destruct_1, bool $validate = true): self
+    public function withDestruct(string $destruct, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_destruct_1, self::$_schema['properties']['__destruct']);
+            $validator->validate($destruct, self::$_schema['properties']['__destruct']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_destruct_1 = $_destruct_1;
+        $clone->destruct = $destruct;
 
         return $clone;
     }
@@ -1661,28 +1661,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getGet2(): string
+    public function get_Get(): string
     {
-        return $this->_get_2;
+        return $this->get;
     }
 
     /**
-     * @param string $_get_2
+     * @param string $get
      * @return self
      * @param bool $validate
      */
-    public function withGet2(string $_get_2, bool $validate = true): self
+    public function with_Get(string $get, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_get_2, self::$_schema['properties']['__get']);
+            $validator->validate($get, self::$_schema['properties']['__get']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_get_2 = $_get_2;
+        $clone->get = $get;
 
         return $clone;
     }
@@ -1690,28 +1690,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSet1(): string
+    public function getSet(): string
     {
-        return $this->_set_1;
+        return $this->set;
     }
 
     /**
-     * @param string $_set_1
+     * @param string $set
      * @return self
      * @param bool $validate
      */
-    public function withSet1(string $_set_1, bool $validate = true): self
+    public function withSet(string $set, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_set_1, self::$_schema['properties']['__set']);
+            $validator->validate($set, self::$_schema['properties']['__set']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_set_1 = $_set_1;
+        $clone->set = $set;
 
         return $clone;
     }
@@ -1719,28 +1719,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getCall1(): string
+    public function getCall(): string
     {
-        return $this->_call_1;
+        return $this->call;
     }
 
     /**
-     * @param string $_call_1
+     * @param string $call
      * @return self
      * @param bool $validate
      */
-    public function withCall1(string $_call_1, bool $validate = true): self
+    public function withCall(string $call, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_call_1, self::$_schema['properties']['__call']);
+            $validator->validate($call, self::$_schema['properties']['__call']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_call_1 = $_call_1;
+        $clone->call = $call;
 
         return $clone;
     }
@@ -1748,28 +1748,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getIsset1(): string
+    public function getIsset(): string
     {
-        return $this->_isset_1;
+        return $this->isset;
     }
 
     /**
-     * @param string $_isset_1
+     * @param string $isset
      * @return self
      * @param bool $validate
      */
-    public function withIsset1(string $_isset_1, bool $validate = true): self
+    public function withIsset(string $isset, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_isset_1, self::$_schema['properties']['__isset']);
+            $validator->validate($isset, self::$_schema['properties']['__isset']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_isset_1 = $_isset_1;
+        $clone->isset = $isset;
 
         return $clone;
     }
@@ -1777,28 +1777,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getUnset1(): string
+    public function getUnset(): string
     {
-        return $this->_unset_1;
+        return $this->unset;
     }
 
     /**
-     * @param string $_unset_1
+     * @param string $unset
      * @return self
      * @param bool $validate
      */
-    public function withUnset1(string $_unset_1, bool $validate = true): self
+    public function withUnset(string $unset, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_unset_1, self::$_schema['properties']['__unset']);
+            $validator->validate($unset, self::$_schema['properties']['__unset']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_unset_1 = $_unset_1;
+        $clone->unset = $unset;
 
         return $clone;
     }
@@ -1806,28 +1806,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSleep1(): string
+    public function getSleep(): string
     {
-        return $this->_sleep_1;
+        return $this->sleep;
     }
 
     /**
-     * @param string $_sleep_1
+     * @param string $sleep
      * @return self
      * @param bool $validate
      */
-    public function withSleep1(string $_sleep_1, bool $validate = true): self
+    public function withSleep(string $sleep, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_sleep_1, self::$_schema['properties']['__sleep']);
+            $validator->validate($sleep, self::$_schema['properties']['__sleep']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_sleep_1 = $_sleep_1;
+        $clone->sleep = $sleep;
 
         return $clone;
     }
@@ -1835,28 +1835,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getWakeup1(): string
+    public function getWakeup(): string
     {
-        return $this->_wakeup_1;
+        return $this->wakeup;
     }
 
     /**
-     * @param string $_wakeup_1
+     * @param string $wakeup
      * @return self
      * @param bool $validate
      */
-    public function withWakeup1(string $_wakeup_1, bool $validate = true): self
+    public function withWakeup(string $wakeup, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_wakeup_1, self::$_schema['properties']['__wakeup']);
+            $validator->validate($wakeup, self::$_schema['properties']['__wakeup']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_wakeup_1 = $_wakeup_1;
+        $clone->wakeup = $wakeup;
 
         return $clone;
     }
@@ -1864,28 +1864,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getToString1(): string
+    public function getToString(): string
     {
-        return $this->_toString_1;
+        return $this->toString;
     }
 
     /**
-     * @param string $_toString_1
+     * @param string $toString
      * @return self
      * @param bool $validate
      */
-    public function withToString1(string $_toString_1, bool $validate = true): self
+    public function withToString(string $toString, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toString_1, self::$_schema['properties']['__toString']);
+            $validator->validate($toString, self::$_schema['properties']['__toString']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toString_1 = $_toString_1;
+        $clone->toString = $toString;
 
         return $clone;
     }
@@ -1893,28 +1893,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getInvoke1(): string
+    public function getInvoke(): string
     {
-        return $this->_invoke_1;
+        return $this->invoke;
     }
 
     /**
-     * @param string $_invoke_1
+     * @param string $invoke
      * @return self
      * @param bool $validate
      */
-    public function withInvoke1(string $_invoke_1, bool $validate = true): self
+    public function withInvoke(string $invoke, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_invoke_1, self::$_schema['properties']['__invoke']);
+            $validator->validate($invoke, self::$_schema['properties']['__invoke']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_invoke_1 = $_invoke_1;
+        $clone->invoke = $invoke;
 
         return $clone;
     }
@@ -1922,28 +1922,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getDebugInfo1(): string
+    public function getDebugInfo(): string
     {
-        return $this->_debugInfo_1;
+        return $this->debugInfo;
     }
 
     /**
-     * @param string $_debugInfo_1
+     * @param string $debugInfo
      * @return self
      * @param bool $validate
      */
-    public function withDebugInfo1(string $_debugInfo_1, bool $validate = true): self
+    public function withDebugInfo(string $debugInfo, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_debugInfo_1, self::$_schema['properties']['__debugInfo']);
+            $validator->validate($debugInfo, self::$_schema['properties']['__debugInfo']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_debugInfo_1 = $_debugInfo_1;
+        $clone->debugInfo = $debugInfo;
 
         return $clone;
     }
@@ -1951,28 +1951,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getClone2(): string
+    public function getClone(): string
     {
-        return $this->_clone_2;
+        return $this->clone;
     }
 
     /**
-     * @param string $_clone_2
+     * @param string $clone
      * @return self
      * @param bool $validate
      */
-    public function withClone2(string $_clone_2, bool $validate = true): self
+    public function withClone(string $clone, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone_2, self::$_schema['properties']['__clone']);
+            $validator->validate($clone, self::$_schema['properties']['__clone']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_clone_2 = $_clone_2;
+        $clone->clone = $clone;
 
         return $clone;
     }
@@ -1980,7 +1980,7 @@ class MyClass
     /**
      * @return string
      */
-    public function getFiles(): string
+    public function get_Files(): string
     {
         return $this->files;
     }
@@ -1990,7 +1990,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function withFiles(string $files, bool $validate = true): self
+    public function with_Files(string $files, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -2173,19 +2173,19 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $_GLOBALS_1 = $input->{'_GLOBALS'};
-        $_GLOBALS_2 = $input->{'GLOBALS'};
-        $_GLOBALS1_1 = $input->{'GLOBALS_1'};
-        $_SERVER_1 = $input->{'_SERVER'};
-        $_GET_1 = $input->{'_GET'};
-        $_POST_1 = $input->{'_POST'};
-        $_FILES_1 = $input->{'_FILES'};
-        $_REQUEST_1 = $input->{'_REQUEST'};
-        $_SESSION_1 = $input->{'_SESSION'};
-        $_ENV_1 = $input->{'_ENV'};
-        $_COOKIE_1 = $input->{'_COOKIE'};
-        $_phpErrormsg = $input->{'php_errormsg'};
-        $_httpResponseHeader = $input->{'http_response_header'};
+        $_GLOBALS_2 = $input->{'_GLOBALS'};
+        $_GLOBALS_1 = $input->{'GLOBALS'};
+        $GLOBALS1 = $input->{'GLOBALS_1'};
+        $SERVER = $input->{'_SERVER'};
+        $GET = $input->{'_GET'};
+        $POST = $input->{'_POST'};
+        $FILES = $input->{'_FILES'};
+        $REQUEST = $input->{'_REQUEST'};
+        $SESSION = $input->{'_SESSION'};
+        $ENV = $input->{'_ENV'};
+        $COOKIE = $input->{'_COOKIE'};
+        $phpErrormsg = $input->{'php_errormsg'};
+        $httpResponseHeader = $input->{'http_response_header'};
         $_argc = $input->{'argc'};
         $_argv = $input->{'argv'};
         $_input = $input->{'input'};
@@ -2197,41 +2197,41 @@ class MyClass
         $_obj = $input->{'obj'};
         $includeDefaults = $input->{'includeDefaults'};
         $testObj = isset($input->{'testObj'}) ? MyClassTestObj::fromInput($input->{'testObj'}, $validate, $materializeDefaults) : null;
-        $_fromInput_1 = $input->{'fromInput'};
-        $_toArray_1 = $input->{'toArray'};
-        $_toStdClass_1 = $input->{'toStdClass'};
-        $_validateInput_1 = $input->{'validateInput'};
-        $_schema_1 = $input->{'_schema'};
-        $_schema_2 = $input->{'schema'};
-        $_defaults_1 = $input->{'_defaults'};
-        $_defaults_2 = $input->{'defaults'};
+        $fromInput = $input->{'fromInput'};
+        $toArray = $input->{'toArray'};
+        $toStdClass = $input->{'toStdClass'};
+        $validateInput = $input->{'validateInput'};
+        $schema = $input->{'_schema'};
+        $_schema_1 = $input->{'schema'};
+        $defaults = $input->{'_defaults'};
+        $_defaults_1 = $input->{'defaults'};
         $_providedOptionals_1 = $input->{'_providedOptionals'};
-        $_providedOptionals_2 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
-        $_clone_1 = $input->{'clone'};
-        $_construct_1 = $input->{'__construct'};
-        $_destruct_1 = $input->{'__destruct'};
-        $_get_2 = $input->{'__get'};
-        $_set_1 = $input->{'__set'};
-        $_call_1 = $input->{'__call'};
-        $_isset_1 = $input->{'__isset'};
-        $_unset_1 = $input->{'__unset'};
-        $_sleep_1 = $input->{'__sleep'};
-        $_wakeup_1 = $input->{'__wakeup'};
-        $_toString_1 = $input->{'__toString'};
-        $_invoke_1 = $input->{'__invoke'};
-        $_debugInfo_1 = $input->{'__debugInfo'};
-        $_clone_2 = $input->{'__clone'};
+        $providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
+        $_clone = $input->{'clone'};
+        $construct = $input->{'__construct'};
+        $destruct = $input->{'__destruct'};
+        $get = $input->{'__get'};
+        $set = $input->{'__set'};
+        $call = $input->{'__call'};
+        $isset = $input->{'__isset'};
+        $unset = $input->{'__unset'};
+        $sleep = $input->{'__sleep'};
+        $wakeup = $input->{'__wakeup'};
+        $toString = $input->{'__toString'};
+        $invoke = $input->{'__invoke'};
+        $debugInfo = $input->{'__debugInfo'};
+        $clone = $input->{'__clone'};
         $files = $input->{'files'};
         $_this = $input->{'this'};
         $ensureArgs1 = isset($input->{'ensureArgs1'}) ? ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : (((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (null)))))) : null;
         $ensureArgs2 = isset($input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($input->{'ensureArgs2'}, $validate, $materializeDefaults) : null;
         $ensureArgs3 = isset($input->{'ensureArgs3'}) ? array_map(fn ($i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::fromInput($i, $validate, $materializeDefaults), $input->{'ensureArgs3'}) : null;
 
-        $obj = new self($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $_input, $_obj, $includeDefaults, $_fromInput_1, $_toArray_1, $_toStdClass_1, $_validateInput_1, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone_1, $_construct_1, $_destruct_1, $_get_2, $_set_1, $_call_1, $_isset_1, $_unset_1, $_sleep_1, $_wakeup_1, $_toString_1, $_invoke_1, $_debugInfo_1, $_clone_2, $files, $_this);
+        $obj = new self($_GLOBALS_2, $_GLOBALS_1, $GLOBALS1, $SERVER, $GET, $POST, $FILES, $REQUEST, $SESSION, $ENV, $COOKIE, $phpErrormsg, $httpResponseHeader, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $schema, $_schema_1, $defaults, $_defaults_1, $_providedOptionals_1, $_clone, $construct, $destruct, $get, $set, $call, $isset, $unset, $sleep, $wakeup, $toString, $invoke, $debugInfo, $clone, $files, $_this);
         $obj->validate = $_validate;
         $obj->materializeDefaults = $_materializeDefaults;
         $obj->testObj = $testObj;
-        $obj->_providedOptionals_2 = $_providedOptionals_2;
+        $obj->providedOptionals = $providedOptionals;
         $obj->ensureArgs1 = $ensureArgs1;
         $obj->ensureArgs2 = $ensureArgs2;
         $obj->ensureArgs3 = $ensureArgs3;
@@ -2248,21 +2248,21 @@ class MyClass
     public function toArray(bool $includeDefaults = false): array
     {
         $output = [];
-        $output['_GLOBALS'] = $this->_GLOBALS_1;
-        $output['GLOBALS'] = $this->_GLOBALS_2;
-        $output['GLOBALS_1'] = $this->_GLOBALS1_1;
-        $output['_SERVER'] = $this->_SERVER_1;
-        $output['_GET'] = $this->_GET_1;
-        $output['_POST'] = $this->_POST_1;
-        $output['_FILES'] = $this->_FILES_1;
-        $output['_REQUEST'] = $this->_REQUEST_1;
-        $output['_SESSION'] = $this->_SESSION_1;
-        $output['_ENV'] = $this->_ENV_1;
-        $output['_COOKIE'] = $this->_COOKIE_1;
-        $output['php_errormsg'] = $this->_phpErrormsg;
-        $output['http_response_header'] = $this->_httpResponseHeader;
-        $output['argc'] = $this->_argc;
-        $output['argv'] = $this->_argv;
+        $output['_GLOBALS'] = $this->_GLOBALS;
+        $output['GLOBALS'] = $this->GLOBALS;
+        $output['GLOBALS_1'] = $this->GLOBALS1;
+        $output['_SERVER'] = $this->SERVER;
+        $output['_GET'] = $this->GET;
+        $output['_POST'] = $this->POST;
+        $output['_FILES'] = $this->FILES;
+        $output['_REQUEST'] = $this->REQUEST;
+        $output['_SESSION'] = $this->SESSION;
+        $output['_ENV'] = $this->ENV;
+        $output['_COOKIE'] = $this->COOKIE;
+        $output['php_errormsg'] = $this->phpErrormsg;
+        $output['http_response_header'] = $this->httpResponseHeader;
+        $output['argc'] = $this->argc;
+        $output['argv'] = $this->argv;
         $output['input'] = $this->input;
         if (isset($this->validate)) {
             $output['validate'] = $this->validate;
@@ -2275,32 +2275,32 @@ class MyClass
         if (isset($this->testObj)) {
             $output['testObj'] = ($this->testObj)->toArray($includeDefaults);
         }
-        $output['fromInput'] = $this->_fromInput_1;
-        $output['toArray'] = $this->_toArray_1;
-        $output['toStdClass'] = $this->_toStdClass_1;
-        $output['validateInput'] = $this->_validateInput_1;
-        $output['_schema'] = $this->_schema_1;
-        $output['schema'] = $this->_schema_2;
-        $output['_defaults'] = $this->_defaults_1;
-        $output['defaults'] = $this->_defaults_2;
+        $output['fromInput'] = $this->fromInput;
+        $output['toArray'] = $this->toArray;
+        $output['toStdClass'] = $this->toStdClass;
+        $output['validateInput'] = $this->validateInput;
+        $output['_schema'] = $this->schema;
+        $output['schema'] = $this->_schema_1;
+        $output['_defaults'] = $this->defaults;
+        $output['defaults'] = $this->_defaults_1;
         $output['_providedOptionals'] = $this->_providedOptionals_1;
-        if (isset($this->_providedOptionals_2)) {
-            $output['__providedOptionals'] = $this->_providedOptionals_2;
+        if (isset($this->providedOptionals)) {
+            $output['__providedOptionals'] = $this->providedOptionals;
         }
-        $output['clone'] = $this->_clone_1;
-        $output['__construct'] = $this->_construct_1;
-        $output['__destruct'] = $this->_destruct_1;
-        $output['__get'] = $this->_get_2;
-        $output['__set'] = $this->_set_1;
-        $output['__call'] = $this->_call_1;
-        $output['__isset'] = $this->_isset_1;
-        $output['__unset'] = $this->_unset_1;
-        $output['__sleep'] = $this->_sleep_1;
-        $output['__wakeup'] = $this->_wakeup_1;
-        $output['__toString'] = $this->_toString_1;
-        $output['__invoke'] = $this->_invoke_1;
-        $output['__debugInfo'] = $this->_debugInfo_1;
-        $output['__clone'] = $this->_clone_2;
+        $output['clone'] = $this->_clone;
+        $output['__construct'] = $this->construct;
+        $output['__destruct'] = $this->destruct;
+        $output['__get'] = $this->get;
+        $output['__set'] = $this->set;
+        $output['__call'] = $this->call;
+        $output['__isset'] = $this->isset;
+        $output['__unset'] = $this->unset;
+        $output['__sleep'] = $this->sleep;
+        $output['__wakeup'] = $this->wakeup;
+        $output['__toString'] = $this->toString;
+        $output['__invoke'] = $this->invoke;
+        $output['__debugInfo'] = $this->debugInfo;
+        $output['__clone'] = $this->clone;
         $output['files'] = $this->files;
         $output['this'] = $this->_this;
         if (isset($this->ensureArgs1)) {
@@ -2337,21 +2337,21 @@ class MyClass
     public function toStdClass(bool $includeDefaults = false): \stdClass
     {
         $output = new \stdClass();
-        $output->{'_GLOBALS'} = $this->_GLOBALS_1;
-        $output->{'GLOBALS'} = $this->_GLOBALS_2;
-        $output->{'GLOBALS_1'} = $this->_GLOBALS1_1;
-        $output->{'_SERVER'} = $this->_SERVER_1;
-        $output->{'_GET'} = $this->_GET_1;
-        $output->{'_POST'} = $this->_POST_1;
-        $output->{'_FILES'} = $this->_FILES_1;
-        $output->{'_REQUEST'} = $this->_REQUEST_1;
-        $output->{'_SESSION'} = $this->_SESSION_1;
-        $output->{'_ENV'} = $this->_ENV_1;
-        $output->{'_COOKIE'} = $this->_COOKIE_1;
-        $output->{'php_errormsg'} = $this->_phpErrormsg;
-        $output->{'http_response_header'} = $this->_httpResponseHeader;
-        $output->{'argc'} = $this->_argc;
-        $output->{'argv'} = $this->_argv;
+        $output->{'_GLOBALS'} = $this->_GLOBALS;
+        $output->{'GLOBALS'} = $this->GLOBALS;
+        $output->{'GLOBALS_1'} = $this->GLOBALS1;
+        $output->{'_SERVER'} = $this->SERVER;
+        $output->{'_GET'} = $this->GET;
+        $output->{'_POST'} = $this->POST;
+        $output->{'_FILES'} = $this->FILES;
+        $output->{'_REQUEST'} = $this->REQUEST;
+        $output->{'_SESSION'} = $this->SESSION;
+        $output->{'_ENV'} = $this->ENV;
+        $output->{'_COOKIE'} = $this->COOKIE;
+        $output->{'php_errormsg'} = $this->phpErrormsg;
+        $output->{'http_response_header'} = $this->httpResponseHeader;
+        $output->{'argc'} = $this->argc;
+        $output->{'argv'} = $this->argv;
         $output->{'input'} = $this->input;
         if (isset($this->validate)) {
             $output->{'validate'} = $this->validate;
@@ -2364,32 +2364,32 @@ class MyClass
         if (isset($this->testObj)) {
             $output->{'testObj'} = ($this->testObj)->toStdClass($includeDefaults);
         }
-        $output->{'fromInput'} = $this->_fromInput_1;
-        $output->{'toArray'} = $this->_toArray_1;
-        $output->{'toStdClass'} = $this->_toStdClass_1;
-        $output->{'validateInput'} = $this->_validateInput_1;
-        $output->{'_schema'} = $this->_schema_1;
-        $output->{'schema'} = $this->_schema_2;
-        $output->{'_defaults'} = $this->_defaults_1;
-        $output->{'defaults'} = $this->_defaults_2;
+        $output->{'fromInput'} = $this->fromInput;
+        $output->{'toArray'} = $this->toArray;
+        $output->{'toStdClass'} = $this->toStdClass;
+        $output->{'validateInput'} = $this->validateInput;
+        $output->{'_schema'} = $this->schema;
+        $output->{'schema'} = $this->_schema_1;
+        $output->{'_defaults'} = $this->defaults;
+        $output->{'defaults'} = $this->_defaults_1;
         $output->{'_providedOptionals'} = $this->_providedOptionals_1;
-        if (isset($this->_providedOptionals_2)) {
-            $output->{'__providedOptionals'} = $this->_providedOptionals_2;
+        if (isset($this->providedOptionals)) {
+            $output->{'__providedOptionals'} = $this->providedOptionals;
         }
-        $output->{'clone'} = $this->_clone_1;
-        $output->{'__construct'} = $this->_construct_1;
-        $output->{'__destruct'} = $this->_destruct_1;
-        $output->{'__get'} = $this->_get_2;
-        $output->{'__set'} = $this->_set_1;
-        $output->{'__call'} = $this->_call_1;
-        $output->{'__isset'} = $this->_isset_1;
-        $output->{'__unset'} = $this->_unset_1;
-        $output->{'__sleep'} = $this->_sleep_1;
-        $output->{'__wakeup'} = $this->_wakeup_1;
-        $output->{'__toString'} = $this->_toString_1;
-        $output->{'__invoke'} = $this->_invoke_1;
-        $output->{'__debugInfo'} = $this->_debugInfo_1;
-        $output->{'__clone'} = $this->_clone_2;
+        $output->{'clone'} = $this->_clone;
+        $output->{'__construct'} = $this->construct;
+        $output->{'__destruct'} = $this->destruct;
+        $output->{'__get'} = $this->get;
+        $output->{'__set'} = $this->set;
+        $output->{'__call'} = $this->call;
+        $output->{'__isset'} = $this->isset;
+        $output->{'__unset'} = $this->unset;
+        $output->{'__sleep'} = $this->sleep;
+        $output->{'__wakeup'} = $this->wakeup;
+        $output->{'__toString'} = $this->toString;
+        $output->{'__invoke'} = $this->invoke;
+        $output->{'__debugInfo'} = $this->debugInfo;
+        $output->{'__clone'} = $this->clone;
         $output->{'files'} = $this->files;
         $output->{'this'} = $this->_this;
         if (isset($this->ensureArgs1)) {

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
@@ -296,77 +296,77 @@ class MyClass
     /**
      * @var string
      */
-    private string $_GLOBALS_1;
+    private string $_GLOBALS;
 
     /**
      * @var string
      */
-    private string $_GLOBALS_2;
+    private string $GLOBALS;
 
     /**
      * @var string
      */
-    private string $_GLOBALS1_1;
+    private string $GLOBALS1;
 
     /**
      * @var string
      */
-    private string $_SERVER_1;
+    private string $SERVER;
 
     /**
      * @var string
      */
-    private string $_GET_1;
+    private string $GET;
 
     /**
      * @var string
      */
-    private string $_POST_1;
+    private string $POST;
 
     /**
      * @var string
      */
-    private string $_FILES_1;
+    private string $FILES;
 
     /**
      * @var string
      */
-    private string $_REQUEST_1;
+    private string $REQUEST;
 
     /**
      * @var string
      */
-    private string $_SESSION_1;
+    private string $SESSION;
 
     /**
      * @var string
      */
-    private string $_ENV_1;
+    private string $ENV;
 
     /**
      * @var string
      */
-    private string $_COOKIE_1;
+    private string $COOKIE;
 
     /**
      * @var string
      */
-    private string $_phpErrormsg;
+    private string $phpErrormsg;
 
     /**
      * @var string
      */
-    private string $_httpResponseHeader;
+    private string $httpResponseHeader;
 
     /**
      * @var string
      */
-    private string $_argc;
+    private string $argc;
 
     /**
      * @var string
      */
-    private string $_argv;
+    private string $argv;
 
     /**
      * @var string
@@ -401,22 +401,27 @@ class MyClass
     /**
      * @var string
      */
-    private string $_fromInput_1;
+    private string $fromInput;
 
     /**
      * @var string
      */
-    private string $_toArray_1;
+    private string $toArray;
 
     /**
      * @var string
      */
-    private string $_toStdClass_1;
+    private string $toStdClass;
 
     /**
      * @var string
      */
-    private string $_validateInput_1;
+    private string $validateInput;
+
+    /**
+     * @var string
+     */
+    private string $schema;
 
     /**
      * @var string
@@ -426,7 +431,7 @@ class MyClass
     /**
      * @var string
      */
-    private string $_schema_2;
+    private string $defaults;
 
     /**
      * @var string
@@ -436,87 +441,82 @@ class MyClass
     /**
      * @var string
      */
-    private string $_defaults_2;
-
-    /**
-     * @var string
-     */
     private string $_providedOptionals_1;
 
     /**
      * @var string|null
      */
-    private ?string $_providedOptionals_2 = null;
+    private ?string $providedOptionals = null;
 
     /**
      * @var string
      */
-    private string $_clone_1;
+    private string $_clone;
 
     /**
      * @var string
      */
-    private string $_construct_1;
+    private string $construct;
 
     /**
      * @var string
      */
-    private string $_destruct_1;
+    private string $destruct;
 
     /**
      * @var string
      */
-    private string $_get_2;
+    private string $get;
 
     /**
      * @var string
      */
-    private string $_set_1;
+    private string $set;
 
     /**
      * @var string
      */
-    private string $_call_1;
+    private string $call;
 
     /**
      * @var string
      */
-    private string $_isset_1;
+    private string $isset;
 
     /**
      * @var string
      */
-    private string $_unset_1;
+    private string $unset;
 
     /**
      * @var string
      */
-    private string $_sleep_1;
+    private string $sleep;
 
     /**
      * @var string
      */
-    private string $_wakeup_1;
+    private string $wakeup;
 
     /**
      * @var string
      */
-    private string $_toString_1;
+    private string $toString;
 
     /**
      * @var string
      */
-    private string $_invoke_1;
+    private string $invoke;
 
     /**
      * @var string
      */
-    private string $_debugInfo_1;
+    private string $debugInfo;
 
     /**
      * @var string
      */
-    private string $_clone_2;
+    private string $clone;
 
     /**
      * @var string
@@ -544,93 +544,93 @@ class MyClass
     private ?array $ensureArgs3 = null;
 
     /**
-     * @param string $_GLOBALS_1
      * @param string $_GLOBALS_2
-     * @param string $_GLOBALS1_1
-     * @param string $_SERVER_1
-     * @param string $_GET_1
-     * @param string $_POST_1
-     * @param string $_FILES_1
-     * @param string $_REQUEST_1
-     * @param string $_SESSION_1
-     * @param string $_ENV_1
-     * @param string $_COOKIE_1
-     * @param string $_phpErrormsg
-     * @param string $_httpResponseHeader
+     * @param string $_GLOBALS_1
+     * @param string $GLOBALS1
+     * @param string $SERVER
+     * @param string $GET
+     * @param string $POST
+     * @param string $FILES
+     * @param string $REQUEST
+     * @param string $SESSION
+     * @param string $ENV
+     * @param string $COOKIE
+     * @param string $phpErrormsg
+     * @param string $httpResponseHeader
      * @param string $_argc
      * @param string $_argv
-     * @param string $input
-     * @param string $obj
+     * @param string $_input
+     * @param string $_obj
      * @param string $includeDefaults
-     * @param string $_fromInput_1
-     * @param string $_toArray_1
-     * @param string $_toStdClass_1
-     * @param string $_validateInput_1
+     * @param string $fromInput
+     * @param string $toArray
+     * @param string $toStdClass
+     * @param string $validateInput
+     * @param string $schema
      * @param string $_schema_1
-     * @param string $_schema_2
+     * @param string $defaults
      * @param string $_defaults_1
-     * @param string $_defaults_2
      * @param string $_providedOptionals_1
-     * @param string $_clone_1
-     * @param string $_construct_1
-     * @param string $_destruct_1
-     * @param string $_get_2
-     * @param string $_set_1
-     * @param string $_call_1
-     * @param string $_isset_1
-     * @param string $_unset_1
-     * @param string $_sleep_1
-     * @param string $_wakeup_1
-     * @param string $_toString_1
-     * @param string $_invoke_1
-     * @param string $_debugInfo_1
-     * @param string $_clone_2
+     * @param string $_clone
+     * @param string $construct
+     * @param string $destruct
+     * @param string $get
+     * @param string $set
+     * @param string $call
+     * @param string $isset
+     * @param string $unset
+     * @param string $sleep
+     * @param string $wakeup
+     * @param string $toString
+     * @param string $invoke
+     * @param string $debugInfo
+     * @param string $clone
      * @param string $files
      * @param string $_this
      */
-    public function __construct(string $_GLOBALS_1, string $_GLOBALS_2, string $_GLOBALS1_1, string $_SERVER_1, string $_GET_1, string $_POST_1, string $_FILES_1, string $_REQUEST_1, string $_SESSION_1, string $_ENV_1, string $_COOKIE_1, string $_phpErrormsg, string $_httpResponseHeader, string $_argc, string $_argv, string $input, string $obj, string $includeDefaults, string $_fromInput_1, string $_toArray_1, string $_toStdClass_1, string $_validateInput_1, string $_schema_1, string $_schema_2, string $_defaults_1, string $_defaults_2, string $_providedOptionals_1, string $_clone_1, string $_construct_1, string $_destruct_1, string $_get_2, string $_set_1, string $_call_1, string $_isset_1, string $_unset_1, string $_sleep_1, string $_wakeup_1, string $_toString_1, string $_invoke_1, string $_debugInfo_1, string $_clone_2, string $files, string $_this)
+    public function __construct(string $_GLOBALS_2, string $_GLOBALS_1, string $GLOBALS1, string $SERVER, string $GET, string $POST, string $FILES, string $REQUEST, string $SESSION, string $ENV, string $COOKIE, string $phpErrormsg, string $httpResponseHeader, string $_argc, string $_argv, string $_input, string $_obj, string $includeDefaults, string $fromInput, string $toArray, string $toStdClass, string $validateInput, string $schema, string $_schema_1, string $defaults, string $_defaults_1, string $_providedOptionals_1, string $_clone, string $construct, string $destruct, string $get, string $set, string $call, string $isset, string $unset, string $sleep, string $wakeup, string $toString, string $invoke, string $debugInfo, string $clone, string $files, string $_this)
     {
-        $this->_GLOBALS_1 = $_GLOBALS_1;
-        $this->_GLOBALS_2 = $_GLOBALS_2;
-        $this->_GLOBALS1_1 = $_GLOBALS1_1;
-        $this->_SERVER_1 = $_SERVER_1;
-        $this->_GET_1 = $_GET_1;
-        $this->_POST_1 = $_POST_1;
-        $this->_FILES_1 = $_FILES_1;
-        $this->_REQUEST_1 = $_REQUEST_1;
-        $this->_SESSION_1 = $_SESSION_1;
-        $this->_ENV_1 = $_ENV_1;
-        $this->_COOKIE_1 = $_COOKIE_1;
-        $this->_phpErrormsg = $_phpErrormsg;
-        $this->_httpResponseHeader = $_httpResponseHeader;
-        $this->_argc = $_argc;
-        $this->_argv = $_argv;
-        $this->input = $input;
-        $this->obj = $obj;
+        $this->_GLOBALS = $_GLOBALS_2;
+        $this->GLOBALS = $_GLOBALS_1;
+        $this->GLOBALS1 = $GLOBALS1;
+        $this->SERVER = $SERVER;
+        $this->GET = $GET;
+        $this->POST = $POST;
+        $this->FILES = $FILES;
+        $this->REQUEST = $REQUEST;
+        $this->SESSION = $SESSION;
+        $this->ENV = $ENV;
+        $this->COOKIE = $COOKIE;
+        $this->phpErrormsg = $phpErrormsg;
+        $this->httpResponseHeader = $httpResponseHeader;
+        $this->argc = $_argc;
+        $this->argv = $_argv;
+        $this->input = $_input;
+        $this->obj = $_obj;
         $this->includeDefaults = $includeDefaults;
-        $this->_fromInput_1 = $_fromInput_1;
-        $this->_toArray_1 = $_toArray_1;
-        $this->_toStdClass_1 = $_toStdClass_1;
-        $this->_validateInput_1 = $_validateInput_1;
+        $this->fromInput = $fromInput;
+        $this->toArray = $toArray;
+        $this->toStdClass = $toStdClass;
+        $this->validateInput = $validateInput;
+        $this->schema = $schema;
         $this->_schema_1 = $_schema_1;
-        $this->_schema_2 = $_schema_2;
+        $this->defaults = $defaults;
         $this->_defaults_1 = $_defaults_1;
-        $this->_defaults_2 = $_defaults_2;
         $this->_providedOptionals_1 = $_providedOptionals_1;
-        $this->_clone_1 = $_clone_1;
-        $this->_construct_1 = $_construct_1;
-        $this->_destruct_1 = $_destruct_1;
-        $this->_get_2 = $_get_2;
-        $this->_set_1 = $_set_1;
-        $this->_call_1 = $_call_1;
-        $this->_isset_1 = $_isset_1;
-        $this->_unset_1 = $_unset_1;
-        $this->_sleep_1 = $_sleep_1;
-        $this->_wakeup_1 = $_wakeup_1;
-        $this->_toString_1 = $_toString_1;
-        $this->_invoke_1 = $_invoke_1;
-        $this->_debugInfo_1 = $_debugInfo_1;
-        $this->_clone_2 = $_clone_2;
+        $this->_clone = $_clone;
+        $this->construct = $construct;
+        $this->destruct = $destruct;
+        $this->get = $get;
+        $this->set = $set;
+        $this->call = $call;
+        $this->isset = $isset;
+        $this->unset = $unset;
+        $this->sleep = $sleep;
+        $this->wakeup = $wakeup;
+        $this->toString = $toString;
+        $this->invoke = $invoke;
+        $this->debugInfo = $debugInfo;
+        $this->clone = $clone;
         $this->files = $files;
         $this->_this = $_this;
     }
@@ -638,38 +638,9 @@ class MyClass
     /**
      * @return string
      */
-    public function getGLOBALS1(): string
+    public function get_GLOBALS(): string
     {
-        return $this->_GLOBALS_1;
-    }
-
-    /**
-     * @param string $_GLOBALS_1
-     * @return self
-     * @param bool $validate
-     */
-    public function withGLOBALS1(string $_GLOBALS_1, bool $validate = true): self
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_1, self::$_schema['properties']['_GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->_GLOBALS_1 = $_GLOBALS_1;
-
-        return $clone;
-    }
-
-    /**
-     * @return string
-     */
-    public function getGLOBALS2(): string
-    {
-        return $this->_GLOBALS_2;
+        return $this->_GLOBALS;
     }
 
     /**
@@ -677,18 +648,18 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function withGLOBALS2(string $_GLOBALS_2, bool $validate = true): self
+    public function with_GLOBALS(string $_GLOBALS_2, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_2, self::$_schema['properties']['GLOBALS']);
+            $validator->validate($_GLOBALS_2, self::$_schema['properties']['_GLOBALS']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_GLOBALS_2 = $_GLOBALS_2;
+        $clone->_GLOBALS = $_GLOBALS_2;
 
         return $clone;
     }
@@ -696,28 +667,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getGLOBALS11(): string
+    public function getGLOBALS(): string
     {
-        return $this->_GLOBALS1_1;
+        return $this->GLOBALS;
     }
 
     /**
-     * @param string $_GLOBALS1_1
+     * @param string $_GLOBALS_1
      * @return self
      * @param bool $validate
      */
-    public function withGLOBALS11(string $_GLOBALS1_1, bool $validate = true): self
+    public function withGLOBALS(string $_GLOBALS_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS1_1, self::$_schema['properties']['GLOBALS_1']);
+            $validator->validate($_GLOBALS_1, self::$_schema['properties']['GLOBALS']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_GLOBALS1_1 = $_GLOBALS1_1;
+        $clone->GLOBALS = $_GLOBALS_1;
 
         return $clone;
     }
@@ -725,28 +696,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSERVER1(): string
+    public function getGLOBALS1(): string
     {
-        return $this->_SERVER_1;
+        return $this->GLOBALS1;
     }
 
     /**
-     * @param string $_SERVER_1
+     * @param string $GLOBALS1
      * @return self
      * @param bool $validate
      */
-    public function withSERVER1(string $_SERVER_1, bool $validate = true): self
+    public function withGLOBALS1(string $GLOBALS1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_SERVER_1, self::$_schema['properties']['_SERVER']);
+            $validator->validate($GLOBALS1, self::$_schema['properties']['GLOBALS_1']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_SERVER_1 = $_SERVER_1;
+        $clone->GLOBALS1 = $GLOBALS1;
 
         return $clone;
     }
@@ -754,28 +725,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getGET1(): string
+    public function getSERVER(): string
     {
-        return $this->_GET_1;
+        return $this->SERVER;
     }
 
     /**
-     * @param string $_GET_1
+     * @param string $SERVER
      * @return self
      * @param bool $validate
      */
-    public function withGET1(string $_GET_1, bool $validate = true): self
+    public function withSERVER(string $SERVER, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_GET_1, self::$_schema['properties']['_GET']);
+            $validator->validate($SERVER, self::$_schema['properties']['_SERVER']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_GET_1 = $_GET_1;
+        $clone->SERVER = $SERVER;
 
         return $clone;
     }
@@ -783,28 +754,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getPOST1(): string
+    public function getGET(): string
     {
-        return $this->_POST_1;
+        return $this->GET;
     }
 
     /**
-     * @param string $_POST_1
+     * @param string $GET
      * @return self
      * @param bool $validate
      */
-    public function withPOST1(string $_POST_1, bool $validate = true): self
+    public function withGET(string $GET, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_POST_1, self::$_schema['properties']['_POST']);
+            $validator->validate($GET, self::$_schema['properties']['_GET']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_POST_1 = $_POST_1;
+        $clone->GET = $GET;
 
         return $clone;
     }
@@ -812,28 +783,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getFILES1(): string
+    public function getPOST(): string
     {
-        return $this->_FILES_1;
+        return $this->POST;
     }
 
     /**
-     * @param string $_FILES_1
+     * @param string $POST
      * @return self
      * @param bool $validate
      */
-    public function withFILES1(string $_FILES_1, bool $validate = true): self
+    public function withPOST(string $POST, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_FILES_1, self::$_schema['properties']['_FILES']);
+            $validator->validate($POST, self::$_schema['properties']['_POST']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_FILES_1 = $_FILES_1;
+        $clone->POST = $POST;
 
         return $clone;
     }
@@ -841,28 +812,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getREQUEST1(): string
+    public function getFILES(): string
     {
-        return $this->_REQUEST_1;
+        return $this->FILES;
     }
 
     /**
-     * @param string $_REQUEST_1
+     * @param string $FILES
      * @return self
      * @param bool $validate
      */
-    public function withREQUEST1(string $_REQUEST_1, bool $validate = true): self
+    public function withFILES(string $FILES, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_REQUEST_1, self::$_schema['properties']['_REQUEST']);
+            $validator->validate($FILES, self::$_schema['properties']['_FILES']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_REQUEST_1 = $_REQUEST_1;
+        $clone->FILES = $FILES;
 
         return $clone;
     }
@@ -870,28 +841,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSESSION1(): string
+    public function getREQUEST(): string
     {
-        return $this->_SESSION_1;
+        return $this->REQUEST;
     }
 
     /**
-     * @param string $_SESSION_1
+     * @param string $REQUEST
      * @return self
      * @param bool $validate
      */
-    public function withSESSION1(string $_SESSION_1, bool $validate = true): self
+    public function withREQUEST(string $REQUEST, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_SESSION_1, self::$_schema['properties']['_SESSION']);
+            $validator->validate($REQUEST, self::$_schema['properties']['_REQUEST']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_SESSION_1 = $_SESSION_1;
+        $clone->REQUEST = $REQUEST;
 
         return $clone;
     }
@@ -899,28 +870,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getENV1(): string
+    public function getSESSION(): string
     {
-        return $this->_ENV_1;
+        return $this->SESSION;
     }
 
     /**
-     * @param string $_ENV_1
+     * @param string $SESSION
      * @return self
      * @param bool $validate
      */
-    public function withENV1(string $_ENV_1, bool $validate = true): self
+    public function withSESSION(string $SESSION, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_ENV_1, self::$_schema['properties']['_ENV']);
+            $validator->validate($SESSION, self::$_schema['properties']['_SESSION']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_ENV_1 = $_ENV_1;
+        $clone->SESSION = $SESSION;
 
         return $clone;
     }
@@ -928,28 +899,57 @@ class MyClass
     /**
      * @return string
      */
-    public function getCOOKIE1(): string
+    public function getENV(): string
     {
-        return $this->_COOKIE_1;
+        return $this->ENV;
     }
 
     /**
-     * @param string $_COOKIE_1
+     * @param string $ENV
      * @return self
      * @param bool $validate
      */
-    public function withCOOKIE1(string $_COOKIE_1, bool $validate = true): self
+    public function withENV(string $ENV, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_COOKIE_1, self::$_schema['properties']['_COOKIE']);
+            $validator->validate($ENV, self::$_schema['properties']['_ENV']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_COOKIE_1 = $_COOKIE_1;
+        $clone->ENV = $ENV;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCOOKIE(): string
+    {
+        return $this->COOKIE;
+    }
+
+    /**
+     * @param string $COOKIE
+     * @return self
+     * @param bool $validate
+     */
+    public function withCOOKIE(string $COOKIE, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($COOKIE, self::$_schema['properties']['_COOKIE']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->COOKIE = $COOKIE;
 
         return $clone;
     }
@@ -959,26 +959,26 @@ class MyClass
      */
     public function getPhpErrormsg(): string
     {
-        return $this->_phpErrormsg;
+        return $this->phpErrormsg;
     }
 
     /**
-     * @param string $_phpErrormsg
+     * @param string $phpErrormsg
      * @return self
      * @param bool $validate
      */
-    public function withPhpErrormsg(string $_phpErrormsg, bool $validate = true): self
+    public function withPhpErrormsg(string $phpErrormsg, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_phpErrormsg, self::$_schema['properties']['php_errormsg']);
+            $validator->validate($phpErrormsg, self::$_schema['properties']['php_errormsg']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_phpErrormsg = $_phpErrormsg;
+        $clone->phpErrormsg = $phpErrormsg;
 
         return $clone;
     }
@@ -988,26 +988,26 @@ class MyClass
      */
     public function getHttpResponseHeader(): string
     {
-        return $this->_httpResponseHeader;
+        return $this->httpResponseHeader;
     }
 
     /**
-     * @param string $_httpResponseHeader
+     * @param string $httpResponseHeader
      * @return self
      * @param bool $validate
      */
-    public function withHttpResponseHeader(string $_httpResponseHeader, bool $validate = true): self
+    public function withHttpResponseHeader(string $httpResponseHeader, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_httpResponseHeader, self::$_schema['properties']['http_response_header']);
+            $validator->validate($httpResponseHeader, self::$_schema['properties']['http_response_header']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_httpResponseHeader = $_httpResponseHeader;
+        $clone->httpResponseHeader = $httpResponseHeader;
 
         return $clone;
     }
@@ -1017,7 +1017,7 @@ class MyClass
      */
     public function getArgc(): string
     {
-        return $this->_argc;
+        return $this->argc;
     }
 
     /**
@@ -1036,7 +1036,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_argc = $_argc;
+        $clone->argc = $_argc;
 
         return $clone;
     }
@@ -1046,7 +1046,7 @@ class MyClass
      */
     public function getArgv(): string
     {
-        return $this->_argv;
+        return $this->argv;
     }
 
     /**
@@ -1065,7 +1065,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_argv = $_argv;
+        $clone->argv = $_argv;
 
         return $clone;
     }
@@ -1079,22 +1079,22 @@ class MyClass
     }
 
     /**
-     * @param string $input
+     * @param string $_input
      * @return self
      * @param bool $validate
      */
-    public function withInput(string $input, bool $validate = true): self
+    public function withInput(string $_input, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($input, self::$_schema['properties']['input']);
+            $validator->validate($_input, self::$_schema['properties']['input']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->input = $input;
+        $clone->input = $_input;
 
         return $clone;
     }
@@ -1108,22 +1108,22 @@ class MyClass
     }
 
     /**
-     * @param string $validate
+     * @param string $_validate
      * @return self
      * @param bool $validate
      */
-    public function withValidate(bool $validate = true): self
+    public function withValidate(string $_validate, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($validate, self::$_schema['properties']['validate']);
+            $validator->validate($_validate, self::$_schema['properties']['validate']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->validate = $validate;
+        $clone->validate = $_validate;
 
         return $clone;
     }
@@ -1148,22 +1148,22 @@ class MyClass
     }
 
     /**
-     * @param string $materializeDefaults
+     * @param string $_materializeDefaults
      * @return self
      * @param bool $validate
      */
-    public function withMaterializeDefaults(string $materializeDefaults, bool $validate = true): self
+    public function withMaterializeDefaults(string $_materializeDefaults, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($materializeDefaults, self::$_schema['properties']['materializeDefaults']);
+            $validator->validate($_materializeDefaults, self::$_schema['properties']['materializeDefaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->materializeDefaults = $materializeDefaults;
+        $clone->materializeDefaults = $_materializeDefaults;
         $clone->_providedOptionals['materializeDefaults'] = true;
 
         return $clone;
@@ -1190,22 +1190,22 @@ class MyClass
     }
 
     /**
-     * @param string $obj
+     * @param string $_obj
      * @return self
      * @param bool $validate
      */
-    public function withObj(string $obj, bool $validate = true): self
+    public function withObj(string $_obj, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($obj, self::$_schema['properties']['obj']);
+            $validator->validate($_obj, self::$_schema['properties']['obj']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->obj = $obj;
+        $clone->obj = $_obj;
 
         return $clone;
     }
@@ -1273,28 +1273,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getFromInput1(): string
+    public function getFromInput(): string
     {
-        return $this->_fromInput_1;
+        return $this->fromInput;
     }
 
     /**
-     * @param string $_fromInput_1
+     * @param string $fromInput
      * @return self
      * @param bool $validate
      */
-    public function withFromInput1(string $_fromInput_1, bool $validate = true): self
+    public function withFromInput(string $fromInput, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_fromInput_1, self::$_schema['properties']['fromInput']);
+            $validator->validate($fromInput, self::$_schema['properties']['fromInput']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_fromInput_1 = $_fromInput_1;
+        $clone->fromInput = $fromInput;
 
         return $clone;
     }
@@ -1302,28 +1302,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getToArray1(): string
+    public function getToArray(): string
     {
-        return $this->_toArray_1;
+        return $this->toArray;
     }
 
     /**
-     * @param string $_toArray_1
+     * @param string $toArray
      * @return self
      * @param bool $validate
      */
-    public function withToArray1(string $_toArray_1, bool $validate = true): self
+    public function withToArray(string $toArray, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toArray_1, self::$_schema['properties']['toArray']);
+            $validator->validate($toArray, self::$_schema['properties']['toArray']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toArray_1 = $_toArray_1;
+        $clone->toArray = $toArray;
 
         return $clone;
     }
@@ -1331,28 +1331,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getToStdClass1(): string
+    public function getToStdClass(): string
     {
-        return $this->_toStdClass_1;
+        return $this->toStdClass;
     }
 
     /**
-     * @param string $_toStdClass_1
+     * @param string $toStdClass
      * @return self
      * @param bool $validate
      */
-    public function withToStdClass1(string $_toStdClass_1, bool $validate = true): self
+    public function withToStdClass(string $toStdClass, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toStdClass_1, self::$_schema['properties']['toStdClass']);
+            $validator->validate($toStdClass, self::$_schema['properties']['toStdClass']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toStdClass_1 = $_toStdClass_1;
+        $clone->toStdClass = $toStdClass;
 
         return $clone;
     }
@@ -1360,28 +1360,57 @@ class MyClass
     /**
      * @return string
      */
-    public function getValidateInput1(): string
+    public function getValidateInput(): string
     {
-        return $this->_validateInput_1;
+        return $this->validateInput;
     }
 
     /**
-     * @param string $_validateInput_1
+     * @param string $validateInput
      * @return self
      * @param bool $validate
      */
-    public function withValidateInput1(string $_validateInput_1, bool $validate = true): self
+    public function withValidateInput(string $validateInput, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_validateInput_1, self::$_schema['properties']['validateInput']);
+            $validator->validate($validateInput, self::$_schema['properties']['validateInput']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_validateInput_1 = $_validateInput_1;
+        $clone->validateInput = $validateInput;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSchema(): string
+    {
+        return $this->schema;
+    }
+
+    /**
+     * @param string $schema
+     * @return self
+     * @param bool $validate
+     */
+    public function withSchema(string $schema, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($schema, self::$_schema['properties']['_schema']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->schema = $schema;
 
         return $clone;
     }
@@ -1403,7 +1432,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_1, self::$_schema['properties']['_schema']);
+            $validator->validate($_schema_1, self::$_schema['properties']['schema']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -1418,28 +1447,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSchema2(): string
+    public function getDefaults(): string
     {
-        return $this->_schema_2;
+        return $this->defaults;
     }
 
     /**
-     * @param string $_schema_2
+     * @param string $defaults
      * @return self
      * @param bool $validate
      */
-    public function withSchema2(string $_schema_2, bool $validate = true): self
+    public function withDefaults(string $defaults, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_2, self::$_schema['properties']['schema']);
+            $validator->validate($defaults, self::$_schema['properties']['_defaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_schema_2 = $_schema_2;
+        $clone->defaults = $defaults;
 
         return $clone;
     }
@@ -1461,7 +1490,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_1, self::$_schema['properties']['_defaults']);
+            $validator->validate($_defaults_1, self::$_schema['properties']['defaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -1469,35 +1498,6 @@ class MyClass
 
         $clone = clone $this;
         $clone->_defaults_1 = $_defaults_1;
-
-        return $clone;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDefaults2(): string
-    {
-        return $this->_defaults_2;
-    }
-
-    /**
-     * @param string $_defaults_2
-     * @return self
-     * @param bool $validate
-     */
-    public function withDefaults2(string $_defaults_2, bool $validate = true): self
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_2, self::$_schema['properties']['defaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->_defaults_2 = $_defaults_2;
 
         return $clone;
     }
@@ -1534,28 +1534,28 @@ class MyClass
     /**
      * @return string|null
      */
-    public function getProvidedOptionals2(): ?string
+    public function getProvidedOptionals(): ?string
     {
-        return $this->_providedOptionals_2 ?? null;
+        return $this->providedOptionals ?? null;
     }
 
     /**
-     * @param string $_providedOptionals_2
+     * @param string $providedOptionals
      * @return self
      * @param bool $validate
      */
-    public function withProvidedOptionals2(string $_providedOptionals_2, bool $validate = true): self
+    public function withProvidedOptionals(string $providedOptionals, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_providedOptionals_2, self::$_schema['properties']['__providedOptionals']);
+            $validator->validate($providedOptionals, self::$_schema['properties']['__providedOptionals']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_providedOptionals_2 = $_providedOptionals_2;
+        $clone->providedOptionals = $providedOptionals;
 
         return $clone;
     }
@@ -1563,10 +1563,10 @@ class MyClass
     /**
      * @return self
      */
-    public function withoutProvidedOptionals2(): self
+    public function withoutProvidedOptionals(): self
     {
         $clone = clone $this;
-        unset($clone->_providedOptionals_2);
+        unset($clone->providedOptionals);
 
         return $clone;
     }
@@ -1574,28 +1574,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getClone1(): string
+    public function get_Clone(): string
     {
-        return $this->_clone_1;
+        return $this->_clone;
     }
 
     /**
-     * @param string $_clone_1
+     * @param string $_clone
      * @return self
      * @param bool $validate
      */
-    public function withClone1(string $_clone_1, bool $validate = true): self
+    public function with_Clone(string $_clone, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone_1, self::$_schema['properties']['clone']);
+            $validator->validate($_clone, self::$_schema['properties']['clone']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_clone_1 = $_clone_1;
+        $clone->_clone = $_clone;
 
         return $clone;
     }
@@ -1603,28 +1603,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getConstruct1(): string
+    public function getConstruct(): string
     {
-        return $this->_construct_1;
+        return $this->construct;
     }
 
     /**
-     * @param string $_construct_1
+     * @param string $construct
      * @return self
      * @param bool $validate
      */
-    public function withConstruct1(string $_construct_1, bool $validate = true): self
+    public function withConstruct(string $construct, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_construct_1, self::$_schema['properties']['__construct']);
+            $validator->validate($construct, self::$_schema['properties']['__construct']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_construct_1 = $_construct_1;
+        $clone->construct = $construct;
 
         return $clone;
     }
@@ -1632,28 +1632,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getDestruct1(): string
+    public function getDestruct(): string
     {
-        return $this->_destruct_1;
+        return $this->destruct;
     }
 
     /**
-     * @param string $_destruct_1
+     * @param string $destruct
      * @return self
      * @param bool $validate
      */
-    public function withDestruct1(string $_destruct_1, bool $validate = true): self
+    public function withDestruct(string $destruct, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_destruct_1, self::$_schema['properties']['__destruct']);
+            $validator->validate($destruct, self::$_schema['properties']['__destruct']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_destruct_1 = $_destruct_1;
+        $clone->destruct = $destruct;
 
         return $clone;
     }
@@ -1661,28 +1661,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getGet2(): string
+    public function get_Get(): string
     {
-        return $this->_get_2;
+        return $this->get;
     }
 
     /**
-     * @param string $_get_2
+     * @param string $get
      * @return self
      * @param bool $validate
      */
-    public function withGet2(string $_get_2, bool $validate = true): self
+    public function with_Get(string $get, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_get_2, self::$_schema['properties']['__get']);
+            $validator->validate($get, self::$_schema['properties']['__get']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_get_2 = $_get_2;
+        $clone->get = $get;
 
         return $clone;
     }
@@ -1690,28 +1690,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSet1(): string
+    public function getSet(): string
     {
-        return $this->_set_1;
+        return $this->set;
     }
 
     /**
-     * @param string $_set_1
+     * @param string $set
      * @return self
      * @param bool $validate
      */
-    public function withSet1(string $_set_1, bool $validate = true): self
+    public function withSet(string $set, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_set_1, self::$_schema['properties']['__set']);
+            $validator->validate($set, self::$_schema['properties']['__set']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_set_1 = $_set_1;
+        $clone->set = $set;
 
         return $clone;
     }
@@ -1719,28 +1719,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getCall1(): string
+    public function getCall(): string
     {
-        return $this->_call_1;
+        return $this->call;
     }
 
     /**
-     * @param string $_call_1
+     * @param string $call
      * @return self
      * @param bool $validate
      */
-    public function withCall1(string $_call_1, bool $validate = true): self
+    public function withCall(string $call, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_call_1, self::$_schema['properties']['__call']);
+            $validator->validate($call, self::$_schema['properties']['__call']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_call_1 = $_call_1;
+        $clone->call = $call;
 
         return $clone;
     }
@@ -1748,28 +1748,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getIsset1(): string
+    public function getIsset(): string
     {
-        return $this->_isset_1;
+        return $this->isset;
     }
 
     /**
-     * @param string $_isset_1
+     * @param string $isset
      * @return self
      * @param bool $validate
      */
-    public function withIsset1(string $_isset_1, bool $validate = true): self
+    public function withIsset(string $isset, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_isset_1, self::$_schema['properties']['__isset']);
+            $validator->validate($isset, self::$_schema['properties']['__isset']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_isset_1 = $_isset_1;
+        $clone->isset = $isset;
 
         return $clone;
     }
@@ -1777,28 +1777,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getUnset1(): string
+    public function getUnset(): string
     {
-        return $this->_unset_1;
+        return $this->unset;
     }
 
     /**
-     * @param string $_unset_1
+     * @param string $unset
      * @return self
      * @param bool $validate
      */
-    public function withUnset1(string $_unset_1, bool $validate = true): self
+    public function withUnset(string $unset, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_unset_1, self::$_schema['properties']['__unset']);
+            $validator->validate($unset, self::$_schema['properties']['__unset']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_unset_1 = $_unset_1;
+        $clone->unset = $unset;
 
         return $clone;
     }
@@ -1806,28 +1806,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getSleep1(): string
+    public function getSleep(): string
     {
-        return $this->_sleep_1;
+        return $this->sleep;
     }
 
     /**
-     * @param string $_sleep_1
+     * @param string $sleep
      * @return self
      * @param bool $validate
      */
-    public function withSleep1(string $_sleep_1, bool $validate = true): self
+    public function withSleep(string $sleep, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_sleep_1, self::$_schema['properties']['__sleep']);
+            $validator->validate($sleep, self::$_schema['properties']['__sleep']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_sleep_1 = $_sleep_1;
+        $clone->sleep = $sleep;
 
         return $clone;
     }
@@ -1835,28 +1835,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getWakeup1(): string
+    public function getWakeup(): string
     {
-        return $this->_wakeup_1;
+        return $this->wakeup;
     }
 
     /**
-     * @param string $_wakeup_1
+     * @param string $wakeup
      * @return self
      * @param bool $validate
      */
-    public function withWakeup1(string $_wakeup_1, bool $validate = true): self
+    public function withWakeup(string $wakeup, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_wakeup_1, self::$_schema['properties']['__wakeup']);
+            $validator->validate($wakeup, self::$_schema['properties']['__wakeup']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_wakeup_1 = $_wakeup_1;
+        $clone->wakeup = $wakeup;
 
         return $clone;
     }
@@ -1864,28 +1864,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getToString1(): string
+    public function getToString(): string
     {
-        return $this->_toString_1;
+        return $this->toString;
     }
 
     /**
-     * @param string $_toString_1
+     * @param string $toString
      * @return self
      * @param bool $validate
      */
-    public function withToString1(string $_toString_1, bool $validate = true): self
+    public function withToString(string $toString, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toString_1, self::$_schema['properties']['__toString']);
+            $validator->validate($toString, self::$_schema['properties']['__toString']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toString_1 = $_toString_1;
+        $clone->toString = $toString;
 
         return $clone;
     }
@@ -1893,28 +1893,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getInvoke1(): string
+    public function getInvoke(): string
     {
-        return $this->_invoke_1;
+        return $this->invoke;
     }
 
     /**
-     * @param string $_invoke_1
+     * @param string $invoke
      * @return self
      * @param bool $validate
      */
-    public function withInvoke1(string $_invoke_1, bool $validate = true): self
+    public function withInvoke(string $invoke, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_invoke_1, self::$_schema['properties']['__invoke']);
+            $validator->validate($invoke, self::$_schema['properties']['__invoke']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_invoke_1 = $_invoke_1;
+        $clone->invoke = $invoke;
 
         return $clone;
     }
@@ -1922,28 +1922,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getDebugInfo1(): string
+    public function getDebugInfo(): string
     {
-        return $this->_debugInfo_1;
+        return $this->debugInfo;
     }
 
     /**
-     * @param string $_debugInfo_1
+     * @param string $debugInfo
      * @return self
      * @param bool $validate
      */
-    public function withDebugInfo1(string $_debugInfo_1, bool $validate = true): self
+    public function withDebugInfo(string $debugInfo, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_debugInfo_1, self::$_schema['properties']['__debugInfo']);
+            $validator->validate($debugInfo, self::$_schema['properties']['__debugInfo']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_debugInfo_1 = $_debugInfo_1;
+        $clone->debugInfo = $debugInfo;
 
         return $clone;
     }
@@ -1951,28 +1951,28 @@ class MyClass
     /**
      * @return string
      */
-    public function getClone2(): string
+    public function getClone(): string
     {
-        return $this->_clone_2;
+        return $this->clone;
     }
 
     /**
-     * @param string $_clone_2
+     * @param string $clone
      * @return self
      * @param bool $validate
      */
-    public function withClone2(string $_clone_2, bool $validate = true): self
+    public function withClone(string $clone, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone_2, self::$_schema['properties']['__clone']);
+            $validator->validate($clone, self::$_schema['properties']['__clone']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_clone_2 = $_clone_2;
+        $clone->clone = $clone;
 
         return $clone;
     }
@@ -1980,7 +1980,7 @@ class MyClass
     /**
      * @return string
      */
-    public function getFiles(): string
+    public function get_Files(): string
     {
         return $this->files;
     }
@@ -1990,7 +1990,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function withFiles(string $files, bool $validate = true): self
+    public function with_Files(string $files, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -2167,19 +2167,19 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $_GLOBALS_1 = $input->{'_GLOBALS'};
-        $_GLOBALS_2 = $input->{'GLOBALS'};
-        $_GLOBALS1_1 = $input->{'GLOBALS_1'};
-        $_SERVER_1 = $input->{'_SERVER'};
-        $_GET_1 = $input->{'_GET'};
-        $_POST_1 = $input->{'_POST'};
-        $_FILES_1 = $input->{'_FILES'};
-        $_REQUEST_1 = $input->{'_REQUEST'};
-        $_SESSION_1 = $input->{'_SESSION'};
-        $_ENV_1 = $input->{'_ENV'};
-        $_COOKIE_1 = $input->{'_COOKIE'};
-        $_phpErrormsg = $input->{'php_errormsg'};
-        $_httpResponseHeader = $input->{'http_response_header'};
+        $_GLOBALS_2 = $input->{'_GLOBALS'};
+        $_GLOBALS_1 = $input->{'GLOBALS'};
+        $GLOBALS1 = $input->{'GLOBALS_1'};
+        $SERVER = $input->{'_SERVER'};
+        $GET = $input->{'_GET'};
+        $POST = $input->{'_POST'};
+        $FILES = $input->{'_FILES'};
+        $REQUEST = $input->{'_REQUEST'};
+        $SESSION = $input->{'_SESSION'};
+        $ENV = $input->{'_ENV'};
+        $COOKIE = $input->{'_COOKIE'};
+        $phpErrormsg = $input->{'php_errormsg'};
+        $httpResponseHeader = $input->{'http_response_header'};
         $_argc = $input->{'argc'};
         $_argv = $input->{'argv'};
         $_input = $input->{'input'};
@@ -2191,30 +2191,30 @@ class MyClass
         $_obj = $input->{'obj'};
         $includeDefaults = $input->{'includeDefaults'};
         $testObj = isset($input->{'testObj'}) ? MyClassTestObj::fromInput($input->{'testObj'}, $validate, $materializeDefaults) : null;
-        $_fromInput_1 = $input->{'fromInput'};
-        $_toArray_1 = $input->{'toArray'};
-        $_toStdClass_1 = $input->{'toStdClass'};
-        $_validateInput_1 = $input->{'validateInput'};
-        $_schema_1 = $input->{'_schema'};
-        $_schema_2 = $input->{'schema'};
-        $_defaults_1 = $input->{'_defaults'};
-        $_defaults_2 = $input->{'defaults'};
+        $fromInput = $input->{'fromInput'};
+        $toArray = $input->{'toArray'};
+        $toStdClass = $input->{'toStdClass'};
+        $validateInput = $input->{'validateInput'};
+        $schema = $input->{'_schema'};
+        $_schema_1 = $input->{'schema'};
+        $defaults = $input->{'_defaults'};
+        $_defaults_1 = $input->{'defaults'};
         $_providedOptionals_1 = $input->{'_providedOptionals'};
-        $_providedOptionals_2 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
-        $_clone_1 = $input->{'clone'};
-        $_construct_1 = $input->{'__construct'};
-        $_destruct_1 = $input->{'__destruct'};
-        $_get_2 = $input->{'__get'};
-        $_set_1 = $input->{'__set'};
-        $_call_1 = $input->{'__call'};
-        $_isset_1 = $input->{'__isset'};
-        $_unset_1 = $input->{'__unset'};
-        $_sleep_1 = $input->{'__sleep'};
-        $_wakeup_1 = $input->{'__wakeup'};
-        $_toString_1 = $input->{'__toString'};
-        $_invoke_1 = $input->{'__invoke'};
-        $_debugInfo_1 = $input->{'__debugInfo'};
-        $_clone_2 = $input->{'__clone'};
+        $providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
+        $_clone = $input->{'clone'};
+        $construct = $input->{'__construct'};
+        $destruct = $input->{'__destruct'};
+        $get = $input->{'__get'};
+        $set = $input->{'__set'};
+        $call = $input->{'__call'};
+        $isset = $input->{'__isset'};
+        $unset = $input->{'__unset'};
+        $sleep = $input->{'__sleep'};
+        $wakeup = $input->{'__wakeup'};
+        $toString = $input->{'__toString'};
+        $invoke = $input->{'__invoke'};
+        $debugInfo = $input->{'__debugInfo'};
+        $clone = $input->{'__clone'};
         $files = $input->{'files'};
         $_this = $input->{'this'};
         $ensureArgs1 = isset($input->{'ensureArgs1'}) ? match (true) {
@@ -2226,11 +2226,11 @@ class MyClass
         $ensureArgs2 = isset($input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($input->{'ensureArgs2'}, $validate, $materializeDefaults) : null;
         $ensureArgs3 = isset($input->{'ensureArgs3'}) ? array_map(fn (array|object $i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::fromInput($i, $validate, $materializeDefaults), $input->{'ensureArgs3'}) : null;
 
-        $obj = new self($_GLOBALS_1, $_GLOBALS_2, $_GLOBALS1_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_phpErrormsg, $_httpResponseHeader, $_argc, $_argv, $_input, $_obj, $includeDefaults, $_fromInput_1, $_toArray_1, $_toStdClass_1, $_validateInput_1, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone_1, $_construct_1, $_destruct_1, $_get_2, $_set_1, $_call_1, $_isset_1, $_unset_1, $_sleep_1, $_wakeup_1, $_toString_1, $_invoke_1, $_debugInfo_1, $_clone_2, $files, $_this);
+        $obj = new self($_GLOBALS_2, $_GLOBALS_1, $GLOBALS1, $SERVER, $GET, $POST, $FILES, $REQUEST, $SESSION, $ENV, $COOKIE, $phpErrormsg, $httpResponseHeader, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $schema, $_schema_1, $defaults, $_defaults_1, $_providedOptionals_1, $_clone, $construct, $destruct, $get, $set, $call, $isset, $unset, $sleep, $wakeup, $toString, $invoke, $debugInfo, $clone, $files, $_this);
         $obj->validate = $_validate;
         $obj->materializeDefaults = $_materializeDefaults;
         $obj->testObj = $testObj;
-        $obj->_providedOptionals_2 = $_providedOptionals_2;
+        $obj->providedOptionals = $providedOptionals;
         $obj->ensureArgs1 = $ensureArgs1;
         $obj->ensureArgs2 = $ensureArgs2;
         $obj->ensureArgs3 = $ensureArgs3;
@@ -2247,21 +2247,21 @@ class MyClass
     public function toArray(bool $includeDefaults = false): array
     {
         $output = [];
-        $output['_GLOBALS'] = $this->_GLOBALS_1;
-        $output['GLOBALS'] = $this->_GLOBALS_2;
-        $output['GLOBALS_1'] = $this->_GLOBALS1_1;
-        $output['_SERVER'] = $this->_SERVER_1;
-        $output['_GET'] = $this->_GET_1;
-        $output['_POST'] = $this->_POST_1;
-        $output['_FILES'] = $this->_FILES_1;
-        $output['_REQUEST'] = $this->_REQUEST_1;
-        $output['_SESSION'] = $this->_SESSION_1;
-        $output['_ENV'] = $this->_ENV_1;
-        $output['_COOKIE'] = $this->_COOKIE_1;
-        $output['php_errormsg'] = $this->_phpErrormsg;
-        $output['http_response_header'] = $this->_httpResponseHeader;
-        $output['argc'] = $this->_argc;
-        $output['argv'] = $this->_argv;
+        $output['_GLOBALS'] = $this->_GLOBALS;
+        $output['GLOBALS'] = $this->GLOBALS;
+        $output['GLOBALS_1'] = $this->GLOBALS1;
+        $output['_SERVER'] = $this->SERVER;
+        $output['_GET'] = $this->GET;
+        $output['_POST'] = $this->POST;
+        $output['_FILES'] = $this->FILES;
+        $output['_REQUEST'] = $this->REQUEST;
+        $output['_SESSION'] = $this->SESSION;
+        $output['_ENV'] = $this->ENV;
+        $output['_COOKIE'] = $this->COOKIE;
+        $output['php_errormsg'] = $this->phpErrormsg;
+        $output['http_response_header'] = $this->httpResponseHeader;
+        $output['argc'] = $this->argc;
+        $output['argv'] = $this->argv;
         $output['input'] = $this->input;
         if (isset($this->validate)) {
             $output['validate'] = $this->validate;
@@ -2274,32 +2274,32 @@ class MyClass
         if (isset($this->testObj)) {
             $output['testObj'] = ($this->testObj)->toArray($includeDefaults);
         }
-        $output['fromInput'] = $this->_fromInput_1;
-        $output['toArray'] = $this->_toArray_1;
-        $output['toStdClass'] = $this->_toStdClass_1;
-        $output['validateInput'] = $this->_validateInput_1;
-        $output['_schema'] = $this->_schema_1;
-        $output['schema'] = $this->_schema_2;
-        $output['_defaults'] = $this->_defaults_1;
-        $output['defaults'] = $this->_defaults_2;
+        $output['fromInput'] = $this->fromInput;
+        $output['toArray'] = $this->toArray;
+        $output['toStdClass'] = $this->toStdClass;
+        $output['validateInput'] = $this->validateInput;
+        $output['_schema'] = $this->schema;
+        $output['schema'] = $this->_schema_1;
+        $output['_defaults'] = $this->defaults;
+        $output['defaults'] = $this->_defaults_1;
         $output['_providedOptionals'] = $this->_providedOptionals_1;
-        if (isset($this->_providedOptionals_2)) {
-            $output['__providedOptionals'] = $this->_providedOptionals_2;
+        if (isset($this->providedOptionals)) {
+            $output['__providedOptionals'] = $this->providedOptionals;
         }
-        $output['clone'] = $this->_clone_1;
-        $output['__construct'] = $this->_construct_1;
-        $output['__destruct'] = $this->_destruct_1;
-        $output['__get'] = $this->_get_2;
-        $output['__set'] = $this->_set_1;
-        $output['__call'] = $this->_call_1;
-        $output['__isset'] = $this->_isset_1;
-        $output['__unset'] = $this->_unset_1;
-        $output['__sleep'] = $this->_sleep_1;
-        $output['__wakeup'] = $this->_wakeup_1;
-        $output['__toString'] = $this->_toString_1;
-        $output['__invoke'] = $this->_invoke_1;
-        $output['__debugInfo'] = $this->_debugInfo_1;
-        $output['__clone'] = $this->_clone_2;
+        $output['clone'] = $this->_clone;
+        $output['__construct'] = $this->construct;
+        $output['__destruct'] = $this->destruct;
+        $output['__get'] = $this->get;
+        $output['__set'] = $this->set;
+        $output['__call'] = $this->call;
+        $output['__isset'] = $this->isset;
+        $output['__unset'] = $this->unset;
+        $output['__sleep'] = $this->sleep;
+        $output['__wakeup'] = $this->wakeup;
+        $output['__toString'] = $this->toString;
+        $output['__invoke'] = $this->invoke;
+        $output['__debugInfo'] = $this->debugInfo;
+        $output['__clone'] = $this->clone;
         $output['files'] = $this->files;
         $output['this'] = $this->_this;
         if (isset($this->ensureArgs1)) {
@@ -2336,21 +2336,21 @@ class MyClass
     public function toStdClass(bool $includeDefaults = false): \stdClass
     {
         $output = new \stdClass();
-        $output->{'_GLOBALS'} = $this->_GLOBALS_1;
-        $output->{'GLOBALS'} = $this->_GLOBALS_2;
-        $output->{'GLOBALS_1'} = $this->_GLOBALS1_1;
-        $output->{'_SERVER'} = $this->_SERVER_1;
-        $output->{'_GET'} = $this->_GET_1;
-        $output->{'_POST'} = $this->_POST_1;
-        $output->{'_FILES'} = $this->_FILES_1;
-        $output->{'_REQUEST'} = $this->_REQUEST_1;
-        $output->{'_SESSION'} = $this->_SESSION_1;
-        $output->{'_ENV'} = $this->_ENV_1;
-        $output->{'_COOKIE'} = $this->_COOKIE_1;
-        $output->{'php_errormsg'} = $this->_phpErrormsg;
-        $output->{'http_response_header'} = $this->_httpResponseHeader;
-        $output->{'argc'} = $this->_argc;
-        $output->{'argv'} = $this->_argv;
+        $output->{'_GLOBALS'} = $this->_GLOBALS;
+        $output->{'GLOBALS'} = $this->GLOBALS;
+        $output->{'GLOBALS_1'} = $this->GLOBALS1;
+        $output->{'_SERVER'} = $this->SERVER;
+        $output->{'_GET'} = $this->GET;
+        $output->{'_POST'} = $this->POST;
+        $output->{'_FILES'} = $this->FILES;
+        $output->{'_REQUEST'} = $this->REQUEST;
+        $output->{'_SESSION'} = $this->SESSION;
+        $output->{'_ENV'} = $this->ENV;
+        $output->{'_COOKIE'} = $this->COOKIE;
+        $output->{'php_errormsg'} = $this->phpErrormsg;
+        $output->{'http_response_header'} = $this->httpResponseHeader;
+        $output->{'argc'} = $this->argc;
+        $output->{'argv'} = $this->argv;
         $output->{'input'} = $this->input;
         if (isset($this->validate)) {
             $output->{'validate'} = $this->validate;
@@ -2363,32 +2363,32 @@ class MyClass
         if (isset($this->testObj)) {
             $output->{'testObj'} = ($this->testObj)->toStdClass($includeDefaults);
         }
-        $output->{'fromInput'} = $this->_fromInput_1;
-        $output->{'toArray'} = $this->_toArray_1;
-        $output->{'toStdClass'} = $this->_toStdClass_1;
-        $output->{'validateInput'} = $this->_validateInput_1;
-        $output->{'_schema'} = $this->_schema_1;
-        $output->{'schema'} = $this->_schema_2;
-        $output->{'_defaults'} = $this->_defaults_1;
-        $output->{'defaults'} = $this->_defaults_2;
+        $output->{'fromInput'} = $this->fromInput;
+        $output->{'toArray'} = $this->toArray;
+        $output->{'toStdClass'} = $this->toStdClass;
+        $output->{'validateInput'} = $this->validateInput;
+        $output->{'_schema'} = $this->schema;
+        $output->{'schema'} = $this->_schema_1;
+        $output->{'_defaults'} = $this->defaults;
+        $output->{'defaults'} = $this->_defaults_1;
         $output->{'_providedOptionals'} = $this->_providedOptionals_1;
-        if (isset($this->_providedOptionals_2)) {
-            $output->{'__providedOptionals'} = $this->_providedOptionals_2;
+        if (isset($this->providedOptionals)) {
+            $output->{'__providedOptionals'} = $this->providedOptionals;
         }
-        $output->{'clone'} = $this->_clone_1;
-        $output->{'__construct'} = $this->_construct_1;
-        $output->{'__destruct'} = $this->_destruct_1;
-        $output->{'__get'} = $this->_get_2;
-        $output->{'__set'} = $this->_set_1;
-        $output->{'__call'} = $this->_call_1;
-        $output->{'__isset'} = $this->_isset_1;
-        $output->{'__unset'} = $this->_unset_1;
-        $output->{'__sleep'} = $this->_sleep_1;
-        $output->{'__wakeup'} = $this->_wakeup_1;
-        $output->{'__toString'} = $this->_toString_1;
-        $output->{'__invoke'} = $this->_invoke_1;
-        $output->{'__debugInfo'} = $this->_debugInfo_1;
-        $output->{'__clone'} = $this->_clone_2;
+        $output->{'clone'} = $this->_clone;
+        $output->{'__construct'} = $this->construct;
+        $output->{'__destruct'} = $this->destruct;
+        $output->{'__get'} = $this->get;
+        $output->{'__set'} = $this->set;
+        $output->{'__call'} = $this->call;
+        $output->{'__isset'} = $this->isset;
+        $output->{'__unset'} = $this->unset;
+        $output->{'__sleep'} = $this->sleep;
+        $output->{'__wakeup'} = $this->wakeup;
+        $output->{'__toString'} = $this->toString;
+        $output->{'__invoke'} = $this->invoke;
+        $output->{'__debugInfo'} = $this->debugInfo;
+        $output->{'__clone'} = $this->clone;
         $output->{'files'} = $this->files;
         $output->{'this'} = $this->_this;
         if (isset($this->ensureArgs1)) {

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-5.6/MyClass.php
@@ -81,7 +81,7 @@ class MyClass
     /**
      * @return string|null
      */
-    public function getOutbound()
+    public function get_Outbound_1()
     {
         return $this->outbound;
     }
@@ -91,7 +91,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_Outbound($outbound, bool $validate = true)
+    public function with_Outbound_1($outbound, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -110,7 +110,7 @@ class MyClass
     /**
      * @return self
      */
-    public function withoutOutbound()
+    public function without_Outbound_1()
     {
         $clone = clone $this;
         unset($clone->outbound);
@@ -131,7 +131,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with__Outbound($_outbound, bool $validate = true)
+    public function with_Outbound($_outbound, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-7.4/MyClass.php
@@ -83,7 +83,7 @@ class MyClass
     /**
      * @return string|null
      */
-    public function getOutbound(): ?string
+    public function get_Outbound_1(): ?string
     {
         return $this->outbound ?? null;
     }
@@ -93,7 +93,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_Outbound(string $outbound, bool $validate = true): self
+    public function with_Outbound_1(string $outbound, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -112,7 +112,7 @@ class MyClass
     /**
      * @return self
      */
-    public function withoutOutbound(): self
+    public function without_Outbound_1(): self
     {
         $clone = clone $this;
         unset($clone->outbound);
@@ -133,7 +133,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with__Outbound(string $_outbound, bool $validate = true): self
+    public function with_Outbound(string $_outbound, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-8.4/MyClass.php
@@ -83,7 +83,7 @@ class MyClass
     /**
      * @return string|null
      */
-    public function getOutbound(): ?string
+    public function get_Outbound_1(): ?string
     {
         return $this->outbound ?? null;
     }
@@ -93,7 +93,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_Outbound(string $outbound, bool $validate = true): self
+    public function with_Outbound_1(string $outbound, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -112,7 +112,7 @@ class MyClass
     /**
      * @return self
      */
-    public function withoutOutbound(): self
+    public function without_Outbound_1(): self
     {
         $clone = clone $this;
         unset($clone->outbound);
@@ -133,7 +133,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with__Outbound(string $_outbound, bool $validate = true): self
+    public function with_Outbound(string $_outbound, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -294,12 +294,12 @@ class MyClass
     /**
      * @var string
      */
-    private $_GLOBALS_1;
+    private $_GLOBALS;
 
     /**
      * @var string
      */
-    private $_GLOBALS_2;
+    private $GLOBALS;
 
     /**
      * @var string
@@ -309,62 +309,62 @@ class MyClass
     /**
      * @var string
      */
-    private $_SERVER_1;
+    private $_SERVER;
 
     /**
      * @var string
      */
-    private $_GET_1;
+    private $_GET;
 
     /**
      * @var string
      */
-    private $_POST_1;
+    private $_POST;
 
     /**
      * @var string
      */
-    private $_FILES_1;
+    private $_FILES;
 
     /**
      * @var string
      */
-    private $_REQUEST_1;
+    private $_REQUEST;
 
     /**
      * @var string
      */
-    private $_SESSION_1;
+    private $_SESSION;
 
     /**
      * @var string
      */
-    private $_ENV_1;
+    private $_ENV;
 
     /**
      * @var string
      */
-    private $_COOKIE_1;
+    private $_COOKIE;
 
     /**
      * @var string
      */
-    private $_php_errormsg;
+    private $php_errormsg;
 
     /**
      * @var string
      */
-    private $_http_response_header;
+    private $http_response_header;
 
     /**
      * @var string
      */
-    private $_argc;
+    private $argc;
 
     /**
      * @var string
      */
-    private $_argv;
+    private $argv;
 
     /**
      * @var string
@@ -399,22 +399,22 @@ class MyClass
     /**
      * @var string
      */
-    private $_fromInput;
+    private $fromInput;
 
     /**
      * @var string
      */
-    private $_toArray;
+    private $toArray;
 
     /**
      * @var string
      */
-    private $_toStdClass;
+    private $toStdClass;
 
     /**
      * @var string
      */
-    private $_validateInput;
+    private $validateInput;
 
     /**
      * @var string
@@ -424,7 +424,7 @@ class MyClass
     /**
      * @var string
      */
-    private $_schema_2;
+    private $schema;
 
     /**
      * @var string
@@ -434,7 +434,7 @@ class MyClass
     /**
      * @var string
      */
-    private $_defaults_2;
+    private $defaults;
 
     /**
      * @var string
@@ -449,72 +449,72 @@ class MyClass
     /**
      * @var string
      */
-    private $_clone;
+    private $clone;
 
     /**
      * @var string
      */
-    private $__construct_1;
+    private $__construct;
 
     /**
      * @var string
      */
-    private $__destruct_1;
+    private $__destruct;
 
     /**
      * @var string
      */
-    private $__get_1;
+    private $__get;
 
     /**
      * @var string
      */
-    private $__set_1;
+    private $__set;
 
     /**
      * @var string
      */
-    private $__call_1;
+    private $__call;
 
     /**
      * @var string
      */
-    private $__isset_1;
+    private $__isset;
 
     /**
      * @var string
      */
-    private $__unset_1;
+    private $__unset;
 
     /**
      * @var string
      */
-    private $__sleep_1;
+    private $__sleep;
 
     /**
      * @var string
      */
-    private $__wakeup_1;
+    private $__wakeup;
 
     /**
      * @var string
      */
-    private $__toString_1;
+    private $__toString;
 
     /**
      * @var string
      */
-    private $__invoke_1;
+    private $__invoke;
 
     /**
      * @var string
      */
-    private $__debugInfo_1;
+    private $__debugInfo;
 
     /**
      * @var string
      */
-    private $__clone_1;
+    private $__clone;
 
     /**
      * @var string
@@ -542,8 +542,8 @@ class MyClass
     private $ensureArgs3 = null;
 
     /**
-     * @param string $_GLOBALS_1
      * @param string $_GLOBALS_2
+     * @param string $_GLOBALS_1
      * @param string $GLOBALS_1
      * @param string $_SERVER_1
      * @param string $_GET_1
@@ -557,78 +557,78 @@ class MyClass
      * @param string $_http_response_header
      * @param string $_argc
      * @param string $_argv
-     * @param string $input
-     * @param string $obj
+     * @param string $_input
+     * @param string $_obj
      * @param string $includeDefaults
-     * @param string $_fromInput
-     * @param string $_toArray
-     * @param string $_toStdClass
-     * @param string $_validateInput
+     * @param string $fromInput
+     * @param string $toArray
+     * @param string $toStdClass
+     * @param string $validateInput
      * @param string $_schema_1
-     * @param string $_schema_2
+     * @param string $schema
      * @param string $_defaults_1
-     * @param string $_defaults_2
+     * @param string $defaults
      * @param string $_providedOptionals_1
-     * @param string $_clone
-     * @param string $__construct_1
-     * @param string $__destruct_1
-     * @param string $__get_1
-     * @param string $__set_1
-     * @param string $__call_1
-     * @param string $__isset_1
-     * @param string $__unset_1
-     * @param string $__sleep_1
-     * @param string $__wakeup_1
-     * @param string $__toString_1
-     * @param string $__invoke_1
-     * @param string $__debugInfo_1
-     * @param string $__clone_1
+     * @param string $clone
+     * @param string $__construct
+     * @param string $__destruct
+     * @param string $__get
+     * @param string $__set
+     * @param string $__call
+     * @param string $__isset
+     * @param string $__unset
+     * @param string $__sleep
+     * @param string $__wakeup
+     * @param string $__toString
+     * @param string $__invoke
+     * @param string $__debugInfo
+     * @param string $__clone
      * @param string $files
      * @param string $_this
      */
-    public function __construct($_GLOBALS_1, $_GLOBALS_2, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $input, $obj, $includeDefaults, $_fromInput, $_toArray, $_toStdClass, $_validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone, $__construct_1, $__destruct_1, $__get_1, $__set_1, $__call_1, $__isset_1, $__unset_1, $__sleep_1, $__wakeup_1, $__toString_1, $__invoke_1, $__debugInfo_1, $__clone_1, $files, $_this)
+    public function __construct($_GLOBALS_2, $_GLOBALS_1, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $_schema_1, $schema, $_defaults_1, $defaults, $_providedOptionals_1, $clone, $__construct, $__destruct, $__get, $__set, $__call, $__isset, $__unset, $__sleep, $__wakeup, $__toString, $__invoke, $__debugInfo, $__clone, $files, $_this)
     {
-        $this->_GLOBALS_1 = $_GLOBALS_1;
-        $this->_GLOBALS_2 = $_GLOBALS_2;
+        $this->_GLOBALS = $_GLOBALS_2;
+        $this->GLOBALS = $_GLOBALS_1;
         $this->GLOBALS_1 = $GLOBALS_1;
-        $this->_SERVER_1 = $_SERVER_1;
-        $this->_GET_1 = $_GET_1;
-        $this->_POST_1 = $_POST_1;
-        $this->_FILES_1 = $_FILES_1;
-        $this->_REQUEST_1 = $_REQUEST_1;
-        $this->_SESSION_1 = $_SESSION_1;
-        $this->_ENV_1 = $_ENV_1;
-        $this->_COOKIE_1 = $_COOKIE_1;
-        $this->_php_errormsg = $_php_errormsg;
-        $this->_http_response_header = $_http_response_header;
-        $this->_argc = $_argc;
-        $this->_argv = $_argv;
-        $this->input = $input;
-        $this->obj = $obj;
+        $this->_SERVER = $_SERVER_1;
+        $this->_GET = $_GET_1;
+        $this->_POST = $_POST_1;
+        $this->_FILES = $_FILES_1;
+        $this->_REQUEST = $_REQUEST_1;
+        $this->_SESSION = $_SESSION_1;
+        $this->_ENV = $_ENV_1;
+        $this->_COOKIE = $_COOKIE_1;
+        $this->php_errormsg = $_php_errormsg;
+        $this->http_response_header = $_http_response_header;
+        $this->argc = $_argc;
+        $this->argv = $_argv;
+        $this->input = $_input;
+        $this->obj = $_obj;
         $this->includeDefaults = $includeDefaults;
-        $this->_fromInput = $_fromInput;
-        $this->_toArray = $_toArray;
-        $this->_toStdClass = $_toStdClass;
-        $this->_validateInput = $_validateInput;
+        $this->fromInput = $fromInput;
+        $this->toArray = $toArray;
+        $this->toStdClass = $toStdClass;
+        $this->validateInput = $validateInput;
         $this->_schema_1 = $_schema_1;
-        $this->_schema_2 = $_schema_2;
+        $this->schema = $schema;
         $this->_defaults_1 = $_defaults_1;
-        $this->_defaults_2 = $_defaults_2;
+        $this->defaults = $defaults;
         $this->_providedOptionals_1 = $_providedOptionals_1;
-        $this->_clone = $_clone;
-        $this->__construct_1 = $__construct_1;
-        $this->__destruct_1 = $__destruct_1;
-        $this->__get_1 = $__get_1;
-        $this->__set_1 = $__set_1;
-        $this->__call_1 = $__call_1;
-        $this->__isset_1 = $__isset_1;
-        $this->__unset_1 = $__unset_1;
-        $this->__sleep_1 = $__sleep_1;
-        $this->__wakeup_1 = $__wakeup_1;
-        $this->__toString_1 = $__toString_1;
-        $this->__invoke_1 = $__invoke_1;
-        $this->__debugInfo_1 = $__debugInfo_1;
-        $this->__clone_1 = $__clone_1;
+        $this->clone = $clone;
+        $this->__construct = $__construct;
+        $this->__destruct = $__destruct;
+        $this->__get = $__get;
+        $this->__set = $__set;
+        $this->__call = $__call;
+        $this->__isset = $__isset;
+        $this->__unset = $__unset;
+        $this->__sleep = $__sleep;
+        $this->__wakeup = $__wakeup;
+        $this->__toString = $__toString;
+        $this->__invoke = $__invoke;
+        $this->__debugInfo = $__debugInfo;
+        $this->__clone = $__clone;
         $this->files = $files;
         $this->_this = $_this;
     }
@@ -636,38 +636,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_GLOBALS1()
+    public function get_GLOBALS()
     {
-        return $this->_GLOBALS_1;
-    }
-
-    /**
-     * @param string $_GLOBALS_1
-     * @return self
-     * @param bool $validate
-     */
-    public function with_GLOBALS1($_GLOBALS_1, bool $validate = true)
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_1, self::$_schema['properties']['_GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->_GLOBALS_1 = $_GLOBALS_1;
-
-        return $clone;
-    }
-
-    /**
-     * @return string
-     */
-    public function get_GLOBALS2()
-    {
-        return $this->_GLOBALS_2;
+        return $this->_GLOBALS;
     }
 
     /**
@@ -675,18 +646,47 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_GLOBALS2($_GLOBALS_2, bool $validate = true)
+    public function with_GLOBALS($_GLOBALS_2, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_2, self::$_schema['properties']['GLOBALS']);
+            $validator->validate($_GLOBALS_2, self::$_schema['properties']['_GLOBALS']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_GLOBALS_2 = $_GLOBALS_2;
+        $clone->_GLOBALS = $_GLOBALS_2;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGLOBALS()
+    {
+        return $this->GLOBALS;
+    }
+
+    /**
+     * @param string $_GLOBALS_1
+     * @return self
+     * @param bool $validate
+     */
+    public function withGLOBALS($_GLOBALS_1, bool $validate = true)
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($_GLOBALS_1, self::$_schema['properties']['GLOBALS']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->GLOBALS = $_GLOBALS_1;
 
         return $clone;
     }
@@ -723,9 +723,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_SERVER1()
+    public function get_SERVER()
     {
-        return $this->_SERVER_1;
+        return $this->_SERVER;
     }
 
     /**
@@ -733,7 +733,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_SERVER1($_SERVER_1, bool $validate = true)
+    public function with_SERVER($_SERVER_1, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -744,7 +744,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_SERVER_1 = $_SERVER_1;
+        $clone->_SERVER = $_SERVER_1;
 
         return $clone;
     }
@@ -752,9 +752,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_GET1()
+    public function get_GET()
     {
-        return $this->_GET_1;
+        return $this->_GET;
     }
 
     /**
@@ -762,7 +762,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_GET1($_GET_1, bool $validate = true)
+    public function with_GET($_GET_1, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -773,7 +773,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_GET_1 = $_GET_1;
+        $clone->_GET = $_GET_1;
 
         return $clone;
     }
@@ -781,9 +781,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_POST1()
+    public function get_POST()
     {
-        return $this->_POST_1;
+        return $this->_POST;
     }
 
     /**
@@ -791,7 +791,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_POST1($_POST_1, bool $validate = true)
+    public function with_POST($_POST_1, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -802,7 +802,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_POST_1 = $_POST_1;
+        $clone->_POST = $_POST_1;
 
         return $clone;
     }
@@ -810,9 +810,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_FILES1()
+    public function get_FILES()
     {
-        return $this->_FILES_1;
+        return $this->_FILES;
     }
 
     /**
@@ -820,7 +820,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_FILES1($_FILES_1, bool $validate = true)
+    public function with_FILES($_FILES_1, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -831,7 +831,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_FILES_1 = $_FILES_1;
+        $clone->_FILES = $_FILES_1;
 
         return $clone;
     }
@@ -839,9 +839,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_REQUEST1()
+    public function get_REQUEST()
     {
-        return $this->_REQUEST_1;
+        return $this->_REQUEST;
     }
 
     /**
@@ -849,7 +849,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_REQUEST1($_REQUEST_1, bool $validate = true)
+    public function with_REQUEST($_REQUEST_1, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -860,7 +860,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_REQUEST_1 = $_REQUEST_1;
+        $clone->_REQUEST = $_REQUEST_1;
 
         return $clone;
     }
@@ -868,9 +868,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_SESSION1()
+    public function get_SESSION()
     {
-        return $this->_SESSION_1;
+        return $this->_SESSION;
     }
 
     /**
@@ -878,7 +878,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_SESSION1($_SESSION_1, bool $validate = true)
+    public function with_SESSION($_SESSION_1, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -889,7 +889,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_SESSION_1 = $_SESSION_1;
+        $clone->_SESSION = $_SESSION_1;
 
         return $clone;
     }
@@ -897,9 +897,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_ENV1()
+    public function get_ENV()
     {
-        return $this->_ENV_1;
+        return $this->_ENV;
     }
 
     /**
@@ -907,7 +907,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_ENV1($_ENV_1, bool $validate = true)
+    public function with_ENV($_ENV_1, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -918,7 +918,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_ENV_1 = $_ENV_1;
+        $clone->_ENV = $_ENV_1;
 
         return $clone;
     }
@@ -926,9 +926,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_COOKIE1()
+    public function get_COOKIE()
     {
-        return $this->_COOKIE_1;
+        return $this->_COOKIE;
     }
 
     /**
@@ -936,7 +936,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_COOKIE1($_COOKIE_1, bool $validate = true)
+    public function with_COOKIE($_COOKIE_1, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -947,7 +947,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_COOKIE_1 = $_COOKIE_1;
+        $clone->_COOKIE = $_COOKIE_1;
 
         return $clone;
     }
@@ -955,9 +955,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_PhpErrormsg()
+    public function getPhpErrormsg()
     {
-        return $this->_php_errormsg;
+        return $this->php_errormsg;
     }
 
     /**
@@ -965,7 +965,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_PhpErrormsg($_php_errormsg, bool $validate = true)
+    public function withPhpErrormsg($_php_errormsg, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -976,7 +976,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_php_errormsg = $_php_errormsg;
+        $clone->php_errormsg = $_php_errormsg;
 
         return $clone;
     }
@@ -984,9 +984,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_HttpResponseHeader()
+    public function getHttpResponseHeader()
     {
-        return $this->_http_response_header;
+        return $this->http_response_header;
     }
 
     /**
@@ -994,7 +994,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_HttpResponseHeader($_http_response_header, bool $validate = true)
+    public function withHttpResponseHeader($_http_response_header, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1005,7 +1005,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_http_response_header = $_http_response_header;
+        $clone->http_response_header = $_http_response_header;
 
         return $clone;
     }
@@ -1013,9 +1013,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Argc()
+    public function getArgc()
     {
-        return $this->_argc;
+        return $this->argc;
     }
 
     /**
@@ -1023,7 +1023,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_Argc($_argc, bool $validate = true)
+    public function withArgc($_argc, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1034,7 +1034,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_argc = $_argc;
+        $clone->argc = $_argc;
 
         return $clone;
     }
@@ -1042,9 +1042,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Argv()
+    public function getArgv()
     {
-        return $this->_argv;
+        return $this->argv;
     }
 
     /**
@@ -1052,7 +1052,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_Argv($_argv, bool $validate = true)
+    public function withArgv($_argv, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1063,7 +1063,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_argv = $_argv;
+        $clone->argv = $_argv;
 
         return $clone;
     }
@@ -1077,22 +1077,22 @@ class MyClass
     }
 
     /**
-     * @param string $input
+     * @param string $_input
      * @return self
      * @param bool $validate
      */
-    public function withInput($input, bool $validate = true)
+    public function withInput($_input, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($input, self::$_schema['properties']['input']);
+            $validator->validate($_input, self::$_schema['properties']['input']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->input = $input;
+        $clone->input = $_input;
 
         return $clone;
     }
@@ -1106,22 +1106,22 @@ class MyClass
     }
 
     /**
-     * @param string $validate
+     * @param string $_validate
      * @return self
      * @param bool $validate
      */
-    public function withValidate(bool $validate = true)
+    public function withValidate($_validate, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($validate, self::$_schema['properties']['validate']);
+            $validator->validate($_validate, self::$_schema['properties']['validate']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->validate = $validate;
+        $clone->validate = $_validate;
 
         return $clone;
     }
@@ -1146,22 +1146,22 @@ class MyClass
     }
 
     /**
-     * @param string $materializeDefaults
+     * @param string $_materializeDefaults
      * @return self
      * @param bool $validate
      */
-    public function withMaterializeDefaults($materializeDefaults, bool $validate = true)
+    public function withMaterializeDefaults($_materializeDefaults, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($materializeDefaults, self::$_schema['properties']['materializeDefaults']);
+            $validator->validate($_materializeDefaults, self::$_schema['properties']['materializeDefaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->materializeDefaults = $materializeDefaults;
+        $clone->materializeDefaults = $_materializeDefaults;
         $clone->_providedOptionals['materializeDefaults'] = true;
 
         return $clone;
@@ -1188,22 +1188,22 @@ class MyClass
     }
 
     /**
-     * @param string $obj
+     * @param string $_obj
      * @return self
      * @param bool $validate
      */
-    public function withObj($obj, bool $validate = true)
+    public function withObj($_obj, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($obj, self::$_schema['properties']['obj']);
+            $validator->validate($_obj, self::$_schema['properties']['obj']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->obj = $obj;
+        $clone->obj = $_obj;
 
         return $clone;
     }
@@ -1271,28 +1271,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_FromInput()
+    public function getFromInput()
     {
-        return $this->_fromInput;
+        return $this->fromInput;
     }
 
     /**
-     * @param string $_fromInput
+     * @param string $fromInput
      * @return self
      * @param bool $validate
      */
-    public function with_FromInput($_fromInput, bool $validate = true)
+    public function withFromInput($fromInput, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_fromInput, self::$_schema['properties']['fromInput']);
+            $validator->validate($fromInput, self::$_schema['properties']['fromInput']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_fromInput = $_fromInput;
+        $clone->fromInput = $fromInput;
 
         return $clone;
     }
@@ -1300,28 +1300,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_ToArray()
+    public function getToArray()
     {
-        return $this->_toArray;
+        return $this->toArray;
     }
 
     /**
-     * @param string $_toArray
+     * @param string $toArray
      * @return self
      * @param bool $validate
      */
-    public function with_ToArray($_toArray, bool $validate = true)
+    public function withToArray($toArray, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toArray, self::$_schema['properties']['toArray']);
+            $validator->validate($toArray, self::$_schema['properties']['toArray']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toArray = $_toArray;
+        $clone->toArray = $toArray;
 
         return $clone;
     }
@@ -1329,28 +1329,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_ToStdClass()
+    public function getToStdClass()
     {
-        return $this->_toStdClass;
+        return $this->toStdClass;
     }
 
     /**
-     * @param string $_toStdClass
+     * @param string $toStdClass
      * @return self
      * @param bool $validate
      */
-    public function with_ToStdClass($_toStdClass, bool $validate = true)
+    public function withToStdClass($toStdClass, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toStdClass, self::$_schema['properties']['toStdClass']);
+            $validator->validate($toStdClass, self::$_schema['properties']['toStdClass']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toStdClass = $_toStdClass;
+        $clone->toStdClass = $toStdClass;
 
         return $clone;
     }
@@ -1358,28 +1358,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_ValidateInput()
+    public function getValidateInput()
     {
-        return $this->_validateInput;
+        return $this->validateInput;
     }
 
     /**
-     * @param string $_validateInput
+     * @param string $validateInput
      * @return self
      * @param bool $validate
      */
-    public function with_ValidateInput($_validateInput, bool $validate = true)
+    public function withValidateInput($validateInput, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_validateInput, self::$_schema['properties']['validateInput']);
+            $validator->validate($validateInput, self::$_schema['properties']['validateInput']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_validateInput = $_validateInput;
+        $clone->validateInput = $validateInput;
 
         return $clone;
     }
@@ -1416,28 +1416,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Schema2()
+    public function getSchema()
     {
-        return $this->_schema_2;
+        return $this->schema;
     }
 
     /**
-     * @param string $_schema_2
+     * @param string $schema
      * @return self
      * @param bool $validate
      */
-    public function with_Schema2($_schema_2, bool $validate = true)
+    public function withSchema($schema, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_2, self::$_schema['properties']['schema']);
+            $validator->validate($schema, self::$_schema['properties']['schema']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_schema_2 = $_schema_2;
+        $clone->schema = $schema;
 
         return $clone;
     }
@@ -1474,28 +1474,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Defaults2()
+    public function getDefaults()
     {
-        return $this->_defaults_2;
+        return $this->defaults;
     }
 
     /**
-     * @param string $_defaults_2
+     * @param string $defaults
      * @return self
      * @param bool $validate
      */
-    public function with_Defaults2($_defaults_2, bool $validate = true)
+    public function withDefaults($defaults, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_2, self::$_schema['properties']['defaults']);
+            $validator->validate($defaults, self::$_schema['properties']['defaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_defaults_2 = $_defaults_2;
+        $clone->defaults = $defaults;
 
         return $clone;
     }
@@ -1538,22 +1538,22 @@ class MyClass
     }
 
     /**
-     * @param string $__providedOptionals
+     * @param string $__providedOptionals_1
      * @return self
      * @param bool $validate
      */
-    public function with__ProvidedOptionals($__providedOptionals, bool $validate = true)
+    public function with__ProvidedOptionals($__providedOptionals_1, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__providedOptionals, self::$_schema['properties']['__providedOptionals']);
+            $validator->validate($__providedOptionals_1, self::$_schema['properties']['__providedOptionals']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__providedOptionals = $__providedOptionals;
+        $clone->__providedOptionals = $__providedOptionals_1;
 
         return $clone;
     }
@@ -1572,28 +1572,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Clone()
+    public function getClone()
     {
-        return $this->_clone;
+        return $this->clone;
     }
 
     /**
-     * @param string $_clone
+     * @param string $clone
      * @return self
      * @param bool $validate
      */
-    public function with_Clone($_clone, bool $validate = true)
+    public function withClone($clone, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone, self::$_schema['properties']['clone']);
+            $validator->validate($clone, self::$_schema['properties']['clone']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_clone = $_clone;
+        $clone->clone = $clone;
 
         return $clone;
     }
@@ -1601,28 +1601,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Construct1()
+    public function get__Construct()
     {
-        return $this->__construct_1;
+        return $this->__construct;
     }
 
     /**
-     * @param string $__construct_1
+     * @param string $__construct
      * @return self
      * @param bool $validate
      */
-    public function with__Construct1($__construct_1, bool $validate = true)
+    public function with__Construct($__construct, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__construct_1, self::$_schema['properties']['__construct']);
+            $validator->validate($__construct, self::$_schema['properties']['__construct']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__construct_1 = $__construct_1;
+        $clone->__construct = $__construct;
 
         return $clone;
     }
@@ -1630,28 +1630,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Destruct1()
+    public function get__Destruct()
     {
-        return $this->__destruct_1;
+        return $this->__destruct;
     }
 
     /**
-     * @param string $__destruct_1
+     * @param string $__destruct
      * @return self
      * @param bool $validate
      */
-    public function with__Destruct1($__destruct_1, bool $validate = true)
+    public function with__Destruct($__destruct, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__destruct_1, self::$_schema['properties']['__destruct']);
+            $validator->validate($__destruct, self::$_schema['properties']['__destruct']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__destruct_1 = $__destruct_1;
+        $clone->__destruct = $__destruct;
 
         return $clone;
     }
@@ -1659,28 +1659,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Get1()
+    public function get__Get()
     {
-        return $this->__get_1;
+        return $this->__get;
     }
 
     /**
-     * @param string $__get_1
+     * @param string $__get
      * @return self
      * @param bool $validate
      */
-    public function with__Get1($__get_1, bool $validate = true)
+    public function with__Get($__get, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__get_1, self::$_schema['properties']['__get']);
+            $validator->validate($__get, self::$_schema['properties']['__get']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__get_1 = $__get_1;
+        $clone->__get = $__get;
 
         return $clone;
     }
@@ -1688,28 +1688,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Set1()
+    public function get__Set()
     {
-        return $this->__set_1;
+        return $this->__set;
     }
 
     /**
-     * @param string $__set_1
+     * @param string $__set
      * @return self
      * @param bool $validate
      */
-    public function with__Set1($__set_1, bool $validate = true)
+    public function with__Set($__set, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__set_1, self::$_schema['properties']['__set']);
+            $validator->validate($__set, self::$_schema['properties']['__set']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__set_1 = $__set_1;
+        $clone->__set = $__set;
 
         return $clone;
     }
@@ -1717,28 +1717,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Call1()
+    public function get__Call()
     {
-        return $this->__call_1;
+        return $this->__call;
     }
 
     /**
-     * @param string $__call_1
+     * @param string $__call
      * @return self
      * @param bool $validate
      */
-    public function with__Call1($__call_1, bool $validate = true)
+    public function with__Call($__call, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__call_1, self::$_schema['properties']['__call']);
+            $validator->validate($__call, self::$_schema['properties']['__call']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__call_1 = $__call_1;
+        $clone->__call = $__call;
 
         return $clone;
     }
@@ -1746,28 +1746,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Isset1()
+    public function get__Isset()
     {
-        return $this->__isset_1;
+        return $this->__isset;
     }
 
     /**
-     * @param string $__isset_1
+     * @param string $__isset
      * @return self
      * @param bool $validate
      */
-    public function with__Isset1($__isset_1, bool $validate = true)
+    public function with__Isset($__isset, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__isset_1, self::$_schema['properties']['__isset']);
+            $validator->validate($__isset, self::$_schema['properties']['__isset']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__isset_1 = $__isset_1;
+        $clone->__isset = $__isset;
 
         return $clone;
     }
@@ -1775,28 +1775,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Unset1()
+    public function get__Unset()
     {
-        return $this->__unset_1;
+        return $this->__unset;
     }
 
     /**
-     * @param string $__unset_1
+     * @param string $__unset
      * @return self
      * @param bool $validate
      */
-    public function with__Unset1($__unset_1, bool $validate = true)
+    public function with__Unset($__unset, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__unset_1, self::$_schema['properties']['__unset']);
+            $validator->validate($__unset, self::$_schema['properties']['__unset']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__unset_1 = $__unset_1;
+        $clone->__unset = $__unset;
 
         return $clone;
     }
@@ -1804,28 +1804,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Sleep1()
+    public function get__Sleep()
     {
-        return $this->__sleep_1;
+        return $this->__sleep;
     }
 
     /**
-     * @param string $__sleep_1
+     * @param string $__sleep
      * @return self
      * @param bool $validate
      */
-    public function with__Sleep1($__sleep_1, bool $validate = true)
+    public function with__Sleep($__sleep, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__sleep_1, self::$_schema['properties']['__sleep']);
+            $validator->validate($__sleep, self::$_schema['properties']['__sleep']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__sleep_1 = $__sleep_1;
+        $clone->__sleep = $__sleep;
 
         return $clone;
     }
@@ -1833,28 +1833,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Wakeup1()
+    public function get__Wakeup()
     {
-        return $this->__wakeup_1;
+        return $this->__wakeup;
     }
 
     /**
-     * @param string $__wakeup_1
+     * @param string $__wakeup
      * @return self
      * @param bool $validate
      */
-    public function with__Wakeup1($__wakeup_1, bool $validate = true)
+    public function with__Wakeup($__wakeup, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__wakeup_1, self::$_schema['properties']['__wakeup']);
+            $validator->validate($__wakeup, self::$_schema['properties']['__wakeup']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__wakeup_1 = $__wakeup_1;
+        $clone->__wakeup = $__wakeup;
 
         return $clone;
     }
@@ -1862,28 +1862,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__ToString1()
+    public function get__ToString()
     {
-        return $this->__toString_1;
+        return $this->__toString;
     }
 
     /**
-     * @param string $__toString_1
+     * @param string $__toString
      * @return self
      * @param bool $validate
      */
-    public function with__ToString1($__toString_1, bool $validate = true)
+    public function with__ToString($__toString, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__toString_1, self::$_schema['properties']['__toString']);
+            $validator->validate($__toString, self::$_schema['properties']['__toString']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__toString_1 = $__toString_1;
+        $clone->__toString = $__toString;
 
         return $clone;
     }
@@ -1891,28 +1891,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Invoke1()
+    public function get__Invoke()
     {
-        return $this->__invoke_1;
+        return $this->__invoke;
     }
 
     /**
-     * @param string $__invoke_1
+     * @param string $__invoke
      * @return self
      * @param bool $validate
      */
-    public function with__Invoke1($__invoke_1, bool $validate = true)
+    public function with__Invoke($__invoke, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__invoke_1, self::$_schema['properties']['__invoke']);
+            $validator->validate($__invoke, self::$_schema['properties']['__invoke']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__invoke_1 = $__invoke_1;
+        $clone->__invoke = $__invoke;
 
         return $clone;
     }
@@ -1920,28 +1920,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__DebugInfo1()
+    public function get__DebugInfo()
     {
-        return $this->__debugInfo_1;
+        return $this->__debugInfo;
     }
 
     /**
-     * @param string $__debugInfo_1
+     * @param string $__debugInfo
      * @return self
      * @param bool $validate
      */
-    public function with__DebugInfo1($__debugInfo_1, bool $validate = true)
+    public function with__DebugInfo($__debugInfo, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__debugInfo_1, self::$_schema['properties']['__debugInfo']);
+            $validator->validate($__debugInfo, self::$_schema['properties']['__debugInfo']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__debugInfo_1 = $__debugInfo_1;
+        $clone->__debugInfo = $__debugInfo;
 
         return $clone;
     }
@@ -1949,28 +1949,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Clone1()
+    public function get__Clone()
     {
-        return $this->__clone_1;
+        return $this->__clone;
     }
 
     /**
-     * @param string $__clone_1
+     * @param string $__clone
      * @return self
      * @param bool $validate
      */
-    public function with__Clone1($__clone_1, bool $validate = true)
+    public function with__Clone($__clone, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__clone_1, self::$_schema['properties']['__clone']);
+            $validator->validate($__clone, self::$_schema['properties']['__clone']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__clone_1 = $__clone_1;
+        $clone->__clone = $__clone;
 
         return $clone;
     }
@@ -2171,8 +2171,8 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $_GLOBALS_1 = $input->{'_GLOBALS'};
-        $_GLOBALS_2 = $input->{'GLOBALS'};
+        $_GLOBALS_2 = $input->{'_GLOBALS'};
+        $_GLOBALS_1 = $input->{'GLOBALS'};
         $GLOBALS_1 = $input->{'GLOBALS_1'};
         $_SERVER_1 = $input->{'_SERVER'};
         $_GET_1 = $input->{'_GET'};
@@ -2195,37 +2195,37 @@ class MyClass
         $_obj = $input->{'obj'};
         $includeDefaults = $input->{'includeDefaults'};
         $testObj = isset($input->{'testObj'}) ? MyClassTestObj::fromInput($input->{'testObj'}, $validate, $materializeDefaults) : null;
-        $_fromInput = $input->{'fromInput'};
-        $_toArray = $input->{'toArray'};
-        $_toStdClass = $input->{'toStdClass'};
-        $_validateInput = $input->{'validateInput'};
+        $fromInput = $input->{'fromInput'};
+        $toArray = $input->{'toArray'};
+        $toStdClass = $input->{'toStdClass'};
+        $validateInput = $input->{'validateInput'};
         $_schema_1 = $input->{'_schema'};
-        $_schema_2 = $input->{'schema'};
+        $schema = $input->{'schema'};
         $_defaults_1 = $input->{'_defaults'};
-        $_defaults_2 = $input->{'defaults'};
+        $defaults = $input->{'defaults'};
         $_providedOptionals_1 = $input->{'_providedOptionals'};
         $__providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
-        $_clone = $input->{'clone'};
-        $__construct_1 = $input->{'__construct'};
-        $__destruct_1 = $input->{'__destruct'};
-        $__get_1 = $input->{'__get'};
-        $__set_1 = $input->{'__set'};
-        $__call_1 = $input->{'__call'};
-        $__isset_1 = $input->{'__isset'};
-        $__unset_1 = $input->{'__unset'};
-        $__sleep_1 = $input->{'__sleep'};
-        $__wakeup_1 = $input->{'__wakeup'};
-        $__toString_1 = $input->{'__toString'};
-        $__invoke_1 = $input->{'__invoke'};
-        $__debugInfo_1 = $input->{'__debugInfo'};
-        $__clone_1 = $input->{'__clone'};
+        $clone = $input->{'clone'};
+        $__construct = $input->{'__construct'};
+        $__destruct = $input->{'__destruct'};
+        $__get = $input->{'__get'};
+        $__set = $input->{'__set'};
+        $__call = $input->{'__call'};
+        $__isset = $input->{'__isset'};
+        $__unset = $input->{'__unset'};
+        $__sleep = $input->{'__sleep'};
+        $__wakeup = $input->{'__wakeup'};
+        $__toString = $input->{'__toString'};
+        $__invoke = $input->{'__invoke'};
+        $__debugInfo = $input->{'__debugInfo'};
+        $__clone = $input->{'__clone'};
         $files = $input->{'files'};
         $_this = $input->{'this'};
         $ensureArgs1 = isset($input->{'ensureArgs1'}) ? ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : (((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (null)))))) : null;
         $ensureArgs2 = isset($input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($input->{'ensureArgs2'}, $validate, $materializeDefaults) : null;
         $ensureArgs3 = isset($input->{'ensureArgs3'}) ? array_map(function($i) use ($validate, $materializeDefaults) { return MyClassEnsureArgs3Item::fromInput($i, $validate, $materializeDefaults); }, $input->{'ensureArgs3'}) : null;
 
-        $obj = new self($_GLOBALS_1, $_GLOBALS_2, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $_input, $_obj, $includeDefaults, $_fromInput, $_toArray, $_toStdClass, $_validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone, $__construct_1, $__destruct_1, $__get_1, $__set_1, $__call_1, $__isset_1, $__unset_1, $__sleep_1, $__wakeup_1, $__toString_1, $__invoke_1, $__debugInfo_1, $__clone_1, $files, $_this);
+        $obj = new self($_GLOBALS_2, $_GLOBALS_1, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $_schema_1, $schema, $_defaults_1, $defaults, $_providedOptionals_1, $clone, $__construct, $__destruct, $__get, $__set, $__call, $__isset, $__unset, $__sleep, $__wakeup, $__toString, $__invoke, $__debugInfo, $__clone, $files, $_this);
         $obj->validate = $_validate;
         $obj->materializeDefaults = $_materializeDefaults;
         $obj->testObj = $testObj;
@@ -2246,21 +2246,21 @@ class MyClass
     public function toArray(bool $includeDefaults = false)
     {
         $output = [];
-        $output['_GLOBALS'] = $this->_GLOBALS_1;
-        $output['GLOBALS'] = $this->_GLOBALS_2;
+        $output['_GLOBALS'] = $this->_GLOBALS;
+        $output['GLOBALS'] = $this->GLOBALS;
         $output['GLOBALS_1'] = $this->GLOBALS_1;
-        $output['_SERVER'] = $this->_SERVER_1;
-        $output['_GET'] = $this->_GET_1;
-        $output['_POST'] = $this->_POST_1;
-        $output['_FILES'] = $this->_FILES_1;
-        $output['_REQUEST'] = $this->_REQUEST_1;
-        $output['_SESSION'] = $this->_SESSION_1;
-        $output['_ENV'] = $this->_ENV_1;
-        $output['_COOKIE'] = $this->_COOKIE_1;
-        $output['php_errormsg'] = $this->_php_errormsg;
-        $output['http_response_header'] = $this->_http_response_header;
-        $output['argc'] = $this->_argc;
-        $output['argv'] = $this->_argv;
+        $output['_SERVER'] = $this->_SERVER;
+        $output['_GET'] = $this->_GET;
+        $output['_POST'] = $this->_POST;
+        $output['_FILES'] = $this->_FILES;
+        $output['_REQUEST'] = $this->_REQUEST;
+        $output['_SESSION'] = $this->_SESSION;
+        $output['_ENV'] = $this->_ENV;
+        $output['_COOKIE'] = $this->_COOKIE;
+        $output['php_errormsg'] = $this->php_errormsg;
+        $output['http_response_header'] = $this->http_response_header;
+        $output['argc'] = $this->argc;
+        $output['argv'] = $this->argv;
         $output['input'] = $this->input;
         if (isset($this->validate)) {
             $output['validate'] = $this->validate;
@@ -2273,32 +2273,32 @@ class MyClass
         if (isset($this->testObj)) {
             $output['testObj'] = ($this->testObj)->toArray($includeDefaults);
         }
-        $output['fromInput'] = $this->_fromInput;
-        $output['toArray'] = $this->_toArray;
-        $output['toStdClass'] = $this->_toStdClass;
-        $output['validateInput'] = $this->_validateInput;
+        $output['fromInput'] = $this->fromInput;
+        $output['toArray'] = $this->toArray;
+        $output['toStdClass'] = $this->toStdClass;
+        $output['validateInput'] = $this->validateInput;
         $output['_schema'] = $this->_schema_1;
-        $output['schema'] = $this->_schema_2;
+        $output['schema'] = $this->schema;
         $output['_defaults'] = $this->_defaults_1;
-        $output['defaults'] = $this->_defaults_2;
+        $output['defaults'] = $this->defaults;
         $output['_providedOptionals'] = $this->_providedOptionals_1;
         if (isset($this->__providedOptionals)) {
             $output['__providedOptionals'] = $this->__providedOptionals;
         }
-        $output['clone'] = $this->_clone;
-        $output['__construct'] = $this->__construct_1;
-        $output['__destruct'] = $this->__destruct_1;
-        $output['__get'] = $this->__get_1;
-        $output['__set'] = $this->__set_1;
-        $output['__call'] = $this->__call_1;
-        $output['__isset'] = $this->__isset_1;
-        $output['__unset'] = $this->__unset_1;
-        $output['__sleep'] = $this->__sleep_1;
-        $output['__wakeup'] = $this->__wakeup_1;
-        $output['__toString'] = $this->__toString_1;
-        $output['__invoke'] = $this->__invoke_1;
-        $output['__debugInfo'] = $this->__debugInfo_1;
-        $output['__clone'] = $this->__clone_1;
+        $output['clone'] = $this->clone;
+        $output['__construct'] = $this->__construct;
+        $output['__destruct'] = $this->__destruct;
+        $output['__get'] = $this->__get;
+        $output['__set'] = $this->__set;
+        $output['__call'] = $this->__call;
+        $output['__isset'] = $this->__isset;
+        $output['__unset'] = $this->__unset;
+        $output['__sleep'] = $this->__sleep;
+        $output['__wakeup'] = $this->__wakeup;
+        $output['__toString'] = $this->__toString;
+        $output['__invoke'] = $this->__invoke;
+        $output['__debugInfo'] = $this->__debugInfo;
+        $output['__clone'] = $this->__clone;
         $output['files'] = $this->files;
         $output['this'] = $this->_this;
         if (isset($this->ensureArgs1)) {
@@ -2335,21 +2335,21 @@ class MyClass
     public function toStdClass(bool $includeDefaults = false)
     {
         $output = new \stdClass();
-        $output->{'_GLOBALS'} = $this->_GLOBALS_1;
-        $output->{'GLOBALS'} = $this->_GLOBALS_2;
+        $output->{'_GLOBALS'} = $this->_GLOBALS;
+        $output->{'GLOBALS'} = $this->GLOBALS;
         $output->{'GLOBALS_1'} = $this->GLOBALS_1;
-        $output->{'_SERVER'} = $this->_SERVER_1;
-        $output->{'_GET'} = $this->_GET_1;
-        $output->{'_POST'} = $this->_POST_1;
-        $output->{'_FILES'} = $this->_FILES_1;
-        $output->{'_REQUEST'} = $this->_REQUEST_1;
-        $output->{'_SESSION'} = $this->_SESSION_1;
-        $output->{'_ENV'} = $this->_ENV_1;
-        $output->{'_COOKIE'} = $this->_COOKIE_1;
-        $output->{'php_errormsg'} = $this->_php_errormsg;
-        $output->{'http_response_header'} = $this->_http_response_header;
-        $output->{'argc'} = $this->_argc;
-        $output->{'argv'} = $this->_argv;
+        $output->{'_SERVER'} = $this->_SERVER;
+        $output->{'_GET'} = $this->_GET;
+        $output->{'_POST'} = $this->_POST;
+        $output->{'_FILES'} = $this->_FILES;
+        $output->{'_REQUEST'} = $this->_REQUEST;
+        $output->{'_SESSION'} = $this->_SESSION;
+        $output->{'_ENV'} = $this->_ENV;
+        $output->{'_COOKIE'} = $this->_COOKIE;
+        $output->{'php_errormsg'} = $this->php_errormsg;
+        $output->{'http_response_header'} = $this->http_response_header;
+        $output->{'argc'} = $this->argc;
+        $output->{'argv'} = $this->argv;
         $output->{'input'} = $this->input;
         if (isset($this->validate)) {
             $output->{'validate'} = $this->validate;
@@ -2362,32 +2362,32 @@ class MyClass
         if (isset($this->testObj)) {
             $output->{'testObj'} = ($this->testObj)->toStdClass($includeDefaults);
         }
-        $output->{'fromInput'} = $this->_fromInput;
-        $output->{'toArray'} = $this->_toArray;
-        $output->{'toStdClass'} = $this->_toStdClass;
-        $output->{'validateInput'} = $this->_validateInput;
+        $output->{'fromInput'} = $this->fromInput;
+        $output->{'toArray'} = $this->toArray;
+        $output->{'toStdClass'} = $this->toStdClass;
+        $output->{'validateInput'} = $this->validateInput;
         $output->{'_schema'} = $this->_schema_1;
-        $output->{'schema'} = $this->_schema_2;
+        $output->{'schema'} = $this->schema;
         $output->{'_defaults'} = $this->_defaults_1;
-        $output->{'defaults'} = $this->_defaults_2;
+        $output->{'defaults'} = $this->defaults;
         $output->{'_providedOptionals'} = $this->_providedOptionals_1;
         if (isset($this->__providedOptionals)) {
             $output->{'__providedOptionals'} = $this->__providedOptionals;
         }
-        $output->{'clone'} = $this->_clone;
-        $output->{'__construct'} = $this->__construct_1;
-        $output->{'__destruct'} = $this->__destruct_1;
-        $output->{'__get'} = $this->__get_1;
-        $output->{'__set'} = $this->__set_1;
-        $output->{'__call'} = $this->__call_1;
-        $output->{'__isset'} = $this->__isset_1;
-        $output->{'__unset'} = $this->__unset_1;
-        $output->{'__sleep'} = $this->__sleep_1;
-        $output->{'__wakeup'} = $this->__wakeup_1;
-        $output->{'__toString'} = $this->__toString_1;
-        $output->{'__invoke'} = $this->__invoke_1;
-        $output->{'__debugInfo'} = $this->__debugInfo_1;
-        $output->{'__clone'} = $this->__clone_1;
+        $output->{'clone'} = $this->clone;
+        $output->{'__construct'} = $this->__construct;
+        $output->{'__destruct'} = $this->__destruct;
+        $output->{'__get'} = $this->__get;
+        $output->{'__set'} = $this->__set;
+        $output->{'__call'} = $this->__call;
+        $output->{'__isset'} = $this->__isset;
+        $output->{'__unset'} = $this->__unset;
+        $output->{'__sleep'} = $this->__sleep;
+        $output->{'__wakeup'} = $this->__wakeup;
+        $output->{'__toString'} = $this->__toString;
+        $output->{'__invoke'} = $this->__invoke;
+        $output->{'__debugInfo'} = $this->__debugInfo;
+        $output->{'__clone'} = $this->__clone;
         $output->{'files'} = $this->files;
         $output->{'this'} = $this->_this;
         if (isset($this->ensureArgs1)) {

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -296,12 +296,12 @@ class MyClass
     /**
      * @var string
      */
-    private string $_GLOBALS_1;
+    private string $_GLOBALS;
 
     /**
      * @var string
      */
-    private string $_GLOBALS_2;
+    private string $GLOBALS;
 
     /**
      * @var string
@@ -311,62 +311,62 @@ class MyClass
     /**
      * @var string
      */
-    private string $_SERVER_1;
+    private string $_SERVER;
 
     /**
      * @var string
      */
-    private string $_GET_1;
+    private string $_GET;
 
     /**
      * @var string
      */
-    private string $_POST_1;
+    private string $_POST;
 
     /**
      * @var string
      */
-    private string $_FILES_1;
+    private string $_FILES;
 
     /**
      * @var string
      */
-    private string $_REQUEST_1;
+    private string $_REQUEST;
 
     /**
      * @var string
      */
-    private string $_SESSION_1;
+    private string $_SESSION;
 
     /**
      * @var string
      */
-    private string $_ENV_1;
+    private string $_ENV;
 
     /**
      * @var string
      */
-    private string $_COOKIE_1;
+    private string $_COOKIE;
 
     /**
      * @var string
      */
-    private string $_php_errormsg;
+    private string $php_errormsg;
 
     /**
      * @var string
      */
-    private string $_http_response_header;
+    private string $http_response_header;
 
     /**
      * @var string
      */
-    private string $_argc;
+    private string $argc;
 
     /**
      * @var string
      */
-    private string $_argv;
+    private string $argv;
 
     /**
      * @var string
@@ -401,22 +401,22 @@ class MyClass
     /**
      * @var string
      */
-    private string $_fromInput;
+    private string $fromInput;
 
     /**
      * @var string
      */
-    private string $_toArray;
+    private string $toArray;
 
     /**
      * @var string
      */
-    private string $_toStdClass;
+    private string $toStdClass;
 
     /**
      * @var string
      */
-    private string $_validateInput;
+    private string $validateInput;
 
     /**
      * @var string
@@ -426,7 +426,7 @@ class MyClass
     /**
      * @var string
      */
-    private string $_schema_2;
+    private string $schema;
 
     /**
      * @var string
@@ -436,7 +436,7 @@ class MyClass
     /**
      * @var string
      */
-    private string $_defaults_2;
+    private string $defaults;
 
     /**
      * @var string
@@ -451,72 +451,72 @@ class MyClass
     /**
      * @var string
      */
-    private string $_clone;
+    private string $clone;
 
     /**
      * @var string
      */
-    private string $__construct_1;
+    private string $__construct;
 
     /**
      * @var string
      */
-    private string $__destruct_1;
+    private string $__destruct;
 
     /**
      * @var string
      */
-    private string $__get_1;
+    private string $__get;
 
     /**
      * @var string
      */
-    private string $__set_1;
+    private string $__set;
 
     /**
      * @var string
      */
-    private string $__call_1;
+    private string $__call;
 
     /**
      * @var string
      */
-    private string $__isset_1;
+    private string $__isset;
 
     /**
      * @var string
      */
-    private string $__unset_1;
+    private string $__unset;
 
     /**
      * @var string
      */
-    private string $__sleep_1;
+    private string $__sleep;
 
     /**
      * @var string
      */
-    private string $__wakeup_1;
+    private string $__wakeup;
 
     /**
      * @var string
      */
-    private string $__toString_1;
+    private string $__toString;
 
     /**
      * @var string
      */
-    private string $__invoke_1;
+    private string $__invoke;
 
     /**
      * @var string
      */
-    private string $__debugInfo_1;
+    private string $__debugInfo;
 
     /**
      * @var string
      */
-    private string $__clone_1;
+    private string $__clone;
 
     /**
      * @var string
@@ -544,8 +544,8 @@ class MyClass
     private ?array $ensureArgs3 = null;
 
     /**
-     * @param string $_GLOBALS_1
      * @param string $_GLOBALS_2
+     * @param string $_GLOBALS_1
      * @param string $GLOBALS_1
      * @param string $_SERVER_1
      * @param string $_GET_1
@@ -559,78 +559,78 @@ class MyClass
      * @param string $_http_response_header
      * @param string $_argc
      * @param string $_argv
-     * @param string $input
-     * @param string $obj
+     * @param string $_input
+     * @param string $_obj
      * @param string $includeDefaults
-     * @param string $_fromInput
-     * @param string $_toArray
-     * @param string $_toStdClass
-     * @param string $_validateInput
+     * @param string $fromInput
+     * @param string $toArray
+     * @param string $toStdClass
+     * @param string $validateInput
      * @param string $_schema_1
-     * @param string $_schema_2
+     * @param string $schema
      * @param string $_defaults_1
-     * @param string $_defaults_2
+     * @param string $defaults
      * @param string $_providedOptionals_1
-     * @param string $_clone
-     * @param string $__construct_1
-     * @param string $__destruct_1
-     * @param string $__get_1
-     * @param string $__set_1
-     * @param string $__call_1
-     * @param string $__isset_1
-     * @param string $__unset_1
-     * @param string $__sleep_1
-     * @param string $__wakeup_1
-     * @param string $__toString_1
-     * @param string $__invoke_1
-     * @param string $__debugInfo_1
-     * @param string $__clone_1
+     * @param string $clone
+     * @param string $__construct
+     * @param string $__destruct
+     * @param string $__get
+     * @param string $__set
+     * @param string $__call
+     * @param string $__isset
+     * @param string $__unset
+     * @param string $__sleep
+     * @param string $__wakeup
+     * @param string $__toString
+     * @param string $__invoke
+     * @param string $__debugInfo
+     * @param string $__clone
      * @param string $files
      * @param string $_this
      */
-    public function __construct(string $_GLOBALS_1, string $_GLOBALS_2, string $GLOBALS_1, string $_SERVER_1, string $_GET_1, string $_POST_1, string $_FILES_1, string $_REQUEST_1, string $_SESSION_1, string $_ENV_1, string $_COOKIE_1, string $_php_errormsg, string $_http_response_header, string $_argc, string $_argv, string $input, string $obj, string $includeDefaults, string $_fromInput, string $_toArray, string $_toStdClass, string $_validateInput, string $_schema_1, string $_schema_2, string $_defaults_1, string $_defaults_2, string $_providedOptionals_1, string $_clone, string $__construct_1, string $__destruct_1, string $__get_1, string $__set_1, string $__call_1, string $__isset_1, string $__unset_1, string $__sleep_1, string $__wakeup_1, string $__toString_1, string $__invoke_1, string $__debugInfo_1, string $__clone_1, string $files, string $_this)
+    public function __construct(string $_GLOBALS_2, string $_GLOBALS_1, string $GLOBALS_1, string $_SERVER_1, string $_GET_1, string $_POST_1, string $_FILES_1, string $_REQUEST_1, string $_SESSION_1, string $_ENV_1, string $_COOKIE_1, string $_php_errormsg, string $_http_response_header, string $_argc, string $_argv, string $_input, string $_obj, string $includeDefaults, string $fromInput, string $toArray, string $toStdClass, string $validateInput, string $_schema_1, string $schema, string $_defaults_1, string $defaults, string $_providedOptionals_1, string $clone, string $__construct, string $__destruct, string $__get, string $__set, string $__call, string $__isset, string $__unset, string $__sleep, string $__wakeup, string $__toString, string $__invoke, string $__debugInfo, string $__clone, string $files, string $_this)
     {
-        $this->_GLOBALS_1 = $_GLOBALS_1;
-        $this->_GLOBALS_2 = $_GLOBALS_2;
+        $this->_GLOBALS = $_GLOBALS_2;
+        $this->GLOBALS = $_GLOBALS_1;
         $this->GLOBALS_1 = $GLOBALS_1;
-        $this->_SERVER_1 = $_SERVER_1;
-        $this->_GET_1 = $_GET_1;
-        $this->_POST_1 = $_POST_1;
-        $this->_FILES_1 = $_FILES_1;
-        $this->_REQUEST_1 = $_REQUEST_1;
-        $this->_SESSION_1 = $_SESSION_1;
-        $this->_ENV_1 = $_ENV_1;
-        $this->_COOKIE_1 = $_COOKIE_1;
-        $this->_php_errormsg = $_php_errormsg;
-        $this->_http_response_header = $_http_response_header;
-        $this->_argc = $_argc;
-        $this->_argv = $_argv;
-        $this->input = $input;
-        $this->obj = $obj;
+        $this->_SERVER = $_SERVER_1;
+        $this->_GET = $_GET_1;
+        $this->_POST = $_POST_1;
+        $this->_FILES = $_FILES_1;
+        $this->_REQUEST = $_REQUEST_1;
+        $this->_SESSION = $_SESSION_1;
+        $this->_ENV = $_ENV_1;
+        $this->_COOKIE = $_COOKIE_1;
+        $this->php_errormsg = $_php_errormsg;
+        $this->http_response_header = $_http_response_header;
+        $this->argc = $_argc;
+        $this->argv = $_argv;
+        $this->input = $_input;
+        $this->obj = $_obj;
         $this->includeDefaults = $includeDefaults;
-        $this->_fromInput = $_fromInput;
-        $this->_toArray = $_toArray;
-        $this->_toStdClass = $_toStdClass;
-        $this->_validateInput = $_validateInput;
+        $this->fromInput = $fromInput;
+        $this->toArray = $toArray;
+        $this->toStdClass = $toStdClass;
+        $this->validateInput = $validateInput;
         $this->_schema_1 = $_schema_1;
-        $this->_schema_2 = $_schema_2;
+        $this->schema = $schema;
         $this->_defaults_1 = $_defaults_1;
-        $this->_defaults_2 = $_defaults_2;
+        $this->defaults = $defaults;
         $this->_providedOptionals_1 = $_providedOptionals_1;
-        $this->_clone = $_clone;
-        $this->__construct_1 = $__construct_1;
-        $this->__destruct_1 = $__destruct_1;
-        $this->__get_1 = $__get_1;
-        $this->__set_1 = $__set_1;
-        $this->__call_1 = $__call_1;
-        $this->__isset_1 = $__isset_1;
-        $this->__unset_1 = $__unset_1;
-        $this->__sleep_1 = $__sleep_1;
-        $this->__wakeup_1 = $__wakeup_1;
-        $this->__toString_1 = $__toString_1;
-        $this->__invoke_1 = $__invoke_1;
-        $this->__debugInfo_1 = $__debugInfo_1;
-        $this->__clone_1 = $__clone_1;
+        $this->clone = $clone;
+        $this->__construct = $__construct;
+        $this->__destruct = $__destruct;
+        $this->__get = $__get;
+        $this->__set = $__set;
+        $this->__call = $__call;
+        $this->__isset = $__isset;
+        $this->__unset = $__unset;
+        $this->__sleep = $__sleep;
+        $this->__wakeup = $__wakeup;
+        $this->__toString = $__toString;
+        $this->__invoke = $__invoke;
+        $this->__debugInfo = $__debugInfo;
+        $this->__clone = $__clone;
         $this->files = $files;
         $this->_this = $_this;
     }
@@ -638,38 +638,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_GLOBALS1(): string
+    public function get_GLOBALS(): string
     {
-        return $this->_GLOBALS_1;
-    }
-
-    /**
-     * @param string $_GLOBALS_1
-     * @return self
-     * @param bool $validate
-     */
-    public function with_GLOBALS1(string $_GLOBALS_1, bool $validate = true): self
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_1, self::$_schema['properties']['_GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->_GLOBALS_1 = $_GLOBALS_1;
-
-        return $clone;
-    }
-
-    /**
-     * @return string
-     */
-    public function get_GLOBALS2(): string
-    {
-        return $this->_GLOBALS_2;
+        return $this->_GLOBALS;
     }
 
     /**
@@ -677,18 +648,47 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_GLOBALS2(string $_GLOBALS_2, bool $validate = true): self
+    public function with_GLOBALS(string $_GLOBALS_2, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_2, self::$_schema['properties']['GLOBALS']);
+            $validator->validate($_GLOBALS_2, self::$_schema['properties']['_GLOBALS']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_GLOBALS_2 = $_GLOBALS_2;
+        $clone->_GLOBALS = $_GLOBALS_2;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGLOBALS(): string
+    {
+        return $this->GLOBALS;
+    }
+
+    /**
+     * @param string $_GLOBALS_1
+     * @return self
+     * @param bool $validate
+     */
+    public function withGLOBALS(string $_GLOBALS_1, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($_GLOBALS_1, self::$_schema['properties']['GLOBALS']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->GLOBALS = $_GLOBALS_1;
 
         return $clone;
     }
@@ -725,9 +725,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_SERVER1(): string
+    public function get_SERVER(): string
     {
-        return $this->_SERVER_1;
+        return $this->_SERVER;
     }
 
     /**
@@ -735,7 +735,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_SERVER1(string $_SERVER_1, bool $validate = true): self
+    public function with_SERVER(string $_SERVER_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -746,7 +746,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_SERVER_1 = $_SERVER_1;
+        $clone->_SERVER = $_SERVER_1;
 
         return $clone;
     }
@@ -754,9 +754,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_GET1(): string
+    public function get_GET(): string
     {
-        return $this->_GET_1;
+        return $this->_GET;
     }
 
     /**
@@ -764,7 +764,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_GET1(string $_GET_1, bool $validate = true): self
+    public function with_GET(string $_GET_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -775,7 +775,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_GET_1 = $_GET_1;
+        $clone->_GET = $_GET_1;
 
         return $clone;
     }
@@ -783,9 +783,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_POST1(): string
+    public function get_POST(): string
     {
-        return $this->_POST_1;
+        return $this->_POST;
     }
 
     /**
@@ -793,7 +793,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_POST1(string $_POST_1, bool $validate = true): self
+    public function with_POST(string $_POST_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -804,7 +804,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_POST_1 = $_POST_1;
+        $clone->_POST = $_POST_1;
 
         return $clone;
     }
@@ -812,9 +812,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_FILES1(): string
+    public function get_FILES(): string
     {
-        return $this->_FILES_1;
+        return $this->_FILES;
     }
 
     /**
@@ -822,7 +822,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_FILES1(string $_FILES_1, bool $validate = true): self
+    public function with_FILES(string $_FILES_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -833,7 +833,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_FILES_1 = $_FILES_1;
+        $clone->_FILES = $_FILES_1;
 
         return $clone;
     }
@@ -841,9 +841,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_REQUEST1(): string
+    public function get_REQUEST(): string
     {
-        return $this->_REQUEST_1;
+        return $this->_REQUEST;
     }
 
     /**
@@ -851,7 +851,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_REQUEST1(string $_REQUEST_1, bool $validate = true): self
+    public function with_REQUEST(string $_REQUEST_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -862,7 +862,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_REQUEST_1 = $_REQUEST_1;
+        $clone->_REQUEST = $_REQUEST_1;
 
         return $clone;
     }
@@ -870,9 +870,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_SESSION1(): string
+    public function get_SESSION(): string
     {
-        return $this->_SESSION_1;
+        return $this->_SESSION;
     }
 
     /**
@@ -880,7 +880,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_SESSION1(string $_SESSION_1, bool $validate = true): self
+    public function with_SESSION(string $_SESSION_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -891,7 +891,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_SESSION_1 = $_SESSION_1;
+        $clone->_SESSION = $_SESSION_1;
 
         return $clone;
     }
@@ -899,9 +899,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_ENV1(): string
+    public function get_ENV(): string
     {
-        return $this->_ENV_1;
+        return $this->_ENV;
     }
 
     /**
@@ -909,7 +909,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_ENV1(string $_ENV_1, bool $validate = true): self
+    public function with_ENV(string $_ENV_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -920,7 +920,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_ENV_1 = $_ENV_1;
+        $clone->_ENV = $_ENV_1;
 
         return $clone;
     }
@@ -928,9 +928,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_COOKIE1(): string
+    public function get_COOKIE(): string
     {
-        return $this->_COOKIE_1;
+        return $this->_COOKIE;
     }
 
     /**
@@ -938,7 +938,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_COOKIE1(string $_COOKIE_1, bool $validate = true): self
+    public function with_COOKIE(string $_COOKIE_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -949,7 +949,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_COOKIE_1 = $_COOKIE_1;
+        $clone->_COOKIE = $_COOKIE_1;
 
         return $clone;
     }
@@ -957,9 +957,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_PhpErrormsg(): string
+    public function getPhpErrormsg(): string
     {
-        return $this->_php_errormsg;
+        return $this->php_errormsg;
     }
 
     /**
@@ -967,7 +967,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_PhpErrormsg(string $_php_errormsg, bool $validate = true): self
+    public function withPhpErrormsg(string $_php_errormsg, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -978,7 +978,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_php_errormsg = $_php_errormsg;
+        $clone->php_errormsg = $_php_errormsg;
 
         return $clone;
     }
@@ -986,9 +986,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_HttpResponseHeader(): string
+    public function getHttpResponseHeader(): string
     {
-        return $this->_http_response_header;
+        return $this->http_response_header;
     }
 
     /**
@@ -996,7 +996,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_HttpResponseHeader(string $_http_response_header, bool $validate = true): self
+    public function withHttpResponseHeader(string $_http_response_header, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1007,7 +1007,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_http_response_header = $_http_response_header;
+        $clone->http_response_header = $_http_response_header;
 
         return $clone;
     }
@@ -1015,9 +1015,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Argc(): string
+    public function getArgc(): string
     {
-        return $this->_argc;
+        return $this->argc;
     }
 
     /**
@@ -1025,7 +1025,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_Argc(string $_argc, bool $validate = true): self
+    public function withArgc(string $_argc, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1036,7 +1036,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_argc = $_argc;
+        $clone->argc = $_argc;
 
         return $clone;
     }
@@ -1044,9 +1044,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Argv(): string
+    public function getArgv(): string
     {
-        return $this->_argv;
+        return $this->argv;
     }
 
     /**
@@ -1054,7 +1054,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_Argv(string $_argv, bool $validate = true): self
+    public function withArgv(string $_argv, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1065,7 +1065,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_argv = $_argv;
+        $clone->argv = $_argv;
 
         return $clone;
     }
@@ -1079,22 +1079,22 @@ class MyClass
     }
 
     /**
-     * @param string $input
+     * @param string $_input
      * @return self
      * @param bool $validate
      */
-    public function withInput(string $input, bool $validate = true): self
+    public function withInput(string $_input, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($input, self::$_schema['properties']['input']);
+            $validator->validate($_input, self::$_schema['properties']['input']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->input = $input;
+        $clone->input = $_input;
 
         return $clone;
     }
@@ -1108,22 +1108,22 @@ class MyClass
     }
 
     /**
-     * @param string $validate
+     * @param string $_validate
      * @return self
      * @param bool $validate
      */
-    public function withValidate(bool $validate = true): self
+    public function withValidate(string $_validate, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($validate, self::$_schema['properties']['validate']);
+            $validator->validate($_validate, self::$_schema['properties']['validate']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->validate = $validate;
+        $clone->validate = $_validate;
 
         return $clone;
     }
@@ -1148,22 +1148,22 @@ class MyClass
     }
 
     /**
-     * @param string $materializeDefaults
+     * @param string $_materializeDefaults
      * @return self
      * @param bool $validate
      */
-    public function withMaterializeDefaults(string $materializeDefaults, bool $validate = true): self
+    public function withMaterializeDefaults(string $_materializeDefaults, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($materializeDefaults, self::$_schema['properties']['materializeDefaults']);
+            $validator->validate($_materializeDefaults, self::$_schema['properties']['materializeDefaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->materializeDefaults = $materializeDefaults;
+        $clone->materializeDefaults = $_materializeDefaults;
         $clone->_providedOptionals['materializeDefaults'] = true;
 
         return $clone;
@@ -1190,22 +1190,22 @@ class MyClass
     }
 
     /**
-     * @param string $obj
+     * @param string $_obj
      * @return self
      * @param bool $validate
      */
-    public function withObj(string $obj, bool $validate = true): self
+    public function withObj(string $_obj, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($obj, self::$_schema['properties']['obj']);
+            $validator->validate($_obj, self::$_schema['properties']['obj']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->obj = $obj;
+        $clone->obj = $_obj;
 
         return $clone;
     }
@@ -1273,28 +1273,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_FromInput(): string
+    public function getFromInput(): string
     {
-        return $this->_fromInput;
+        return $this->fromInput;
     }
 
     /**
-     * @param string $_fromInput
+     * @param string $fromInput
      * @return self
      * @param bool $validate
      */
-    public function with_FromInput(string $_fromInput, bool $validate = true): self
+    public function withFromInput(string $fromInput, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_fromInput, self::$_schema['properties']['fromInput']);
+            $validator->validate($fromInput, self::$_schema['properties']['fromInput']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_fromInput = $_fromInput;
+        $clone->fromInput = $fromInput;
 
         return $clone;
     }
@@ -1302,28 +1302,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_ToArray(): string
+    public function getToArray(): string
     {
-        return $this->_toArray;
+        return $this->toArray;
     }
 
     /**
-     * @param string $_toArray
+     * @param string $toArray
      * @return self
      * @param bool $validate
      */
-    public function with_ToArray(string $_toArray, bool $validate = true): self
+    public function withToArray(string $toArray, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toArray, self::$_schema['properties']['toArray']);
+            $validator->validate($toArray, self::$_schema['properties']['toArray']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toArray = $_toArray;
+        $clone->toArray = $toArray;
 
         return $clone;
     }
@@ -1331,28 +1331,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_ToStdClass(): string
+    public function getToStdClass(): string
     {
-        return $this->_toStdClass;
+        return $this->toStdClass;
     }
 
     /**
-     * @param string $_toStdClass
+     * @param string $toStdClass
      * @return self
      * @param bool $validate
      */
-    public function with_ToStdClass(string $_toStdClass, bool $validate = true): self
+    public function withToStdClass(string $toStdClass, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toStdClass, self::$_schema['properties']['toStdClass']);
+            $validator->validate($toStdClass, self::$_schema['properties']['toStdClass']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toStdClass = $_toStdClass;
+        $clone->toStdClass = $toStdClass;
 
         return $clone;
     }
@@ -1360,28 +1360,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_ValidateInput(): string
+    public function getValidateInput(): string
     {
-        return $this->_validateInput;
+        return $this->validateInput;
     }
 
     /**
-     * @param string $_validateInput
+     * @param string $validateInput
      * @return self
      * @param bool $validate
      */
-    public function with_ValidateInput(string $_validateInput, bool $validate = true): self
+    public function withValidateInput(string $validateInput, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_validateInput, self::$_schema['properties']['validateInput']);
+            $validator->validate($validateInput, self::$_schema['properties']['validateInput']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_validateInput = $_validateInput;
+        $clone->validateInput = $validateInput;
 
         return $clone;
     }
@@ -1418,28 +1418,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Schema2(): string
+    public function getSchema(): string
     {
-        return $this->_schema_2;
+        return $this->schema;
     }
 
     /**
-     * @param string $_schema_2
+     * @param string $schema
      * @return self
      * @param bool $validate
      */
-    public function with_Schema2(string $_schema_2, bool $validate = true): self
+    public function withSchema(string $schema, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_2, self::$_schema['properties']['schema']);
+            $validator->validate($schema, self::$_schema['properties']['schema']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_schema_2 = $_schema_2;
+        $clone->schema = $schema;
 
         return $clone;
     }
@@ -1476,28 +1476,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Defaults2(): string
+    public function getDefaults(): string
     {
-        return $this->_defaults_2;
+        return $this->defaults;
     }
 
     /**
-     * @param string $_defaults_2
+     * @param string $defaults
      * @return self
      * @param bool $validate
      */
-    public function with_Defaults2(string $_defaults_2, bool $validate = true): self
+    public function withDefaults(string $defaults, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_2, self::$_schema['properties']['defaults']);
+            $validator->validate($defaults, self::$_schema['properties']['defaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_defaults_2 = $_defaults_2;
+        $clone->defaults = $defaults;
 
         return $clone;
     }
@@ -1540,22 +1540,22 @@ class MyClass
     }
 
     /**
-     * @param string $__providedOptionals
+     * @param string $__providedOptionals_1
      * @return self
      * @param bool $validate
      */
-    public function with__ProvidedOptionals(string $__providedOptionals, bool $validate = true): self
+    public function with__ProvidedOptionals(string $__providedOptionals_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__providedOptionals, self::$_schema['properties']['__providedOptionals']);
+            $validator->validate($__providedOptionals_1, self::$_schema['properties']['__providedOptionals']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__providedOptionals = $__providedOptionals;
+        $clone->__providedOptionals = $__providedOptionals_1;
 
         return $clone;
     }
@@ -1574,28 +1574,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Clone(): string
+    public function getClone(): string
     {
-        return $this->_clone;
+        return $this->clone;
     }
 
     /**
-     * @param string $_clone
+     * @param string $clone
      * @return self
      * @param bool $validate
      */
-    public function with_Clone(string $_clone, bool $validate = true): self
+    public function withClone(string $clone, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone, self::$_schema['properties']['clone']);
+            $validator->validate($clone, self::$_schema['properties']['clone']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_clone = $_clone;
+        $clone->clone = $clone;
 
         return $clone;
     }
@@ -1603,28 +1603,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Construct1(): string
+    public function get__Construct(): string
     {
-        return $this->__construct_1;
+        return $this->__construct;
     }
 
     /**
-     * @param string $__construct_1
+     * @param string $__construct
      * @return self
      * @param bool $validate
      */
-    public function with__Construct1(string $__construct_1, bool $validate = true): self
+    public function with__Construct(string $__construct, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__construct_1, self::$_schema['properties']['__construct']);
+            $validator->validate($__construct, self::$_schema['properties']['__construct']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__construct_1 = $__construct_1;
+        $clone->__construct = $__construct;
 
         return $clone;
     }
@@ -1632,28 +1632,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Destruct1(): string
+    public function get__Destruct(): string
     {
-        return $this->__destruct_1;
+        return $this->__destruct;
     }
 
     /**
-     * @param string $__destruct_1
+     * @param string $__destruct
      * @return self
      * @param bool $validate
      */
-    public function with__Destruct1(string $__destruct_1, bool $validate = true): self
+    public function with__Destruct(string $__destruct, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__destruct_1, self::$_schema['properties']['__destruct']);
+            $validator->validate($__destruct, self::$_schema['properties']['__destruct']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__destruct_1 = $__destruct_1;
+        $clone->__destruct = $__destruct;
 
         return $clone;
     }
@@ -1661,28 +1661,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Get1(): string
+    public function get__Get(): string
     {
-        return $this->__get_1;
+        return $this->__get;
     }
 
     /**
-     * @param string $__get_1
+     * @param string $__get
      * @return self
      * @param bool $validate
      */
-    public function with__Get1(string $__get_1, bool $validate = true): self
+    public function with__Get(string $__get, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__get_1, self::$_schema['properties']['__get']);
+            $validator->validate($__get, self::$_schema['properties']['__get']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__get_1 = $__get_1;
+        $clone->__get = $__get;
 
         return $clone;
     }
@@ -1690,28 +1690,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Set1(): string
+    public function get__Set(): string
     {
-        return $this->__set_1;
+        return $this->__set;
     }
 
     /**
-     * @param string $__set_1
+     * @param string $__set
      * @return self
      * @param bool $validate
      */
-    public function with__Set1(string $__set_1, bool $validate = true): self
+    public function with__Set(string $__set, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__set_1, self::$_schema['properties']['__set']);
+            $validator->validate($__set, self::$_schema['properties']['__set']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__set_1 = $__set_1;
+        $clone->__set = $__set;
 
         return $clone;
     }
@@ -1719,28 +1719,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Call1(): string
+    public function get__Call(): string
     {
-        return $this->__call_1;
+        return $this->__call;
     }
 
     /**
-     * @param string $__call_1
+     * @param string $__call
      * @return self
      * @param bool $validate
      */
-    public function with__Call1(string $__call_1, bool $validate = true): self
+    public function with__Call(string $__call, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__call_1, self::$_schema['properties']['__call']);
+            $validator->validate($__call, self::$_schema['properties']['__call']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__call_1 = $__call_1;
+        $clone->__call = $__call;
 
         return $clone;
     }
@@ -1748,28 +1748,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Isset1(): string
+    public function get__Isset(): string
     {
-        return $this->__isset_1;
+        return $this->__isset;
     }
 
     /**
-     * @param string $__isset_1
+     * @param string $__isset
      * @return self
      * @param bool $validate
      */
-    public function with__Isset1(string $__isset_1, bool $validate = true): self
+    public function with__Isset(string $__isset, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__isset_1, self::$_schema['properties']['__isset']);
+            $validator->validate($__isset, self::$_schema['properties']['__isset']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__isset_1 = $__isset_1;
+        $clone->__isset = $__isset;
 
         return $clone;
     }
@@ -1777,28 +1777,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Unset1(): string
+    public function get__Unset(): string
     {
-        return $this->__unset_1;
+        return $this->__unset;
     }
 
     /**
-     * @param string $__unset_1
+     * @param string $__unset
      * @return self
      * @param bool $validate
      */
-    public function with__Unset1(string $__unset_1, bool $validate = true): self
+    public function with__Unset(string $__unset, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__unset_1, self::$_schema['properties']['__unset']);
+            $validator->validate($__unset, self::$_schema['properties']['__unset']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__unset_1 = $__unset_1;
+        $clone->__unset = $__unset;
 
         return $clone;
     }
@@ -1806,28 +1806,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Sleep1(): string
+    public function get__Sleep(): string
     {
-        return $this->__sleep_1;
+        return $this->__sleep;
     }
 
     /**
-     * @param string $__sleep_1
+     * @param string $__sleep
      * @return self
      * @param bool $validate
      */
-    public function with__Sleep1(string $__sleep_1, bool $validate = true): self
+    public function with__Sleep(string $__sleep, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__sleep_1, self::$_schema['properties']['__sleep']);
+            $validator->validate($__sleep, self::$_schema['properties']['__sleep']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__sleep_1 = $__sleep_1;
+        $clone->__sleep = $__sleep;
 
         return $clone;
     }
@@ -1835,28 +1835,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Wakeup1(): string
+    public function get__Wakeup(): string
     {
-        return $this->__wakeup_1;
+        return $this->__wakeup;
     }
 
     /**
-     * @param string $__wakeup_1
+     * @param string $__wakeup
      * @return self
      * @param bool $validate
      */
-    public function with__Wakeup1(string $__wakeup_1, bool $validate = true): self
+    public function with__Wakeup(string $__wakeup, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__wakeup_1, self::$_schema['properties']['__wakeup']);
+            $validator->validate($__wakeup, self::$_schema['properties']['__wakeup']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__wakeup_1 = $__wakeup_1;
+        $clone->__wakeup = $__wakeup;
 
         return $clone;
     }
@@ -1864,28 +1864,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__ToString1(): string
+    public function get__ToString(): string
     {
-        return $this->__toString_1;
+        return $this->__toString;
     }
 
     /**
-     * @param string $__toString_1
+     * @param string $__toString
      * @return self
      * @param bool $validate
      */
-    public function with__ToString1(string $__toString_1, bool $validate = true): self
+    public function with__ToString(string $__toString, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__toString_1, self::$_schema['properties']['__toString']);
+            $validator->validate($__toString, self::$_schema['properties']['__toString']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__toString_1 = $__toString_1;
+        $clone->__toString = $__toString;
 
         return $clone;
     }
@@ -1893,28 +1893,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Invoke1(): string
+    public function get__Invoke(): string
     {
-        return $this->__invoke_1;
+        return $this->__invoke;
     }
 
     /**
-     * @param string $__invoke_1
+     * @param string $__invoke
      * @return self
      * @param bool $validate
      */
-    public function with__Invoke1(string $__invoke_1, bool $validate = true): self
+    public function with__Invoke(string $__invoke, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__invoke_1, self::$_schema['properties']['__invoke']);
+            $validator->validate($__invoke, self::$_schema['properties']['__invoke']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__invoke_1 = $__invoke_1;
+        $clone->__invoke = $__invoke;
 
         return $clone;
     }
@@ -1922,28 +1922,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__DebugInfo1(): string
+    public function get__DebugInfo(): string
     {
-        return $this->__debugInfo_1;
+        return $this->__debugInfo;
     }
 
     /**
-     * @param string $__debugInfo_1
+     * @param string $__debugInfo
      * @return self
      * @param bool $validate
      */
-    public function with__DebugInfo1(string $__debugInfo_1, bool $validate = true): self
+    public function with__DebugInfo(string $__debugInfo, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__debugInfo_1, self::$_schema['properties']['__debugInfo']);
+            $validator->validate($__debugInfo, self::$_schema['properties']['__debugInfo']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__debugInfo_1 = $__debugInfo_1;
+        $clone->__debugInfo = $__debugInfo;
 
         return $clone;
     }
@@ -1951,28 +1951,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Clone1(): string
+    public function get__Clone(): string
     {
-        return $this->__clone_1;
+        return $this->__clone;
     }
 
     /**
-     * @param string $__clone_1
+     * @param string $__clone
      * @return self
      * @param bool $validate
      */
-    public function with__Clone1(string $__clone_1, bool $validate = true): self
+    public function with__Clone(string $__clone, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__clone_1, self::$_schema['properties']['__clone']);
+            $validator->validate($__clone, self::$_schema['properties']['__clone']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__clone_1 = $__clone_1;
+        $clone->__clone = $__clone;
 
         return $clone;
     }
@@ -2173,8 +2173,8 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $_GLOBALS_1 = $input->{'_GLOBALS'};
-        $_GLOBALS_2 = $input->{'GLOBALS'};
+        $_GLOBALS_2 = $input->{'_GLOBALS'};
+        $_GLOBALS_1 = $input->{'GLOBALS'};
         $GLOBALS_1 = $input->{'GLOBALS_1'};
         $_SERVER_1 = $input->{'_SERVER'};
         $_GET_1 = $input->{'_GET'};
@@ -2197,37 +2197,37 @@ class MyClass
         $_obj = $input->{'obj'};
         $includeDefaults = $input->{'includeDefaults'};
         $testObj = isset($input->{'testObj'}) ? MyClassTestObj::fromInput($input->{'testObj'}, $validate, $materializeDefaults) : null;
-        $_fromInput = $input->{'fromInput'};
-        $_toArray = $input->{'toArray'};
-        $_toStdClass = $input->{'toStdClass'};
-        $_validateInput = $input->{'validateInput'};
+        $fromInput = $input->{'fromInput'};
+        $toArray = $input->{'toArray'};
+        $toStdClass = $input->{'toStdClass'};
+        $validateInput = $input->{'validateInput'};
         $_schema_1 = $input->{'_schema'};
-        $_schema_2 = $input->{'schema'};
+        $schema = $input->{'schema'};
         $_defaults_1 = $input->{'_defaults'};
-        $_defaults_2 = $input->{'defaults'};
+        $defaults = $input->{'defaults'};
         $_providedOptionals_1 = $input->{'_providedOptionals'};
         $__providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
-        $_clone = $input->{'clone'};
-        $__construct_1 = $input->{'__construct'};
-        $__destruct_1 = $input->{'__destruct'};
-        $__get_1 = $input->{'__get'};
-        $__set_1 = $input->{'__set'};
-        $__call_1 = $input->{'__call'};
-        $__isset_1 = $input->{'__isset'};
-        $__unset_1 = $input->{'__unset'};
-        $__sleep_1 = $input->{'__sleep'};
-        $__wakeup_1 = $input->{'__wakeup'};
-        $__toString_1 = $input->{'__toString'};
-        $__invoke_1 = $input->{'__invoke'};
-        $__debugInfo_1 = $input->{'__debugInfo'};
-        $__clone_1 = $input->{'__clone'};
+        $clone = $input->{'clone'};
+        $__construct = $input->{'__construct'};
+        $__destruct = $input->{'__destruct'};
+        $__get = $input->{'__get'};
+        $__set = $input->{'__set'};
+        $__call = $input->{'__call'};
+        $__isset = $input->{'__isset'};
+        $__unset = $input->{'__unset'};
+        $__sleep = $input->{'__sleep'};
+        $__wakeup = $input->{'__wakeup'};
+        $__toString = $input->{'__toString'};
+        $__invoke = $input->{'__invoke'};
+        $__debugInfo = $input->{'__debugInfo'};
+        $__clone = $input->{'__clone'};
         $files = $input->{'files'};
         $_this = $input->{'this'};
         $ensureArgs1 = isset($input->{'ensureArgs1'}) ? ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : (((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)) ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults) : (null)))))) : null;
         $ensureArgs2 = isset($input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($input->{'ensureArgs2'}, $validate, $materializeDefaults) : null;
         $ensureArgs3 = isset($input->{'ensureArgs3'}) ? array_map(fn ($i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::fromInput($i, $validate, $materializeDefaults), $input->{'ensureArgs3'}) : null;
 
-        $obj = new self($_GLOBALS_1, $_GLOBALS_2, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $_input, $_obj, $includeDefaults, $_fromInput, $_toArray, $_toStdClass, $_validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone, $__construct_1, $__destruct_1, $__get_1, $__set_1, $__call_1, $__isset_1, $__unset_1, $__sleep_1, $__wakeup_1, $__toString_1, $__invoke_1, $__debugInfo_1, $__clone_1, $files, $_this);
+        $obj = new self($_GLOBALS_2, $_GLOBALS_1, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $_schema_1, $schema, $_defaults_1, $defaults, $_providedOptionals_1, $clone, $__construct, $__destruct, $__get, $__set, $__call, $__isset, $__unset, $__sleep, $__wakeup, $__toString, $__invoke, $__debugInfo, $__clone, $files, $_this);
         $obj->validate = $_validate;
         $obj->materializeDefaults = $_materializeDefaults;
         $obj->testObj = $testObj;
@@ -2248,21 +2248,21 @@ class MyClass
     public function toArray(bool $includeDefaults = false): array
     {
         $output = [];
-        $output['_GLOBALS'] = $this->_GLOBALS_1;
-        $output['GLOBALS'] = $this->_GLOBALS_2;
+        $output['_GLOBALS'] = $this->_GLOBALS;
+        $output['GLOBALS'] = $this->GLOBALS;
         $output['GLOBALS_1'] = $this->GLOBALS_1;
-        $output['_SERVER'] = $this->_SERVER_1;
-        $output['_GET'] = $this->_GET_1;
-        $output['_POST'] = $this->_POST_1;
-        $output['_FILES'] = $this->_FILES_1;
-        $output['_REQUEST'] = $this->_REQUEST_1;
-        $output['_SESSION'] = $this->_SESSION_1;
-        $output['_ENV'] = $this->_ENV_1;
-        $output['_COOKIE'] = $this->_COOKIE_1;
-        $output['php_errormsg'] = $this->_php_errormsg;
-        $output['http_response_header'] = $this->_http_response_header;
-        $output['argc'] = $this->_argc;
-        $output['argv'] = $this->_argv;
+        $output['_SERVER'] = $this->_SERVER;
+        $output['_GET'] = $this->_GET;
+        $output['_POST'] = $this->_POST;
+        $output['_FILES'] = $this->_FILES;
+        $output['_REQUEST'] = $this->_REQUEST;
+        $output['_SESSION'] = $this->_SESSION;
+        $output['_ENV'] = $this->_ENV;
+        $output['_COOKIE'] = $this->_COOKIE;
+        $output['php_errormsg'] = $this->php_errormsg;
+        $output['http_response_header'] = $this->http_response_header;
+        $output['argc'] = $this->argc;
+        $output['argv'] = $this->argv;
         $output['input'] = $this->input;
         if (isset($this->validate)) {
             $output['validate'] = $this->validate;
@@ -2275,32 +2275,32 @@ class MyClass
         if (isset($this->testObj)) {
             $output['testObj'] = ($this->testObj)->toArray($includeDefaults);
         }
-        $output['fromInput'] = $this->_fromInput;
-        $output['toArray'] = $this->_toArray;
-        $output['toStdClass'] = $this->_toStdClass;
-        $output['validateInput'] = $this->_validateInput;
+        $output['fromInput'] = $this->fromInput;
+        $output['toArray'] = $this->toArray;
+        $output['toStdClass'] = $this->toStdClass;
+        $output['validateInput'] = $this->validateInput;
         $output['_schema'] = $this->_schema_1;
-        $output['schema'] = $this->_schema_2;
+        $output['schema'] = $this->schema;
         $output['_defaults'] = $this->_defaults_1;
-        $output['defaults'] = $this->_defaults_2;
+        $output['defaults'] = $this->defaults;
         $output['_providedOptionals'] = $this->_providedOptionals_1;
         if (isset($this->__providedOptionals)) {
             $output['__providedOptionals'] = $this->__providedOptionals;
         }
-        $output['clone'] = $this->_clone;
-        $output['__construct'] = $this->__construct_1;
-        $output['__destruct'] = $this->__destruct_1;
-        $output['__get'] = $this->__get_1;
-        $output['__set'] = $this->__set_1;
-        $output['__call'] = $this->__call_1;
-        $output['__isset'] = $this->__isset_1;
-        $output['__unset'] = $this->__unset_1;
-        $output['__sleep'] = $this->__sleep_1;
-        $output['__wakeup'] = $this->__wakeup_1;
-        $output['__toString'] = $this->__toString_1;
-        $output['__invoke'] = $this->__invoke_1;
-        $output['__debugInfo'] = $this->__debugInfo_1;
-        $output['__clone'] = $this->__clone_1;
+        $output['clone'] = $this->clone;
+        $output['__construct'] = $this->__construct;
+        $output['__destruct'] = $this->__destruct;
+        $output['__get'] = $this->__get;
+        $output['__set'] = $this->__set;
+        $output['__call'] = $this->__call;
+        $output['__isset'] = $this->__isset;
+        $output['__unset'] = $this->__unset;
+        $output['__sleep'] = $this->__sleep;
+        $output['__wakeup'] = $this->__wakeup;
+        $output['__toString'] = $this->__toString;
+        $output['__invoke'] = $this->__invoke;
+        $output['__debugInfo'] = $this->__debugInfo;
+        $output['__clone'] = $this->__clone;
         $output['files'] = $this->files;
         $output['this'] = $this->_this;
         if (isset($this->ensureArgs1)) {
@@ -2337,21 +2337,21 @@ class MyClass
     public function toStdClass(bool $includeDefaults = false): \stdClass
     {
         $output = new \stdClass();
-        $output->{'_GLOBALS'} = $this->_GLOBALS_1;
-        $output->{'GLOBALS'} = $this->_GLOBALS_2;
+        $output->{'_GLOBALS'} = $this->_GLOBALS;
+        $output->{'GLOBALS'} = $this->GLOBALS;
         $output->{'GLOBALS_1'} = $this->GLOBALS_1;
-        $output->{'_SERVER'} = $this->_SERVER_1;
-        $output->{'_GET'} = $this->_GET_1;
-        $output->{'_POST'} = $this->_POST_1;
-        $output->{'_FILES'} = $this->_FILES_1;
-        $output->{'_REQUEST'} = $this->_REQUEST_1;
-        $output->{'_SESSION'} = $this->_SESSION_1;
-        $output->{'_ENV'} = $this->_ENV_1;
-        $output->{'_COOKIE'} = $this->_COOKIE_1;
-        $output->{'php_errormsg'} = $this->_php_errormsg;
-        $output->{'http_response_header'} = $this->_http_response_header;
-        $output->{'argc'} = $this->_argc;
-        $output->{'argv'} = $this->_argv;
+        $output->{'_SERVER'} = $this->_SERVER;
+        $output->{'_GET'} = $this->_GET;
+        $output->{'_POST'} = $this->_POST;
+        $output->{'_FILES'} = $this->_FILES;
+        $output->{'_REQUEST'} = $this->_REQUEST;
+        $output->{'_SESSION'} = $this->_SESSION;
+        $output->{'_ENV'} = $this->_ENV;
+        $output->{'_COOKIE'} = $this->_COOKIE;
+        $output->{'php_errormsg'} = $this->php_errormsg;
+        $output->{'http_response_header'} = $this->http_response_header;
+        $output->{'argc'} = $this->argc;
+        $output->{'argv'} = $this->argv;
         $output->{'input'} = $this->input;
         if (isset($this->validate)) {
             $output->{'validate'} = $this->validate;
@@ -2364,32 +2364,32 @@ class MyClass
         if (isset($this->testObj)) {
             $output->{'testObj'} = ($this->testObj)->toStdClass($includeDefaults);
         }
-        $output->{'fromInput'} = $this->_fromInput;
-        $output->{'toArray'} = $this->_toArray;
-        $output->{'toStdClass'} = $this->_toStdClass;
-        $output->{'validateInput'} = $this->_validateInput;
+        $output->{'fromInput'} = $this->fromInput;
+        $output->{'toArray'} = $this->toArray;
+        $output->{'toStdClass'} = $this->toStdClass;
+        $output->{'validateInput'} = $this->validateInput;
         $output->{'_schema'} = $this->_schema_1;
-        $output->{'schema'} = $this->_schema_2;
+        $output->{'schema'} = $this->schema;
         $output->{'_defaults'} = $this->_defaults_1;
-        $output->{'defaults'} = $this->_defaults_2;
+        $output->{'defaults'} = $this->defaults;
         $output->{'_providedOptionals'} = $this->_providedOptionals_1;
         if (isset($this->__providedOptionals)) {
             $output->{'__providedOptionals'} = $this->__providedOptionals;
         }
-        $output->{'clone'} = $this->_clone;
-        $output->{'__construct'} = $this->__construct_1;
-        $output->{'__destruct'} = $this->__destruct_1;
-        $output->{'__get'} = $this->__get_1;
-        $output->{'__set'} = $this->__set_1;
-        $output->{'__call'} = $this->__call_1;
-        $output->{'__isset'} = $this->__isset_1;
-        $output->{'__unset'} = $this->__unset_1;
-        $output->{'__sleep'} = $this->__sleep_1;
-        $output->{'__wakeup'} = $this->__wakeup_1;
-        $output->{'__toString'} = $this->__toString_1;
-        $output->{'__invoke'} = $this->__invoke_1;
-        $output->{'__debugInfo'} = $this->__debugInfo_1;
-        $output->{'__clone'} = $this->__clone_1;
+        $output->{'clone'} = $this->clone;
+        $output->{'__construct'} = $this->__construct;
+        $output->{'__destruct'} = $this->__destruct;
+        $output->{'__get'} = $this->__get;
+        $output->{'__set'} = $this->__set;
+        $output->{'__call'} = $this->__call;
+        $output->{'__isset'} = $this->__isset;
+        $output->{'__unset'} = $this->__unset;
+        $output->{'__sleep'} = $this->__sleep;
+        $output->{'__wakeup'} = $this->__wakeup;
+        $output->{'__toString'} = $this->__toString;
+        $output->{'__invoke'} = $this->__invoke;
+        $output->{'__debugInfo'} = $this->__debugInfo;
+        $output->{'__clone'} = $this->__clone;
         $output->{'files'} = $this->files;
         $output->{'this'} = $this->_this;
         if (isset($this->ensureArgs1)) {

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
@@ -296,12 +296,12 @@ class MyClass
     /**
      * @var string
      */
-    private string $_GLOBALS_1;
+    private string $_GLOBALS;
 
     /**
      * @var string
      */
-    private string $_GLOBALS_2;
+    private string $GLOBALS;
 
     /**
      * @var string
@@ -311,62 +311,62 @@ class MyClass
     /**
      * @var string
      */
-    private string $_SERVER_1;
+    private string $_SERVER;
 
     /**
      * @var string
      */
-    private string $_GET_1;
+    private string $_GET;
 
     /**
      * @var string
      */
-    private string $_POST_1;
+    private string $_POST;
 
     /**
      * @var string
      */
-    private string $_FILES_1;
+    private string $_FILES;
 
     /**
      * @var string
      */
-    private string $_REQUEST_1;
+    private string $_REQUEST;
 
     /**
      * @var string
      */
-    private string $_SESSION_1;
+    private string $_SESSION;
 
     /**
      * @var string
      */
-    private string $_ENV_1;
+    private string $_ENV;
 
     /**
      * @var string
      */
-    private string $_COOKIE_1;
+    private string $_COOKIE;
 
     /**
      * @var string
      */
-    private string $_php_errormsg;
+    private string $php_errormsg;
 
     /**
      * @var string
      */
-    private string $_http_response_header;
+    private string $http_response_header;
 
     /**
      * @var string
      */
-    private string $_argc;
+    private string $argc;
 
     /**
      * @var string
      */
-    private string $_argv;
+    private string $argv;
 
     /**
      * @var string
@@ -401,22 +401,22 @@ class MyClass
     /**
      * @var string
      */
-    private string $_fromInput;
+    private string $fromInput;
 
     /**
      * @var string
      */
-    private string $_toArray;
+    private string $toArray;
 
     /**
      * @var string
      */
-    private string $_toStdClass;
+    private string $toStdClass;
 
     /**
      * @var string
      */
-    private string $_validateInput;
+    private string $validateInput;
 
     /**
      * @var string
@@ -426,7 +426,7 @@ class MyClass
     /**
      * @var string
      */
-    private string $_schema_2;
+    private string $schema;
 
     /**
      * @var string
@@ -436,7 +436,7 @@ class MyClass
     /**
      * @var string
      */
-    private string $_defaults_2;
+    private string $defaults;
 
     /**
      * @var string
@@ -451,72 +451,72 @@ class MyClass
     /**
      * @var string
      */
-    private string $_clone;
+    private string $clone;
 
     /**
      * @var string
      */
-    private string $__construct_1;
+    private string $__construct;
 
     /**
      * @var string
      */
-    private string $__destruct_1;
+    private string $__destruct;
 
     /**
      * @var string
      */
-    private string $__get_1;
+    private string $__get;
 
     /**
      * @var string
      */
-    private string $__set_1;
+    private string $__set;
 
     /**
      * @var string
      */
-    private string $__call_1;
+    private string $__call;
 
     /**
      * @var string
      */
-    private string $__isset_1;
+    private string $__isset;
 
     /**
      * @var string
      */
-    private string $__unset_1;
+    private string $__unset;
 
     /**
      * @var string
      */
-    private string $__sleep_1;
+    private string $__sleep;
 
     /**
      * @var string
      */
-    private string $__wakeup_1;
+    private string $__wakeup;
 
     /**
      * @var string
      */
-    private string $__toString_1;
+    private string $__toString;
 
     /**
      * @var string
      */
-    private string $__invoke_1;
+    private string $__invoke;
 
     /**
      * @var string
      */
-    private string $__debugInfo_1;
+    private string $__debugInfo;
 
     /**
      * @var string
      */
-    private string $__clone_1;
+    private string $__clone;
 
     /**
      * @var string
@@ -544,8 +544,8 @@ class MyClass
     private ?array $ensureArgs3 = null;
 
     /**
-     * @param string $_GLOBALS_1
      * @param string $_GLOBALS_2
+     * @param string $_GLOBALS_1
      * @param string $GLOBALS_1
      * @param string $_SERVER_1
      * @param string $_GET_1
@@ -559,78 +559,78 @@ class MyClass
      * @param string $_http_response_header
      * @param string $_argc
      * @param string $_argv
-     * @param string $input
-     * @param string $obj
+     * @param string $_input
+     * @param string $_obj
      * @param string $includeDefaults
-     * @param string $_fromInput
-     * @param string $_toArray
-     * @param string $_toStdClass
-     * @param string $_validateInput
+     * @param string $fromInput
+     * @param string $toArray
+     * @param string $toStdClass
+     * @param string $validateInput
      * @param string $_schema_1
-     * @param string $_schema_2
+     * @param string $schema
      * @param string $_defaults_1
-     * @param string $_defaults_2
+     * @param string $defaults
      * @param string $_providedOptionals_1
-     * @param string $_clone
-     * @param string $__construct_1
-     * @param string $__destruct_1
-     * @param string $__get_1
-     * @param string $__set_1
-     * @param string $__call_1
-     * @param string $__isset_1
-     * @param string $__unset_1
-     * @param string $__sleep_1
-     * @param string $__wakeup_1
-     * @param string $__toString_1
-     * @param string $__invoke_1
-     * @param string $__debugInfo_1
-     * @param string $__clone_1
+     * @param string $clone
+     * @param string $__construct
+     * @param string $__destruct
+     * @param string $__get
+     * @param string $__set
+     * @param string $__call
+     * @param string $__isset
+     * @param string $__unset
+     * @param string $__sleep
+     * @param string $__wakeup
+     * @param string $__toString
+     * @param string $__invoke
+     * @param string $__debugInfo
+     * @param string $__clone
      * @param string $files
      * @param string $_this
      */
-    public function __construct(string $_GLOBALS_1, string $_GLOBALS_2, string $GLOBALS_1, string $_SERVER_1, string $_GET_1, string $_POST_1, string $_FILES_1, string $_REQUEST_1, string $_SESSION_1, string $_ENV_1, string $_COOKIE_1, string $_php_errormsg, string $_http_response_header, string $_argc, string $_argv, string $input, string $obj, string $includeDefaults, string $_fromInput, string $_toArray, string $_toStdClass, string $_validateInput, string $_schema_1, string $_schema_2, string $_defaults_1, string $_defaults_2, string $_providedOptionals_1, string $_clone, string $__construct_1, string $__destruct_1, string $__get_1, string $__set_1, string $__call_1, string $__isset_1, string $__unset_1, string $__sleep_1, string $__wakeup_1, string $__toString_1, string $__invoke_1, string $__debugInfo_1, string $__clone_1, string $files, string $_this)
+    public function __construct(string $_GLOBALS_2, string $_GLOBALS_1, string $GLOBALS_1, string $_SERVER_1, string $_GET_1, string $_POST_1, string $_FILES_1, string $_REQUEST_1, string $_SESSION_1, string $_ENV_1, string $_COOKIE_1, string $_php_errormsg, string $_http_response_header, string $_argc, string $_argv, string $_input, string $_obj, string $includeDefaults, string $fromInput, string $toArray, string $toStdClass, string $validateInput, string $_schema_1, string $schema, string $_defaults_1, string $defaults, string $_providedOptionals_1, string $clone, string $__construct, string $__destruct, string $__get, string $__set, string $__call, string $__isset, string $__unset, string $__sleep, string $__wakeup, string $__toString, string $__invoke, string $__debugInfo, string $__clone, string $files, string $_this)
     {
-        $this->_GLOBALS_1 = $_GLOBALS_1;
-        $this->_GLOBALS_2 = $_GLOBALS_2;
+        $this->_GLOBALS = $_GLOBALS_2;
+        $this->GLOBALS = $_GLOBALS_1;
         $this->GLOBALS_1 = $GLOBALS_1;
-        $this->_SERVER_1 = $_SERVER_1;
-        $this->_GET_1 = $_GET_1;
-        $this->_POST_1 = $_POST_1;
-        $this->_FILES_1 = $_FILES_1;
-        $this->_REQUEST_1 = $_REQUEST_1;
-        $this->_SESSION_1 = $_SESSION_1;
-        $this->_ENV_1 = $_ENV_1;
-        $this->_COOKIE_1 = $_COOKIE_1;
-        $this->_php_errormsg = $_php_errormsg;
-        $this->_http_response_header = $_http_response_header;
-        $this->_argc = $_argc;
-        $this->_argv = $_argv;
-        $this->input = $input;
-        $this->obj = $obj;
+        $this->_SERVER = $_SERVER_1;
+        $this->_GET = $_GET_1;
+        $this->_POST = $_POST_1;
+        $this->_FILES = $_FILES_1;
+        $this->_REQUEST = $_REQUEST_1;
+        $this->_SESSION = $_SESSION_1;
+        $this->_ENV = $_ENV_1;
+        $this->_COOKIE = $_COOKIE_1;
+        $this->php_errormsg = $_php_errormsg;
+        $this->http_response_header = $_http_response_header;
+        $this->argc = $_argc;
+        $this->argv = $_argv;
+        $this->input = $_input;
+        $this->obj = $_obj;
         $this->includeDefaults = $includeDefaults;
-        $this->_fromInput = $_fromInput;
-        $this->_toArray = $_toArray;
-        $this->_toStdClass = $_toStdClass;
-        $this->_validateInput = $_validateInput;
+        $this->fromInput = $fromInput;
+        $this->toArray = $toArray;
+        $this->toStdClass = $toStdClass;
+        $this->validateInput = $validateInput;
         $this->_schema_1 = $_schema_1;
-        $this->_schema_2 = $_schema_2;
+        $this->schema = $schema;
         $this->_defaults_1 = $_defaults_1;
-        $this->_defaults_2 = $_defaults_2;
+        $this->defaults = $defaults;
         $this->_providedOptionals_1 = $_providedOptionals_1;
-        $this->_clone = $_clone;
-        $this->__construct_1 = $__construct_1;
-        $this->__destruct_1 = $__destruct_1;
-        $this->__get_1 = $__get_1;
-        $this->__set_1 = $__set_1;
-        $this->__call_1 = $__call_1;
-        $this->__isset_1 = $__isset_1;
-        $this->__unset_1 = $__unset_1;
-        $this->__sleep_1 = $__sleep_1;
-        $this->__wakeup_1 = $__wakeup_1;
-        $this->__toString_1 = $__toString_1;
-        $this->__invoke_1 = $__invoke_1;
-        $this->__debugInfo_1 = $__debugInfo_1;
-        $this->__clone_1 = $__clone_1;
+        $this->clone = $clone;
+        $this->__construct = $__construct;
+        $this->__destruct = $__destruct;
+        $this->__get = $__get;
+        $this->__set = $__set;
+        $this->__call = $__call;
+        $this->__isset = $__isset;
+        $this->__unset = $__unset;
+        $this->__sleep = $__sleep;
+        $this->__wakeup = $__wakeup;
+        $this->__toString = $__toString;
+        $this->__invoke = $__invoke;
+        $this->__debugInfo = $__debugInfo;
+        $this->__clone = $__clone;
         $this->files = $files;
         $this->_this = $_this;
     }
@@ -638,38 +638,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_GLOBALS1(): string
+    public function get_GLOBALS(): string
     {
-        return $this->_GLOBALS_1;
-    }
-
-    /**
-     * @param string $_GLOBALS_1
-     * @return self
-     * @param bool $validate
-     */
-    public function with_GLOBALS1(string $_GLOBALS_1, bool $validate = true): self
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_1, self::$_schema['properties']['_GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->_GLOBALS_1 = $_GLOBALS_1;
-
-        return $clone;
-    }
-
-    /**
-     * @return string
-     */
-    public function get_GLOBALS2(): string
-    {
-        return $this->_GLOBALS_2;
+        return $this->_GLOBALS;
     }
 
     /**
@@ -677,18 +648,47 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_GLOBALS2(string $_GLOBALS_2, bool $validate = true): self
+    public function with_GLOBALS(string $_GLOBALS_2, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_2, self::$_schema['properties']['GLOBALS']);
+            $validator->validate($_GLOBALS_2, self::$_schema['properties']['_GLOBALS']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_GLOBALS_2 = $_GLOBALS_2;
+        $clone->_GLOBALS = $_GLOBALS_2;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGLOBALS(): string
+    {
+        return $this->GLOBALS;
+    }
+
+    /**
+     * @param string $_GLOBALS_1
+     * @return self
+     * @param bool $validate
+     */
+    public function withGLOBALS(string $_GLOBALS_1, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($_GLOBALS_1, self::$_schema['properties']['GLOBALS']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->GLOBALS = $_GLOBALS_1;
 
         return $clone;
     }
@@ -725,9 +725,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_SERVER1(): string
+    public function get_SERVER(): string
     {
-        return $this->_SERVER_1;
+        return $this->_SERVER;
     }
 
     /**
@@ -735,7 +735,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_SERVER1(string $_SERVER_1, bool $validate = true): self
+    public function with_SERVER(string $_SERVER_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -746,7 +746,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_SERVER_1 = $_SERVER_1;
+        $clone->_SERVER = $_SERVER_1;
 
         return $clone;
     }
@@ -754,9 +754,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_GET1(): string
+    public function get_GET(): string
     {
-        return $this->_GET_1;
+        return $this->_GET;
     }
 
     /**
@@ -764,7 +764,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_GET1(string $_GET_1, bool $validate = true): self
+    public function with_GET(string $_GET_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -775,7 +775,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_GET_1 = $_GET_1;
+        $clone->_GET = $_GET_1;
 
         return $clone;
     }
@@ -783,9 +783,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_POST1(): string
+    public function get_POST(): string
     {
-        return $this->_POST_1;
+        return $this->_POST;
     }
 
     /**
@@ -793,7 +793,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_POST1(string $_POST_1, bool $validate = true): self
+    public function with_POST(string $_POST_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -804,7 +804,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_POST_1 = $_POST_1;
+        $clone->_POST = $_POST_1;
 
         return $clone;
     }
@@ -812,9 +812,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_FILES1(): string
+    public function get_FILES(): string
     {
-        return $this->_FILES_1;
+        return $this->_FILES;
     }
 
     /**
@@ -822,7 +822,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_FILES1(string $_FILES_1, bool $validate = true): self
+    public function with_FILES(string $_FILES_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -833,7 +833,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_FILES_1 = $_FILES_1;
+        $clone->_FILES = $_FILES_1;
 
         return $clone;
     }
@@ -841,9 +841,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_REQUEST1(): string
+    public function get_REQUEST(): string
     {
-        return $this->_REQUEST_1;
+        return $this->_REQUEST;
     }
 
     /**
@@ -851,7 +851,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_REQUEST1(string $_REQUEST_1, bool $validate = true): self
+    public function with_REQUEST(string $_REQUEST_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -862,7 +862,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_REQUEST_1 = $_REQUEST_1;
+        $clone->_REQUEST = $_REQUEST_1;
 
         return $clone;
     }
@@ -870,9 +870,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_SESSION1(): string
+    public function get_SESSION(): string
     {
-        return $this->_SESSION_1;
+        return $this->_SESSION;
     }
 
     /**
@@ -880,7 +880,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_SESSION1(string $_SESSION_1, bool $validate = true): self
+    public function with_SESSION(string $_SESSION_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -891,7 +891,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_SESSION_1 = $_SESSION_1;
+        $clone->_SESSION = $_SESSION_1;
 
         return $clone;
     }
@@ -899,9 +899,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_ENV1(): string
+    public function get_ENV(): string
     {
-        return $this->_ENV_1;
+        return $this->_ENV;
     }
 
     /**
@@ -909,7 +909,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_ENV1(string $_ENV_1, bool $validate = true): self
+    public function with_ENV(string $_ENV_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -920,7 +920,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_ENV_1 = $_ENV_1;
+        $clone->_ENV = $_ENV_1;
 
         return $clone;
     }
@@ -928,9 +928,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_COOKIE1(): string
+    public function get_COOKIE(): string
     {
-        return $this->_COOKIE_1;
+        return $this->_COOKIE;
     }
 
     /**
@@ -938,7 +938,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_COOKIE1(string $_COOKIE_1, bool $validate = true): self
+    public function with_COOKIE(string $_COOKIE_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -949,7 +949,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_COOKIE_1 = $_COOKIE_1;
+        $clone->_COOKIE = $_COOKIE_1;
 
         return $clone;
     }
@@ -957,9 +957,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_PhpErrormsg(): string
+    public function getPhpErrormsg(): string
     {
-        return $this->_php_errormsg;
+        return $this->php_errormsg;
     }
 
     /**
@@ -967,7 +967,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_PhpErrormsg(string $_php_errormsg, bool $validate = true): self
+    public function withPhpErrormsg(string $_php_errormsg, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -978,7 +978,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_php_errormsg = $_php_errormsg;
+        $clone->php_errormsg = $_php_errormsg;
 
         return $clone;
     }
@@ -986,9 +986,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_HttpResponseHeader(): string
+    public function getHttpResponseHeader(): string
     {
-        return $this->_http_response_header;
+        return $this->http_response_header;
     }
 
     /**
@@ -996,7 +996,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_HttpResponseHeader(string $_http_response_header, bool $validate = true): self
+    public function withHttpResponseHeader(string $_http_response_header, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1007,7 +1007,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_http_response_header = $_http_response_header;
+        $clone->http_response_header = $_http_response_header;
 
         return $clone;
     }
@@ -1015,9 +1015,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Argc(): string
+    public function getArgc(): string
     {
-        return $this->_argc;
+        return $this->argc;
     }
 
     /**
@@ -1025,7 +1025,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_Argc(string $_argc, bool $validate = true): self
+    public function withArgc(string $_argc, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1036,7 +1036,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_argc = $_argc;
+        $clone->argc = $_argc;
 
         return $clone;
     }
@@ -1044,9 +1044,9 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Argv(): string
+    public function getArgv(): string
     {
-        return $this->_argv;
+        return $this->argv;
     }
 
     /**
@@ -1054,7 +1054,7 @@ class MyClass
      * @return self
      * @param bool $validate
      */
-    public function with_Argv(string $_argv, bool $validate = true): self
+    public function withArgv(string $_argv, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1065,7 +1065,7 @@ class MyClass
         }
 
         $clone = clone $this;
-        $clone->_argv = $_argv;
+        $clone->argv = $_argv;
 
         return $clone;
     }
@@ -1079,22 +1079,22 @@ class MyClass
     }
 
     /**
-     * @param string $input
+     * @param string $_input
      * @return self
      * @param bool $validate
      */
-    public function withInput(string $input, bool $validate = true): self
+    public function withInput(string $_input, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($input, self::$_schema['properties']['input']);
+            $validator->validate($_input, self::$_schema['properties']['input']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->input = $input;
+        $clone->input = $_input;
 
         return $clone;
     }
@@ -1108,22 +1108,22 @@ class MyClass
     }
 
     /**
-     * @param string $validate
+     * @param string $_validate
      * @return self
      * @param bool $validate
      */
-    public function withValidate(bool $validate = true): self
+    public function withValidate(string $_validate, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($validate, self::$_schema['properties']['validate']);
+            $validator->validate($_validate, self::$_schema['properties']['validate']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->validate = $validate;
+        $clone->validate = $_validate;
 
         return $clone;
     }
@@ -1148,22 +1148,22 @@ class MyClass
     }
 
     /**
-     * @param string $materializeDefaults
+     * @param string $_materializeDefaults
      * @return self
      * @param bool $validate
      */
-    public function withMaterializeDefaults(string $materializeDefaults, bool $validate = true): self
+    public function withMaterializeDefaults(string $_materializeDefaults, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($materializeDefaults, self::$_schema['properties']['materializeDefaults']);
+            $validator->validate($_materializeDefaults, self::$_schema['properties']['materializeDefaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->materializeDefaults = $materializeDefaults;
+        $clone->materializeDefaults = $_materializeDefaults;
         $clone->_providedOptionals['materializeDefaults'] = true;
 
         return $clone;
@@ -1190,22 +1190,22 @@ class MyClass
     }
 
     /**
-     * @param string $obj
+     * @param string $_obj
      * @return self
      * @param bool $validate
      */
-    public function withObj(string $obj, bool $validate = true): self
+    public function withObj(string $_obj, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($obj, self::$_schema['properties']['obj']);
+            $validator->validate($_obj, self::$_schema['properties']['obj']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->obj = $obj;
+        $clone->obj = $_obj;
 
         return $clone;
     }
@@ -1273,28 +1273,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_FromInput(): string
+    public function getFromInput(): string
     {
-        return $this->_fromInput;
+        return $this->fromInput;
     }
 
     /**
-     * @param string $_fromInput
+     * @param string $fromInput
      * @return self
      * @param bool $validate
      */
-    public function with_FromInput(string $_fromInput, bool $validate = true): self
+    public function withFromInput(string $fromInput, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_fromInput, self::$_schema['properties']['fromInput']);
+            $validator->validate($fromInput, self::$_schema['properties']['fromInput']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_fromInput = $_fromInput;
+        $clone->fromInput = $fromInput;
 
         return $clone;
     }
@@ -1302,28 +1302,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_ToArray(): string
+    public function getToArray(): string
     {
-        return $this->_toArray;
+        return $this->toArray;
     }
 
     /**
-     * @param string $_toArray
+     * @param string $toArray
      * @return self
      * @param bool $validate
      */
-    public function with_ToArray(string $_toArray, bool $validate = true): self
+    public function withToArray(string $toArray, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toArray, self::$_schema['properties']['toArray']);
+            $validator->validate($toArray, self::$_schema['properties']['toArray']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toArray = $_toArray;
+        $clone->toArray = $toArray;
 
         return $clone;
     }
@@ -1331,28 +1331,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_ToStdClass(): string
+    public function getToStdClass(): string
     {
-        return $this->_toStdClass;
+        return $this->toStdClass;
     }
 
     /**
-     * @param string $_toStdClass
+     * @param string $toStdClass
      * @return self
      * @param bool $validate
      */
-    public function with_ToStdClass(string $_toStdClass, bool $validate = true): self
+    public function withToStdClass(string $toStdClass, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_toStdClass, self::$_schema['properties']['toStdClass']);
+            $validator->validate($toStdClass, self::$_schema['properties']['toStdClass']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_toStdClass = $_toStdClass;
+        $clone->toStdClass = $toStdClass;
 
         return $clone;
     }
@@ -1360,28 +1360,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_ValidateInput(): string
+    public function getValidateInput(): string
     {
-        return $this->_validateInput;
+        return $this->validateInput;
     }
 
     /**
-     * @param string $_validateInput
+     * @param string $validateInput
      * @return self
      * @param bool $validate
      */
-    public function with_ValidateInput(string $_validateInput, bool $validate = true): self
+    public function withValidateInput(string $validateInput, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_validateInput, self::$_schema['properties']['validateInput']);
+            $validator->validate($validateInput, self::$_schema['properties']['validateInput']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_validateInput = $_validateInput;
+        $clone->validateInput = $validateInput;
 
         return $clone;
     }
@@ -1418,28 +1418,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Schema2(): string
+    public function getSchema(): string
     {
-        return $this->_schema_2;
+        return $this->schema;
     }
 
     /**
-     * @param string $_schema_2
+     * @param string $schema
      * @return self
      * @param bool $validate
      */
-    public function with_Schema2(string $_schema_2, bool $validate = true): self
+    public function withSchema(string $schema, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_2, self::$_schema['properties']['schema']);
+            $validator->validate($schema, self::$_schema['properties']['schema']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_schema_2 = $_schema_2;
+        $clone->schema = $schema;
 
         return $clone;
     }
@@ -1476,28 +1476,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Defaults2(): string
+    public function getDefaults(): string
     {
-        return $this->_defaults_2;
+        return $this->defaults;
     }
 
     /**
-     * @param string $_defaults_2
+     * @param string $defaults
      * @return self
      * @param bool $validate
      */
-    public function with_Defaults2(string $_defaults_2, bool $validate = true): self
+    public function withDefaults(string $defaults, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_2, self::$_schema['properties']['defaults']);
+            $validator->validate($defaults, self::$_schema['properties']['defaults']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_defaults_2 = $_defaults_2;
+        $clone->defaults = $defaults;
 
         return $clone;
     }
@@ -1540,22 +1540,22 @@ class MyClass
     }
 
     /**
-     * @param string $__providedOptionals
+     * @param string $__providedOptionals_1
      * @return self
      * @param bool $validate
      */
-    public function with__ProvidedOptionals(string $__providedOptionals, bool $validate = true): self
+    public function with__ProvidedOptionals(string $__providedOptionals_1, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__providedOptionals, self::$_schema['properties']['__providedOptionals']);
+            $validator->validate($__providedOptionals_1, self::$_schema['properties']['__providedOptionals']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__providedOptionals = $__providedOptionals;
+        $clone->__providedOptionals = $__providedOptionals_1;
 
         return $clone;
     }
@@ -1574,28 +1574,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get_Clone(): string
+    public function getClone(): string
     {
-        return $this->_clone;
+        return $this->clone;
     }
 
     /**
-     * @param string $_clone
+     * @param string $clone
      * @return self
      * @param bool $validate
      */
-    public function with_Clone(string $_clone, bool $validate = true): self
+    public function withClone(string $clone, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone, self::$_schema['properties']['clone']);
+            $validator->validate($clone, self::$_schema['properties']['clone']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_clone = $_clone;
+        $clone->clone = $clone;
 
         return $clone;
     }
@@ -1603,28 +1603,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Construct1(): string
+    public function get__Construct(): string
     {
-        return $this->__construct_1;
+        return $this->__construct;
     }
 
     /**
-     * @param string $__construct_1
+     * @param string $__construct
      * @return self
      * @param bool $validate
      */
-    public function with__Construct1(string $__construct_1, bool $validate = true): self
+    public function with__Construct(string $__construct, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__construct_1, self::$_schema['properties']['__construct']);
+            $validator->validate($__construct, self::$_schema['properties']['__construct']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__construct_1 = $__construct_1;
+        $clone->__construct = $__construct;
 
         return $clone;
     }
@@ -1632,28 +1632,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Destruct1(): string
+    public function get__Destruct(): string
     {
-        return $this->__destruct_1;
+        return $this->__destruct;
     }
 
     /**
-     * @param string $__destruct_1
+     * @param string $__destruct
      * @return self
      * @param bool $validate
      */
-    public function with__Destruct1(string $__destruct_1, bool $validate = true): self
+    public function with__Destruct(string $__destruct, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__destruct_1, self::$_schema['properties']['__destruct']);
+            $validator->validate($__destruct, self::$_schema['properties']['__destruct']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__destruct_1 = $__destruct_1;
+        $clone->__destruct = $__destruct;
 
         return $clone;
     }
@@ -1661,28 +1661,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Get1(): string
+    public function get__Get(): string
     {
-        return $this->__get_1;
+        return $this->__get;
     }
 
     /**
-     * @param string $__get_1
+     * @param string $__get
      * @return self
      * @param bool $validate
      */
-    public function with__Get1(string $__get_1, bool $validate = true): self
+    public function with__Get(string $__get, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__get_1, self::$_schema['properties']['__get']);
+            $validator->validate($__get, self::$_schema['properties']['__get']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__get_1 = $__get_1;
+        $clone->__get = $__get;
 
         return $clone;
     }
@@ -1690,28 +1690,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Set1(): string
+    public function get__Set(): string
     {
-        return $this->__set_1;
+        return $this->__set;
     }
 
     /**
-     * @param string $__set_1
+     * @param string $__set
      * @return self
      * @param bool $validate
      */
-    public function with__Set1(string $__set_1, bool $validate = true): self
+    public function with__Set(string $__set, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__set_1, self::$_schema['properties']['__set']);
+            $validator->validate($__set, self::$_schema['properties']['__set']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__set_1 = $__set_1;
+        $clone->__set = $__set;
 
         return $clone;
     }
@@ -1719,28 +1719,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Call1(): string
+    public function get__Call(): string
     {
-        return $this->__call_1;
+        return $this->__call;
     }
 
     /**
-     * @param string $__call_1
+     * @param string $__call
      * @return self
      * @param bool $validate
      */
-    public function with__Call1(string $__call_1, bool $validate = true): self
+    public function with__Call(string $__call, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__call_1, self::$_schema['properties']['__call']);
+            $validator->validate($__call, self::$_schema['properties']['__call']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__call_1 = $__call_1;
+        $clone->__call = $__call;
 
         return $clone;
     }
@@ -1748,28 +1748,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Isset1(): string
+    public function get__Isset(): string
     {
-        return $this->__isset_1;
+        return $this->__isset;
     }
 
     /**
-     * @param string $__isset_1
+     * @param string $__isset
      * @return self
      * @param bool $validate
      */
-    public function with__Isset1(string $__isset_1, bool $validate = true): self
+    public function with__Isset(string $__isset, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__isset_1, self::$_schema['properties']['__isset']);
+            $validator->validate($__isset, self::$_schema['properties']['__isset']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__isset_1 = $__isset_1;
+        $clone->__isset = $__isset;
 
         return $clone;
     }
@@ -1777,28 +1777,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Unset1(): string
+    public function get__Unset(): string
     {
-        return $this->__unset_1;
+        return $this->__unset;
     }
 
     /**
-     * @param string $__unset_1
+     * @param string $__unset
      * @return self
      * @param bool $validate
      */
-    public function with__Unset1(string $__unset_1, bool $validate = true): self
+    public function with__Unset(string $__unset, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__unset_1, self::$_schema['properties']['__unset']);
+            $validator->validate($__unset, self::$_schema['properties']['__unset']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__unset_1 = $__unset_1;
+        $clone->__unset = $__unset;
 
         return $clone;
     }
@@ -1806,28 +1806,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Sleep1(): string
+    public function get__Sleep(): string
     {
-        return $this->__sleep_1;
+        return $this->__sleep;
     }
 
     /**
-     * @param string $__sleep_1
+     * @param string $__sleep
      * @return self
      * @param bool $validate
      */
-    public function with__Sleep1(string $__sleep_1, bool $validate = true): self
+    public function with__Sleep(string $__sleep, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__sleep_1, self::$_schema['properties']['__sleep']);
+            $validator->validate($__sleep, self::$_schema['properties']['__sleep']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__sleep_1 = $__sleep_1;
+        $clone->__sleep = $__sleep;
 
         return $clone;
     }
@@ -1835,28 +1835,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Wakeup1(): string
+    public function get__Wakeup(): string
     {
-        return $this->__wakeup_1;
+        return $this->__wakeup;
     }
 
     /**
-     * @param string $__wakeup_1
+     * @param string $__wakeup
      * @return self
      * @param bool $validate
      */
-    public function with__Wakeup1(string $__wakeup_1, bool $validate = true): self
+    public function with__Wakeup(string $__wakeup, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__wakeup_1, self::$_schema['properties']['__wakeup']);
+            $validator->validate($__wakeup, self::$_schema['properties']['__wakeup']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__wakeup_1 = $__wakeup_1;
+        $clone->__wakeup = $__wakeup;
 
         return $clone;
     }
@@ -1864,28 +1864,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__ToString1(): string
+    public function get__ToString(): string
     {
-        return $this->__toString_1;
+        return $this->__toString;
     }
 
     /**
-     * @param string $__toString_1
+     * @param string $__toString
      * @return self
      * @param bool $validate
      */
-    public function with__ToString1(string $__toString_1, bool $validate = true): self
+    public function with__ToString(string $__toString, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__toString_1, self::$_schema['properties']['__toString']);
+            $validator->validate($__toString, self::$_schema['properties']['__toString']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__toString_1 = $__toString_1;
+        $clone->__toString = $__toString;
 
         return $clone;
     }
@@ -1893,28 +1893,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Invoke1(): string
+    public function get__Invoke(): string
     {
-        return $this->__invoke_1;
+        return $this->__invoke;
     }
 
     /**
-     * @param string $__invoke_1
+     * @param string $__invoke
      * @return self
      * @param bool $validate
      */
-    public function with__Invoke1(string $__invoke_1, bool $validate = true): self
+    public function with__Invoke(string $__invoke, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__invoke_1, self::$_schema['properties']['__invoke']);
+            $validator->validate($__invoke, self::$_schema['properties']['__invoke']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__invoke_1 = $__invoke_1;
+        $clone->__invoke = $__invoke;
 
         return $clone;
     }
@@ -1922,28 +1922,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__DebugInfo1(): string
+    public function get__DebugInfo(): string
     {
-        return $this->__debugInfo_1;
+        return $this->__debugInfo;
     }
 
     /**
-     * @param string $__debugInfo_1
+     * @param string $__debugInfo
      * @return self
      * @param bool $validate
      */
-    public function with__DebugInfo1(string $__debugInfo_1, bool $validate = true): self
+    public function with__DebugInfo(string $__debugInfo, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__debugInfo_1, self::$_schema['properties']['__debugInfo']);
+            $validator->validate($__debugInfo, self::$_schema['properties']['__debugInfo']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__debugInfo_1 = $__debugInfo_1;
+        $clone->__debugInfo = $__debugInfo;
 
         return $clone;
     }
@@ -1951,28 +1951,28 @@ class MyClass
     /**
      * @return string
      */
-    public function get__Clone1(): string
+    public function get__Clone(): string
     {
-        return $this->__clone_1;
+        return $this->__clone;
     }
 
     /**
-     * @param string $__clone_1
+     * @param string $__clone
      * @return self
      * @param bool $validate
      */
-    public function with__Clone1(string $__clone_1, bool $validate = true): self
+    public function with__Clone(string $__clone, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($__clone_1, self::$_schema['properties']['__clone']);
+            $validator->validate($__clone, self::$_schema['properties']['__clone']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->__clone_1 = $__clone_1;
+        $clone->__clone = $__clone;
 
         return $clone;
     }
@@ -2167,8 +2167,8 @@ class MyClass
         }
 
         $__providedOptionals = [];
-        $_GLOBALS_1 = $input->{'_GLOBALS'};
-        $_GLOBALS_2 = $input->{'GLOBALS'};
+        $_GLOBALS_2 = $input->{'_GLOBALS'};
+        $_GLOBALS_1 = $input->{'GLOBALS'};
         $GLOBALS_1 = $input->{'GLOBALS_1'};
         $_SERVER_1 = $input->{'_SERVER'};
         $_GET_1 = $input->{'_GET'};
@@ -2191,30 +2191,30 @@ class MyClass
         $_obj = $input->{'obj'};
         $includeDefaults = $input->{'includeDefaults'};
         $testObj = isset($input->{'testObj'}) ? MyClassTestObj::fromInput($input->{'testObj'}, $validate, $materializeDefaults) : null;
-        $_fromInput = $input->{'fromInput'};
-        $_toArray = $input->{'toArray'};
-        $_toStdClass = $input->{'toStdClass'};
-        $_validateInput = $input->{'validateInput'};
+        $fromInput = $input->{'fromInput'};
+        $toArray = $input->{'toArray'};
+        $toStdClass = $input->{'toStdClass'};
+        $validateInput = $input->{'validateInput'};
         $_schema_1 = $input->{'_schema'};
-        $_schema_2 = $input->{'schema'};
+        $schema = $input->{'schema'};
         $_defaults_1 = $input->{'_defaults'};
-        $_defaults_2 = $input->{'defaults'};
+        $defaults = $input->{'defaults'};
         $_providedOptionals_1 = $input->{'_providedOptionals'};
         $__providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
-        $_clone = $input->{'clone'};
-        $__construct_1 = $input->{'__construct'};
-        $__destruct_1 = $input->{'__destruct'};
-        $__get_1 = $input->{'__get'};
-        $__set_1 = $input->{'__set'};
-        $__call_1 = $input->{'__call'};
-        $__isset_1 = $input->{'__isset'};
-        $__unset_1 = $input->{'__unset'};
-        $__sleep_1 = $input->{'__sleep'};
-        $__wakeup_1 = $input->{'__wakeup'};
-        $__toString_1 = $input->{'__toString'};
-        $__invoke_1 = $input->{'__invoke'};
-        $__debugInfo_1 = $input->{'__debugInfo'};
-        $__clone_1 = $input->{'__clone'};
+        $clone = $input->{'clone'};
+        $__construct = $input->{'__construct'};
+        $__destruct = $input->{'__destruct'};
+        $__get = $input->{'__get'};
+        $__set = $input->{'__set'};
+        $__call = $input->{'__call'};
+        $__isset = $input->{'__isset'};
+        $__unset = $input->{'__unset'};
+        $__sleep = $input->{'__sleep'};
+        $__wakeup = $input->{'__wakeup'};
+        $__toString = $input->{'__toString'};
+        $__invoke = $input->{'__invoke'};
+        $__debugInfo = $input->{'__debugInfo'};
+        $__clone = $input->{'__clone'};
         $files = $input->{'files'};
         $_this = $input->{'this'};
         $ensureArgs1 = isset($input->{'ensureArgs1'}) ? match (true) {
@@ -2226,7 +2226,7 @@ class MyClass
         $ensureArgs2 = isset($input->{'ensureArgs2'}) ? MyClassEnsureArgs2::fromInput($input->{'ensureArgs2'}, $validate, $materializeDefaults) : null;
         $ensureArgs3 = isset($input->{'ensureArgs3'}) ? array_map(fn (array|object $i): MyClassEnsureArgs3Item => MyClassEnsureArgs3Item::fromInput($i, $validate, $materializeDefaults), $input->{'ensureArgs3'}) : null;
 
-        $obj = new self($_GLOBALS_1, $_GLOBALS_2, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $_input, $_obj, $includeDefaults, $_fromInput, $_toArray, $_toStdClass, $_validateInput, $_schema_1, $_schema_2, $_defaults_1, $_defaults_2, $_providedOptionals_1, $_clone, $__construct_1, $__destruct_1, $__get_1, $__set_1, $__call_1, $__isset_1, $__unset_1, $__sleep_1, $__wakeup_1, $__toString_1, $__invoke_1, $__debugInfo_1, $__clone_1, $files, $_this);
+        $obj = new self($_GLOBALS_2, $_GLOBALS_1, $GLOBALS_1, $_SERVER_1, $_GET_1, $_POST_1, $_FILES_1, $_REQUEST_1, $_SESSION_1, $_ENV_1, $_COOKIE_1, $_php_errormsg, $_http_response_header, $_argc, $_argv, $_input, $_obj, $includeDefaults, $fromInput, $toArray, $toStdClass, $validateInput, $_schema_1, $schema, $_defaults_1, $defaults, $_providedOptionals_1, $clone, $__construct, $__destruct, $__get, $__set, $__call, $__isset, $__unset, $__sleep, $__wakeup, $__toString, $__invoke, $__debugInfo, $__clone, $files, $_this);
         $obj->validate = $_validate;
         $obj->materializeDefaults = $_materializeDefaults;
         $obj->testObj = $testObj;
@@ -2247,21 +2247,21 @@ class MyClass
     public function toArray(bool $includeDefaults = false): array
     {
         $output = [];
-        $output['_GLOBALS'] = $this->_GLOBALS_1;
-        $output['GLOBALS'] = $this->_GLOBALS_2;
+        $output['_GLOBALS'] = $this->_GLOBALS;
+        $output['GLOBALS'] = $this->GLOBALS;
         $output['GLOBALS_1'] = $this->GLOBALS_1;
-        $output['_SERVER'] = $this->_SERVER_1;
-        $output['_GET'] = $this->_GET_1;
-        $output['_POST'] = $this->_POST_1;
-        $output['_FILES'] = $this->_FILES_1;
-        $output['_REQUEST'] = $this->_REQUEST_1;
-        $output['_SESSION'] = $this->_SESSION_1;
-        $output['_ENV'] = $this->_ENV_1;
-        $output['_COOKIE'] = $this->_COOKIE_1;
-        $output['php_errormsg'] = $this->_php_errormsg;
-        $output['http_response_header'] = $this->_http_response_header;
-        $output['argc'] = $this->_argc;
-        $output['argv'] = $this->_argv;
+        $output['_SERVER'] = $this->_SERVER;
+        $output['_GET'] = $this->_GET;
+        $output['_POST'] = $this->_POST;
+        $output['_FILES'] = $this->_FILES;
+        $output['_REQUEST'] = $this->_REQUEST;
+        $output['_SESSION'] = $this->_SESSION;
+        $output['_ENV'] = $this->_ENV;
+        $output['_COOKIE'] = $this->_COOKIE;
+        $output['php_errormsg'] = $this->php_errormsg;
+        $output['http_response_header'] = $this->http_response_header;
+        $output['argc'] = $this->argc;
+        $output['argv'] = $this->argv;
         $output['input'] = $this->input;
         if (isset($this->validate)) {
             $output['validate'] = $this->validate;
@@ -2274,32 +2274,32 @@ class MyClass
         if (isset($this->testObj)) {
             $output['testObj'] = ($this->testObj)->toArray($includeDefaults);
         }
-        $output['fromInput'] = $this->_fromInput;
-        $output['toArray'] = $this->_toArray;
-        $output['toStdClass'] = $this->_toStdClass;
-        $output['validateInput'] = $this->_validateInput;
+        $output['fromInput'] = $this->fromInput;
+        $output['toArray'] = $this->toArray;
+        $output['toStdClass'] = $this->toStdClass;
+        $output['validateInput'] = $this->validateInput;
         $output['_schema'] = $this->_schema_1;
-        $output['schema'] = $this->_schema_2;
+        $output['schema'] = $this->schema;
         $output['_defaults'] = $this->_defaults_1;
-        $output['defaults'] = $this->_defaults_2;
+        $output['defaults'] = $this->defaults;
         $output['_providedOptionals'] = $this->_providedOptionals_1;
         if (isset($this->__providedOptionals)) {
             $output['__providedOptionals'] = $this->__providedOptionals;
         }
-        $output['clone'] = $this->_clone;
-        $output['__construct'] = $this->__construct_1;
-        $output['__destruct'] = $this->__destruct_1;
-        $output['__get'] = $this->__get_1;
-        $output['__set'] = $this->__set_1;
-        $output['__call'] = $this->__call_1;
-        $output['__isset'] = $this->__isset_1;
-        $output['__unset'] = $this->__unset_1;
-        $output['__sleep'] = $this->__sleep_1;
-        $output['__wakeup'] = $this->__wakeup_1;
-        $output['__toString'] = $this->__toString_1;
-        $output['__invoke'] = $this->__invoke_1;
-        $output['__debugInfo'] = $this->__debugInfo_1;
-        $output['__clone'] = $this->__clone_1;
+        $output['clone'] = $this->clone;
+        $output['__construct'] = $this->__construct;
+        $output['__destruct'] = $this->__destruct;
+        $output['__get'] = $this->__get;
+        $output['__set'] = $this->__set;
+        $output['__call'] = $this->__call;
+        $output['__isset'] = $this->__isset;
+        $output['__unset'] = $this->__unset;
+        $output['__sleep'] = $this->__sleep;
+        $output['__wakeup'] = $this->__wakeup;
+        $output['__toString'] = $this->__toString;
+        $output['__invoke'] = $this->__invoke;
+        $output['__debugInfo'] = $this->__debugInfo;
+        $output['__clone'] = $this->__clone;
         $output['files'] = $this->files;
         $output['this'] = $this->_this;
         if (isset($this->ensureArgs1)) {
@@ -2336,21 +2336,21 @@ class MyClass
     public function toStdClass(bool $includeDefaults = false): \stdClass
     {
         $output = new \stdClass();
-        $output->{'_GLOBALS'} = $this->_GLOBALS_1;
-        $output->{'GLOBALS'} = $this->_GLOBALS_2;
+        $output->{'_GLOBALS'} = $this->_GLOBALS;
+        $output->{'GLOBALS'} = $this->GLOBALS;
         $output->{'GLOBALS_1'} = $this->GLOBALS_1;
-        $output->{'_SERVER'} = $this->_SERVER_1;
-        $output->{'_GET'} = $this->_GET_1;
-        $output->{'_POST'} = $this->_POST_1;
-        $output->{'_FILES'} = $this->_FILES_1;
-        $output->{'_REQUEST'} = $this->_REQUEST_1;
-        $output->{'_SESSION'} = $this->_SESSION_1;
-        $output->{'_ENV'} = $this->_ENV_1;
-        $output->{'_COOKIE'} = $this->_COOKIE_1;
-        $output->{'php_errormsg'} = $this->_php_errormsg;
-        $output->{'http_response_header'} = $this->_http_response_header;
-        $output->{'argc'} = $this->_argc;
-        $output->{'argv'} = $this->_argv;
+        $output->{'_SERVER'} = $this->_SERVER;
+        $output->{'_GET'} = $this->_GET;
+        $output->{'_POST'} = $this->_POST;
+        $output->{'_FILES'} = $this->_FILES;
+        $output->{'_REQUEST'} = $this->_REQUEST;
+        $output->{'_SESSION'} = $this->_SESSION;
+        $output->{'_ENV'} = $this->_ENV;
+        $output->{'_COOKIE'} = $this->_COOKIE;
+        $output->{'php_errormsg'} = $this->php_errormsg;
+        $output->{'http_response_header'} = $this->http_response_header;
+        $output->{'argc'} = $this->argc;
+        $output->{'argv'} = $this->argv;
         $output->{'input'} = $this->input;
         if (isset($this->validate)) {
             $output->{'validate'} = $this->validate;
@@ -2363,32 +2363,32 @@ class MyClass
         if (isset($this->testObj)) {
             $output->{'testObj'} = ($this->testObj)->toStdClass($includeDefaults);
         }
-        $output->{'fromInput'} = $this->_fromInput;
-        $output->{'toArray'} = $this->_toArray;
-        $output->{'toStdClass'} = $this->_toStdClass;
-        $output->{'validateInput'} = $this->_validateInput;
+        $output->{'fromInput'} = $this->fromInput;
+        $output->{'toArray'} = $this->toArray;
+        $output->{'toStdClass'} = $this->toStdClass;
+        $output->{'validateInput'} = $this->validateInput;
         $output->{'_schema'} = $this->_schema_1;
-        $output->{'schema'} = $this->_schema_2;
+        $output->{'schema'} = $this->schema;
         $output->{'_defaults'} = $this->_defaults_1;
-        $output->{'defaults'} = $this->_defaults_2;
+        $output->{'defaults'} = $this->defaults;
         $output->{'_providedOptionals'} = $this->_providedOptionals_1;
         if (isset($this->__providedOptionals)) {
             $output->{'__providedOptionals'} = $this->__providedOptionals;
         }
-        $output->{'clone'} = $this->_clone;
-        $output->{'__construct'} = $this->__construct_1;
-        $output->{'__destruct'} = $this->__destruct_1;
-        $output->{'__get'} = $this->__get_1;
-        $output->{'__set'} = $this->__set_1;
-        $output->{'__call'} = $this->__call_1;
-        $output->{'__isset'} = $this->__isset_1;
-        $output->{'__unset'} = $this->__unset_1;
-        $output->{'__sleep'} = $this->__sleep_1;
-        $output->{'__wakeup'} = $this->__wakeup_1;
-        $output->{'__toString'} = $this->__toString_1;
-        $output->{'__invoke'} = $this->__invoke_1;
-        $output->{'__debugInfo'} = $this->__debugInfo_1;
-        $output->{'__clone'} = $this->__clone_1;
+        $output->{'clone'} = $this->clone;
+        $output->{'__construct'} = $this->__construct;
+        $output->{'__destruct'} = $this->__destruct;
+        $output->{'__get'} = $this->__get;
+        $output->{'__set'} = $this->__set;
+        $output->{'__call'} = $this->__call;
+        $output->{'__isset'} = $this->__isset;
+        $output->{'__unset'} = $this->__unset;
+        $output->{'__sleep'} = $this->__sleep;
+        $output->{'__wakeup'} = $this->__wakeup;
+        $output->{'__toString'} = $this->__toString;
+        $output->{'__invoke'} = $this->__invoke;
+        $output->{'__debugInfo'} = $this->__debugInfo;
+        $output->{'__clone'} = $this->__clone;
         $output->{'files'} = $this->files;
         $output->{'this'} = $this->_this;
         if (isset($this->ensureArgs1)) {

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClassFilesItem.php
@@ -48,22 +48,22 @@ class MyClassFilesItem
     }
 
     /**
-     * @param string $input
+     * @param string $_input
      * @return self
      * @param bool $validate
      */
-    public function withInput($input, bool $validate = true)
+    public function withInput($_input, bool $validate = true)
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($input, self::$_schema['properties']['input']);
+            $validator->validate($_input, self::$_schema['properties']['input']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->input = $input;
+        $clone->input = $_input;
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
@@ -50,22 +50,22 @@ class MyClassFilesItem
     }
 
     /**
-     * @param string $input
+     * @param string $_input
      * @return self
      * @param bool $validate
      */
-    public function withInput(string $input, bool $validate = true): self
+    public function withInput(string $_input, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($input, self::$_schema['properties']['input']);
+            $validator->validate($_input, self::$_schema['properties']['input']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->input = $input;
+        $clone->input = $_input;
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
@@ -50,22 +50,22 @@ class MyClassFilesItem
     }
 
     /**
-     * @param string $input
+     * @param string $_input
      * @return self
      * @param bool $validate
      */
-    public function withInput(string $input, bool $validate = true): self
+    public function withInput(string $_input, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($input, self::$_schema['properties']['input']);
+            $validator->validate($_input, self::$_schema['properties']['input']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->input = $input;
+        $clone->input = $_input;
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-5.6/MyClass.php
@@ -117,12 +117,12 @@ class MyClass
     /**
      * @var string
      */
-    private $foo_bar;
+    private $_foo_bar;
 
     /**
      * @var string
      */
-    private $_foo_bar;
+    private $foo_bar;
 
     /**
      * @var string
@@ -167,8 +167,8 @@ class MyClass
      * @param string $foo__
      * @param string $_foo_
      * @param string $__foo__
-     * @param string $foo_bar
      * @param string $_foo_bar
+     * @param string $foo_bar
      * @param string $baz_qux
      * @param string $_123_qwe
      * @param string $Gorod
@@ -176,7 +176,7 @@ class MyClass
      * @param string $IP_adres
      * @param string $_tildas
      */
-    public function __construct($foo, $_foo, $__foo, $foo_, $foo__, $_foo_, $__foo__, $foo_bar, $_foo_bar, $baz_qux, $_123_qwe, $Gorod, $nazvanie_iur_litsa, $IP_adres, $_tildas)
+    public function __construct($foo, $_foo, $__foo, $foo_, $foo__, $_foo_, $__foo__, $_foo_bar, $foo_bar, $baz_qux, $_123_qwe, $Gorod, $nazvanie_iur_litsa, $IP_adres, $_tildas)
     {
         $this->foo = $foo;
         $this->_foo = $_foo;
@@ -185,8 +185,8 @@ class MyClass
         $this->foo__ = $foo__;
         $this->_foo_ = $_foo_;
         $this->__foo__ = $__foo__;
-        $this->foo_bar = $foo_bar;
         $this->_foo_bar = $_foo_bar;
+        $this->foo_bar = $foo_bar;
         $this->baz_qux = $baz_qux;
         $this->_123_qwe = $_123_qwe;
         $this->Gorod = $Gorod;
@@ -401,35 +401,6 @@ class MyClass
     /**
      * @return string
      */
-    public function getFooBar()
-    {
-        return $this->foo_bar;
-    }
-
-    /**
-     * @param string $foo_bar
-     * @return self
-     * @param bool $validate
-     */
-    public function withFooBar($foo_bar, bool $validate = true)
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->foo_bar = $foo_bar;
-
-        return $clone;
-    }
-
-    /**
-     * @return string
-     */
     public function get_FooBar()
     {
         return $this->_foo_bar;
@@ -444,7 +415,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo bar']);
+            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -452,6 +423,35 @@ class MyClass
 
         $clone = clone $this;
         $clone->_foo_bar = $_foo_bar;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFooBar()
+    {
+        return $this->foo_bar;
+    }
+
+    /**
+     * @param string $foo_bar
+     * @return self
+     * @param bool $validate
+     */
+    public function withFooBar($foo_bar, bool $validate = true)
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar = $foo_bar;
 
         return $clone;
     }
@@ -698,8 +698,8 @@ class MyClass
         $foo__ = $input->{'foo__'};
         $_foo_ = $input->{'_foo_'};
         $__foo__ = $input->{'__foo__'};
-        $foo_bar = $input->{'foo-bar'};
-        $_foo_bar = $input->{'foo bar'};
+        $_foo_bar = $input->{'foo-bar'};
+        $foo_bar = $input->{'foo bar'};
         $baz_qux = $input->{'baz qux'};
         $_123_qwe = $input->{'123 qwe'};
         $Gorod = $input->{'Город'};
@@ -708,7 +708,7 @@ class MyClass
         $_tildas = $input->{'~~tildas~~'};
         $it_s_A = isset($input->{'it\'s "A"'}) ? $input->{'it\'s "A"'} : null;
 
-        $obj = new self($foo, $_foo, $__foo, $foo_, $foo__, $_foo_, $__foo__, $foo_bar, $_foo_bar, $baz_qux, $_123_qwe, $Gorod, $nazvanie_iur_litsa, $IP_adres, $_tildas);
+        $obj = new self($foo, $_foo, $__foo, $foo_, $foo__, $_foo_, $__foo__, $_foo_bar, $foo_bar, $baz_qux, $_123_qwe, $Gorod, $nazvanie_iur_litsa, $IP_adres, $_tildas);
         $obj->it_s_A = $it_s_A;
         return $obj;
     }
@@ -728,8 +728,8 @@ class MyClass
         $output['foo__'] = $this->foo__;
         $output['_foo_'] = $this->_foo_;
         $output['__foo__'] = $this->__foo__;
-        $output['foo-bar'] = $this->foo_bar;
-        $output['foo bar'] = $this->_foo_bar;
+        $output['foo-bar'] = $this->_foo_bar;
+        $output['foo bar'] = $this->foo_bar;
         $output['baz qux'] = $this->baz_qux;
         $output['123 qwe'] = $this->_123_qwe;
         $output['Город'] = $this->Gorod;
@@ -758,8 +758,8 @@ class MyClass
         $output->{'foo__'} = $this->foo__;
         $output->{'_foo_'} = $this->_foo_;
         $output->{'__foo__'} = $this->__foo__;
-        $output->{'foo-bar'} = $this->foo_bar;
-        $output->{'foo bar'} = $this->_foo_bar;
+        $output->{'foo-bar'} = $this->_foo_bar;
+        $output->{'foo bar'} = $this->foo_bar;
         $output->{'baz qux'} = $this->baz_qux;
         $output->{'123 qwe'} = $this->_123_qwe;
         $output->{'Город'} = $this->Gorod;

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-7.4/MyClass.php
@@ -119,12 +119,12 @@ class MyClass
     /**
      * @var string
      */
-    private string $foo_bar;
+    private string $_foo_bar;
 
     /**
      * @var string
      */
-    private string $_foo_bar;
+    private string $foo_bar;
 
     /**
      * @var string
@@ -169,8 +169,8 @@ class MyClass
      * @param string $foo__
      * @param string $_foo_
      * @param string $__foo__
-     * @param string $foo_bar
      * @param string $_foo_bar
+     * @param string $foo_bar
      * @param string $baz_qux
      * @param string $_123_qwe
      * @param string $Gorod
@@ -178,7 +178,7 @@ class MyClass
      * @param string $IP_adres
      * @param string $_tildas
      */
-    public function __construct(string $foo, string $_foo, string $__foo, string $foo_, string $foo__, string $_foo_, string $__foo__, string $foo_bar, string $_foo_bar, string $baz_qux, string $_123_qwe, string $Gorod, string $nazvanie_iur_litsa, string $IP_adres, string $_tildas)
+    public function __construct(string $foo, string $_foo, string $__foo, string $foo_, string $foo__, string $_foo_, string $__foo__, string $_foo_bar, string $foo_bar, string $baz_qux, string $_123_qwe, string $Gorod, string $nazvanie_iur_litsa, string $IP_adres, string $_tildas)
     {
         $this->foo = $foo;
         $this->_foo = $_foo;
@@ -187,8 +187,8 @@ class MyClass
         $this->foo__ = $foo__;
         $this->_foo_ = $_foo_;
         $this->__foo__ = $__foo__;
-        $this->foo_bar = $foo_bar;
         $this->_foo_bar = $_foo_bar;
+        $this->foo_bar = $foo_bar;
         $this->baz_qux = $baz_qux;
         $this->_123_qwe = $_123_qwe;
         $this->Gorod = $Gorod;
@@ -403,35 +403,6 @@ class MyClass
     /**
      * @return string
      */
-    public function getFooBar(): string
-    {
-        return $this->foo_bar;
-    }
-
-    /**
-     * @param string $foo_bar
-     * @return self
-     * @param bool $validate
-     */
-    public function withFooBar(string $foo_bar, bool $validate = true): self
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->foo_bar = $foo_bar;
-
-        return $clone;
-    }
-
-    /**
-     * @return string
-     */
     public function get_FooBar(): string
     {
         return $this->_foo_bar;
@@ -446,7 +417,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo bar']);
+            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -454,6 +425,35 @@ class MyClass
 
         $clone = clone $this;
         $clone->_foo_bar = $_foo_bar;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFooBar(): string
+    {
+        return $this->foo_bar;
+    }
+
+    /**
+     * @param string $foo_bar
+     * @return self
+     * @param bool $validate
+     */
+    public function withFooBar(string $foo_bar, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar = $foo_bar;
 
         return $clone;
     }
@@ -700,8 +700,8 @@ class MyClass
         $foo__ = $input->{'foo__'};
         $_foo_ = $input->{'_foo_'};
         $__foo__ = $input->{'__foo__'};
-        $foo_bar = $input->{'foo-bar'};
-        $_foo_bar = $input->{'foo bar'};
+        $_foo_bar = $input->{'foo-bar'};
+        $foo_bar = $input->{'foo bar'};
         $baz_qux = $input->{'baz qux'};
         $_123_qwe = $input->{'123 qwe'};
         $Gorod = $input->{'Город'};
@@ -710,7 +710,7 @@ class MyClass
         $_tildas = $input->{'~~tildas~~'};
         $it_s_A = isset($input->{'it\'s "A"'}) ? $input->{'it\'s "A"'} : null;
 
-        $obj = new self($foo, $_foo, $__foo, $foo_, $foo__, $_foo_, $__foo__, $foo_bar, $_foo_bar, $baz_qux, $_123_qwe, $Gorod, $nazvanie_iur_litsa, $IP_adres, $_tildas);
+        $obj = new self($foo, $_foo, $__foo, $foo_, $foo__, $_foo_, $__foo__, $_foo_bar, $foo_bar, $baz_qux, $_123_qwe, $Gorod, $nazvanie_iur_litsa, $IP_adres, $_tildas);
         $obj->it_s_A = $it_s_A;
         return $obj;
     }
@@ -730,8 +730,8 @@ class MyClass
         $output['foo__'] = $this->foo__;
         $output['_foo_'] = $this->_foo_;
         $output['__foo__'] = $this->__foo__;
-        $output['foo-bar'] = $this->foo_bar;
-        $output['foo bar'] = $this->_foo_bar;
+        $output['foo-bar'] = $this->_foo_bar;
+        $output['foo bar'] = $this->foo_bar;
         $output['baz qux'] = $this->baz_qux;
         $output['123 qwe'] = $this->_123_qwe;
         $output['Город'] = $this->Gorod;
@@ -760,8 +760,8 @@ class MyClass
         $output->{'foo__'} = $this->foo__;
         $output->{'_foo_'} = $this->_foo_;
         $output->{'__foo__'} = $this->__foo__;
-        $output->{'foo-bar'} = $this->foo_bar;
-        $output->{'foo bar'} = $this->_foo_bar;
+        $output->{'foo-bar'} = $this->_foo_bar;
+        $output->{'foo bar'} = $this->foo_bar;
         $output->{'baz qux'} = $this->baz_qux;
         $output->{'123 qwe'} = $this->_123_qwe;
         $output->{'Город'} = $this->Gorod;

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-8.4/MyClass.php
@@ -119,12 +119,12 @@ class MyClass
     /**
      * @var string
      */
-    private string $foo_bar;
+    private string $_foo_bar;
 
     /**
      * @var string
      */
-    private string $_foo_bar;
+    private string $foo_bar;
 
     /**
      * @var string
@@ -169,8 +169,8 @@ class MyClass
      * @param string $foo__
      * @param string $_foo_
      * @param string $__foo__
-     * @param string $foo_bar
      * @param string $_foo_bar
+     * @param string $foo_bar
      * @param string $baz_qux
      * @param string $_123_qwe
      * @param string $Gorod
@@ -178,7 +178,7 @@ class MyClass
      * @param string $IP_adres
      * @param string $_tildas
      */
-    public function __construct(string $foo, string $_foo, string $__foo, string $foo_, string $foo__, string $_foo_, string $__foo__, string $foo_bar, string $_foo_bar, string $baz_qux, string $_123_qwe, string $Gorod, string $nazvanie_iur_litsa, string $IP_adres, string $_tildas)
+    public function __construct(string $foo, string $_foo, string $__foo, string $foo_, string $foo__, string $_foo_, string $__foo__, string $_foo_bar, string $foo_bar, string $baz_qux, string $_123_qwe, string $Gorod, string $nazvanie_iur_litsa, string $IP_adres, string $_tildas)
     {
         $this->foo = $foo;
         $this->_foo = $_foo;
@@ -187,8 +187,8 @@ class MyClass
         $this->foo__ = $foo__;
         $this->_foo_ = $_foo_;
         $this->__foo__ = $__foo__;
-        $this->foo_bar = $foo_bar;
         $this->_foo_bar = $_foo_bar;
+        $this->foo_bar = $foo_bar;
         $this->baz_qux = $baz_qux;
         $this->_123_qwe = $_123_qwe;
         $this->Gorod = $Gorod;
@@ -403,35 +403,6 @@ class MyClass
     /**
      * @return string
      */
-    public function getFooBar(): string
-    {
-        return $this->foo_bar;
-    }
-
-    /**
-     * @param string $foo_bar
-     * @return self
-     * @param bool $validate
-     */
-    public function withFooBar(string $foo_bar, bool $validate = true): self
-    {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
-        $clone = clone $this;
-        $clone->foo_bar = $foo_bar;
-
-        return $clone;
-    }
-
-    /**
-     * @return string
-     */
     public function get_FooBar(): string
     {
         return $this->_foo_bar;
@@ -446,7 +417,7 @@ class MyClass
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo bar']);
+            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
@@ -454,6 +425,35 @@ class MyClass
 
         $clone = clone $this;
         $clone->_foo_bar = $_foo_bar;
+
+        return $clone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFooBar(): string
+    {
+        return $this->foo_bar;
+    }
+
+    /**
+     * @param string $foo_bar
+     * @return self
+     * @param bool $validate
+     */
+    public function withFooBar(string $foo_bar, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->foo_bar = $foo_bar;
 
         return $clone;
     }
@@ -694,8 +694,8 @@ class MyClass
         $foo__ = $input->{'foo__'};
         $_foo_ = $input->{'_foo_'};
         $__foo__ = $input->{'__foo__'};
-        $foo_bar = $input->{'foo-bar'};
-        $_foo_bar = $input->{'foo bar'};
+        $_foo_bar = $input->{'foo-bar'};
+        $foo_bar = $input->{'foo bar'};
         $baz_qux = $input->{'baz qux'};
         $_123_qwe = $input->{'123 qwe'};
         $Gorod = $input->{'Город'};
@@ -704,7 +704,7 @@ class MyClass
         $_tildas = $input->{'~~tildas~~'};
         $it_s_A = isset($input->{'it\'s "A"'}) ? $input->{'it\'s "A"'} : null;
 
-        $obj = new self($foo, $_foo, $__foo, $foo_, $foo__, $_foo_, $__foo__, $foo_bar, $_foo_bar, $baz_qux, $_123_qwe, $Gorod, $nazvanie_iur_litsa, $IP_adres, $_tildas);
+        $obj = new self($foo, $_foo, $__foo, $foo_, $foo__, $_foo_, $__foo__, $_foo_bar, $foo_bar, $baz_qux, $_123_qwe, $Gorod, $nazvanie_iur_litsa, $IP_adres, $_tildas);
         $obj->it_s_A = $it_s_A;
         return $obj;
     }
@@ -724,8 +724,8 @@ class MyClass
         $output['foo__'] = $this->foo__;
         $output['_foo_'] = $this->_foo_;
         $output['__foo__'] = $this->__foo__;
-        $output['foo-bar'] = $this->foo_bar;
-        $output['foo bar'] = $this->_foo_bar;
+        $output['foo-bar'] = $this->_foo_bar;
+        $output['foo bar'] = $this->foo_bar;
         $output['baz qux'] = $this->baz_qux;
         $output['123 qwe'] = $this->_123_qwe;
         $output['Город'] = $this->Gorod;
@@ -754,8 +754,8 @@ class MyClass
         $output->{'foo__'} = $this->foo__;
         $output->{'_foo_'} = $this->_foo_;
         $output->{'__foo__'} = $this->__foo__;
-        $output->{'foo-bar'} = $this->foo_bar;
-        $output->{'foo bar'} = $this->_foo_bar;
+        $output->{'foo-bar'} = $this->_foo_bar;
+        $output->{'foo bar'} = $this->foo_bar;
         $output->{'baz qux'} = $this->baz_qux;
         $output->{'123 qwe'} = $this->_123_qwe;
         $output->{'Город'} = $this->Gorod;

--- a/tests/Generator/Fixtures/TempTest/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TempTest/Output-8.4/MyClass.php
@@ -25,41 +25,41 @@ class MyClass
     /**
      * @var string
      */
-    private string $_schema_1;
+    private string $schema;
 
     /**
-     * @param string $_schema_1
+     * @param string $schema
      */
-    public function __construct(string $_schema_1)
+    public function __construct(string $schema)
     {
-        $this->_schema_1 = $_schema_1;
+        $this->schema = $schema;
     }
 
     /**
      * @return string
      */
-    public function getSchema1(): string
+    public function getSchema(): string
     {
-        return $this->_schema_1;
+        return $this->schema;
     }
 
     /**
-     * @param string $_schema_1
+     * @param string $schema
      * @return self
      * @param bool $validate
      */
-    public function withSchema1(string $_schema_1, bool $validate = true): self
+    public function withSchema(string $schema, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_1, self::$_schema['properties']['schema']);
+            $validator->validate($schema, self::$_schema['properties']['schema']);
             if (!$validator->isValid()) {
                 throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
             }
         }
 
         $clone = clone $this;
-        $clone->_schema_1 = $_schema_1;
+        $clone->schema = $schema;
 
         return $clone;
     }
@@ -79,9 +79,9 @@ class MyClass
             static::validateInput($input);
         }
 
-        $_schema_1 = $input->{'schema'};
+        $schema = $input->{'schema'};
 
-        $obj = new self($_schema_1);
+        $obj = new self($schema);
 
         return $obj;
     }
@@ -94,7 +94,7 @@ class MyClass
     public function toArray(): array
     {
         $output = [];
-        $output['schema'] = $this->_schema_1;
+        $output['schema'] = $this->schema;
 
         return $output;
     }
@@ -107,7 +107,7 @@ class MyClass
     public function toStdClass(): \stdClass
     {
         $output = new \stdClass();
-        $output->{'schema'} = $this->_schema_1;
+        $output->{'schema'} = $this->schema;
 
         return $output;
     }


### PR DESCRIPTION
## Summary
- centralize property, method and variable naming in new `PropertyIdentifierResolver`
- derive accessor suffixes from `PropertyInterface::methodName`
- use `varName` for constructor and setter parameters and drop built‑in names from reserved list
- test deterministic naming and reserved variable handling

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68908dabdb24832db0e01bb7af76955a