### PR TITLE
Fix setter nullability handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Now it:
 - Setter methods (`withX()`) now accept an optional `$validate` argument to be able skip validation, mirroring `fromInput()`.
 - Deterministic resolution of class property, accessor method and temporary variable names via a unified resolver, allowing case-sensitive properties and avoiding collisions with reserved names.
 - Option `mutableSetters` allows generating mutable `setX()` methods (optionally chainable).
+- Setter methods now respect property nullability, allowing `null` only when permitted by the schema.
 - Skips emitting empty `__construct` or `__clone` methods.
 - Prints a notice when skipping `definitions` that do not describe an object.
 - Validates written files with `php -l` to ensure generated code is syntactically correct.

--- a/src/Generator/Class/Method/SetterFactory.php
+++ b/src/Generator/Class/Method/SetterFactory.php
@@ -46,13 +46,19 @@ class SetterFactory
         $propName = $property->propName();
         $varName = $property->varName();
 
-        // We first unwrap only optional property decorator but leave other
-        // decorators in place to get the correct type hint / annotation
-        // TODO: FIXME This logic flawed: sometimes we generate setters with parameter types that are
-        // misaligned with PHPDoc type annotations of those params, and we also sometimes don't allow nulls where we should've.
-        $requiredProperty = ($property instanceof OptionalPropertyDecorator) ? $property->unwrap() : $property;
+        // Optional properties may or may not allow null. We only unwrap the
+        // optional decorator when the schema does not allow `null` so that the
+        // setter parameter type hints match the property's actual
+        // nullability. Previously we always unwrapped, which caused setters for
+        // optional nullable properties to reject `null` values.
+        if ($property instanceof OptionalPropertyDecorator && !$property->isOptionalNullable()) {
+            $requiredProperty = $property->unwrap();
+        } else {
+            $requiredProperty = $property;
+        }
+
         $propAnnotatedType = $requiredProperty->typeAnnotation();
-        $propTypeHint = $requiredProperty->typeHint();
+        $propTypeHint      = $requiredProperty->typeHint();
 
         // then we fully unwrap any other decorators to be able to see the real type
         $base = $property;
@@ -104,8 +110,12 @@ class SetterFactory
         bool $addValidation,
     ): DocBlockGenerator
     {
+        // Use the property's annotation directly so PHPDoc matches the setter's
+        // parameter type hint. Removing `|null` caused mismatches and made the
+        // docblock suggest non-nullable parameters even when `null` was
+        // accepted.
         $tags = [
-            new ParamTag($varName, [str_replace('|null', '', $propAnnotatedType)])
+            new ParamTag($varName, explode('|', $propAnnotatedType))
         ];
 
         if ($this->chainable) {

--- a/tests/Generator/Class/SetterFactoryTest.php
+++ b/tests/Generator/Class/SetterFactoryTest.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Generator\Class;
+
+use Helmich\Schema2Class\Generator\Class\Method\SetterFactory;
+use Helmich\Schema2Class\Generator\Class\SchemaPropertyCollector;
+use Helmich\Schema2Class\Generator\GeneratorRequest;
+use Helmich\Schema2Class\Spec\SpecificationOptions;
+use Helmich\Schema2Class\Spec\ValidatedSpecificationFilesItem;
+use Laminas\Code\Generator\MethodGenerator;
+use Helmich\Schema2Class\Generator\Property\Type\PropertyInterface;
+use PHPUnit\Framework\TestCase;
+
+class SetterFactoryTest extends TestCase
+{
+    /**
+     * @return array{MethodGenerator, PropertyInterface}
+     */
+    private function generateSetter(array $schema): array
+    {
+        $req = new GeneratorRequest(
+            $schema,
+            new ValidatedSpecificationFilesItem('Ns', 'Foo', ''),
+            new SpecificationOptions(),
+        );
+
+        $collector = new SchemaPropertyCollector();
+        $props = $collector->collectPropertiesFromSchema($schema, $req)->toArray();
+        $prop = $props[0];
+
+        $factory = new SetterFactory($req);
+        $setter = $factory->generateSetter($prop);
+        self::assertNotNull($setter);
+
+        return [$setter, $prop];
+    }
+
+    public function testSetterAllowsNullForOptionalNullableProperty(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'foo' => ['type' => ['string', 'null']],
+            ],
+        ];
+
+        [$setter, $prop] = $this->generateSetter($schema);
+        $varName = $prop->varName();
+
+        $param = $setter->getParameters()[$varName];
+        self::assertSame('?string $' . $varName, $param->generate());
+
+        $paramTag = $setter->getDocBlock()->getTags()[0];
+        self::assertEquals(['string', 'null'], $paramTag->getTypes());
+    }
+
+    public function testSetterDisallowsNullForOptionalNonNullableProperty(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'foo' => ['type' => 'string'],
+            ],
+        ];
+
+        [$setter, $prop] = $this->generateSetter($schema);
+        $varName = $prop->varName();
+
+        $param = $setter->getParameters()[$varName];
+        self::assertSame('string $' . $varName, $param->generate());
+
+        $paramTag = $setter->getDocBlock()->getTags()[0];
+        self::assertEquals(['string'], $paramTag->getTypes());
+    }
+
+    public function testSetterAllowsNullForRequiredNullableProperty(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['foo'],
+            'properties' => [
+                'foo' => ['type' => ['string', 'null']],
+            ],
+        ];
+
+        [$setter, $prop] = $this->generateSetter($schema);
+        $varName = $prop->varName();
+
+        $param = $setter->getParameters()[$varName];
+        self::assertSame('?string $' . $varName, $param->generate());
+
+        $paramTag = $setter->getDocBlock()->getTags()[0];
+        self::assertEquals(['string', 'null'], $paramTag->getTypes());
+    }
+}

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -207,7 +207,7 @@ class MyClass
     }
 
     /**
-     * @param array $c
+     * @param array|null $c
      * @return self
      * @param bool $validate
      */
@@ -236,7 +236,7 @@ class MyClass
     }
 
     /**
-     * @param array|string $d
+     * @param array|string|null $d
      * @return self
      */
     public function withD(string|array|null $d): self
@@ -327,7 +327,7 @@ class MyClass
     }
 
     /**
-     * @param array $g
+     * @param array|null $g
      * @return self
      * @param bool $validate
      */
@@ -369,10 +369,10 @@ class MyClass
     }
 
     /**
-     * @param array|string $h
+     * @param array|string|null $h
      * @return self
      */
-    public function withH(string|array $h): self
+    public function withH(string|array|null $h): self
     {
         $clone = clone $this;
         $clone->h = $h;
@@ -402,10 +402,10 @@ class MyClass
     }
 
     /**
-     * @param array|string|object $i
+     * @param array|string|object|null $i
      * @return self
      */
-    public function withI(string|array|object $i): self
+    public function withI(string|array|object|null $i): self
     {
         $clone = clone $this;
         $clone->i = $i;

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -249,11 +249,11 @@ class MyClass
     }
 
     /**
-     * @param int $baz
+     * @param int|null $baz
      * @return self
      * @param bool $validate
      */
-    public function withBaz(int $baz, bool $validate = true): self
+    public function withBaz(?int $baz, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/EnumMixed/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/EnumMixed/Output-5.6/MyClass.php
@@ -224,7 +224,7 @@ class MyClass
     }
 
     /**
-     * @param 'red'|'amber'|'green'|'42'|42|42.5|false $baz
+     * @param 'red'|'amber'|'green'|'42'|42|42.5|false|null $baz
      * @return self
      * @param bool $validate
      */
@@ -311,7 +311,7 @@ class MyClass
     }
 
     /**
-     * @param 'red'|'green' $nullable
+     * @param 'red'|'green'|null $nullable
      * @return self
      * @param bool $validate
      */
@@ -340,7 +340,7 @@ class MyClass
     }
 
     /**
-     * @param 'red'|'green' $optionalNullable
+     * @param 'red'|'green'|null $optionalNullable
      * @return self
      * @param bool $validate
      */

--- a/tests/Generator/Fixtures/EnumMixed/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/EnumMixed/Output-7.4/MyClass.php
@@ -226,7 +226,7 @@ class MyClass
     }
 
     /**
-     * @param 'red'|'amber'|'green'|'42'|42|42.5|false $baz
+     * @param 'red'|'amber'|'green'|'42'|42|42.5|false|null $baz
      * @return self
      * @param bool $validate
      */
@@ -313,7 +313,7 @@ class MyClass
     }
 
     /**
-     * @param 'red'|'green' $nullable
+     * @param 'red'|'green'|null $nullable
      * @return self
      * @param bool $validate
      */
@@ -342,11 +342,11 @@ class MyClass
     }
 
     /**
-     * @param 'red'|'green' $optionalNullable
+     * @param 'red'|'green'|null $optionalNullable
      * @return self
      * @param bool $validate
      */
-    public function withOptionalNullable(string $optionalNullable, bool $validate = true): self
+    public function withOptionalNullable(?string $optionalNullable, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/EnumMixed/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/EnumMixed/Output-8.4/MyClass.php
@@ -226,7 +226,7 @@ class MyClass
     }
 
     /**
-     * @param 'red'|'amber'|'green'|'42'|42|42.5|false $baz
+     * @param 'red'|'amber'|'green'|'42'|42|42.5|false|null $baz
      * @return self
      * @param bool $validate
      */
@@ -313,7 +313,7 @@ class MyClass
     }
 
     /**
-     * @param MyClassNullable $nullable
+     * @param MyClassNullable|null $nullable
      * @return self
      */
     public function withNullable(?MyClassNullable $nullable): self
@@ -333,10 +333,10 @@ class MyClass
     }
 
     /**
-     * @param MyClassOptionalNullable $optionalNullable
+     * @param MyClassOptionalNullable|null $optionalNullable
      * @return self
      */
-    public function withOptionalNullable(MyClassOptionalNullable $optionalNullable): self
+    public function withOptionalNullable(?MyClassOptionalNullable $optionalNullable): self
     {
         $clone = clone $this;
         $clone->optionalNullable = $optionalNullable;

--- a/tests/Generator/Fixtures/EnumWithNull/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/EnumWithNull/Output-7.4/MyClass.php
@@ -49,11 +49,11 @@ class MyClass
     }
 
     /**
-     * @param 'red'|'green' $foo
+     * @param 'red'|'green'|null $foo
      * @return self
      * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(?string $foo, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/EnumWithNull/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/EnumWithNull/Output-8.4/MyClass.php
@@ -49,10 +49,10 @@ class MyClass
     }
 
     /**
-     * @param MyClassFoo $foo
+     * @param MyClassFoo|null $foo
      * @return self
      */
-    public function withFoo(MyClassFoo $foo): self
+    public function withFoo(?MyClassFoo $foo): self
     {
         $clone = clone $this;
         $clone->foo = $foo;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -1146,7 +1146,7 @@ class MyClass
     }
 
     /**
-     * @param string $_materializeDefaults
+     * @param string|null $_materializeDefaults
      * @return self
      * @param bool $validate
      */

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -1148,11 +1148,11 @@ class MyClass
     }
 
     /**
-     * @param string $_materializeDefaults
+     * @param string|null $_materializeDefaults
      * @return self
      * @param bool $validate
      */
-    public function withMaterializeDefaults(string $_materializeDefaults, bool $validate = true): self
+    public function withMaterializeDefaults(?string $_materializeDefaults, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
@@ -1148,11 +1148,11 @@ class MyClass
     }
 
     /**
-     * @param string $_materializeDefaults
+     * @param string|null $_materializeDefaults
      * @return self
      * @param bool $validate
      */
-    public function withMaterializeDefaults(string $_materializeDefaults, bool $validate = true): self
+    public function withMaterializeDefaults(?string $_materializeDefaults, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -1146,7 +1146,7 @@ class MyClass
     }
 
     /**
-     * @param string $_materializeDefaults
+     * @param string|null $_materializeDefaults
      * @return self
      * @param bool $validate
      */

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -1148,11 +1148,11 @@ class MyClass
     }
 
     /**
-     * @param string $_materializeDefaults
+     * @param string|null $_materializeDefaults
      * @return self
      * @param bool $validate
      */
-    public function withMaterializeDefaults(string $_materializeDefaults, bool $validate = true): self
+    public function withMaterializeDefaults(?string $_materializeDefaults, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
@@ -1148,11 +1148,11 @@ class MyClass
     }
 
     /**
-     * @param string $_materializeDefaults
+     * @param string|null $_materializeDefaults
      * @return self
      * @param bool $validate
      */
-    public function withMaterializeDefaults(string $_materializeDefaults, bool $validate = true): self
+    public function withMaterializeDefaults(?string $_materializeDefaults, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -483,7 +483,7 @@ class MyClass
     }
 
     /**
-     * @param MyClassQuxObj $quxObj
+     * @param MyClassQuxObj|null $quxObj
      * @return self
      */
     public function withQuxObj(?MyClassQuxObj $quxObj): self
@@ -518,7 +518,7 @@ class MyClass
     }
 
     /**
-     * @param MyClassQuxObjNest $quxObjNest
+     * @param MyClassQuxObjNest|null $quxObjNest
      * @return self
      */
     public function withQuxObjNest(?MyClassQuxObjNest $quxObjNest): self
@@ -553,7 +553,7 @@ class MyClass
     }
 
     /**
-     * @param string[] $thudArray
+     * @param string[]|null $thudArray
      * @return self
      * @param bool $validate
      */

--- a/tests/Generator/Fixtures/MutableSetters/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-5.6/MyClass.php
@@ -119,7 +119,7 @@ class MyClass
     }
 
     /**
-     * @param string $opt
+     * @param string|null $opt
      * @param bool $validate
      */
     public function setOpt($opt, bool $validate = true)

--- a/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
@@ -121,10 +121,10 @@ class MyClass
     }
 
     /**
-     * @param string $opt
+     * @param string|null $opt
      * @param bool $validate
      */
-    public function setOpt(string $opt, bool $validate = true): void
+    public function setOpt(?string $opt, bool $validate = true): void
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
@@ -121,10 +121,10 @@ class MyClass
     }
 
     /**
-     * @param string $opt
+     * @param string|null $opt
      * @param bool $validate
      */
-    public function setOpt(string $opt, bool $validate = true): void
+    public function setOpt(?string $opt, bool $validate = true): void
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/MyClass.php
@@ -125,7 +125,7 @@ class MyClass
     }
 
     /**
-     * @param string $opt
+     * @param string|null $opt
      * @return self
      * @param bool $validate
      */

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
@@ -127,11 +127,11 @@ class MyClass
     }
 
     /**
-     * @param string $opt
+     * @param string|null $opt
      * @return self
      * @param bool $validate
      */
-    public function setOpt(string $opt, bool $validate = true): self
+    public function setOpt(?string $opt, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
@@ -127,11 +127,11 @@ class MyClass
     }
 
     /**
-     * @param string $opt
+     * @param string|null $opt
      * @return self
      * @param bool $validate
      */
-    public function setOpt(string $opt, bool $validate = true): self
+    public function setOpt(?string $opt, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Fio.php
@@ -42,7 +42,7 @@ class Fio
     }
 
     /**
-     * @param string $bar
+     * @param string|null $bar
      * @return self
      * @param bool $validate
      */

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Fio.php
@@ -44,11 +44,11 @@ class Fio
     }
 
     /**
-     * @param string $bar
+     * @param string|null $bar
      * @return self
      * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(?string $bar, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Fio.php
@@ -44,11 +44,11 @@ class Fio
     }
 
     /**
-     * @param string $bar
+     * @param string|null $bar
      * @return self
      * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(?string $bar, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClass.php
@@ -297,7 +297,7 @@ class MyClass
     }
 
     /**
-     * @param string $baz
+     * @param string|null $baz
      * @return self
      * @param bool $validate
      */
@@ -341,7 +341,7 @@ class MyClass
     }
 
     /**
-     * @param string $qux
+     * @param string|null $qux
      * @return self
      * @param bool $validate
      */
@@ -385,7 +385,7 @@ class MyClass
     }
 
     /**
-     * @param string $quux
+     * @param string|null $quux
      * @return self
      * @param bool $validate
      */
@@ -489,7 +489,7 @@ class MyClass
     }
 
     /**
-     * @param MyClassGrox $grox
+     * @param MyClassGrox|null $grox
      * @return self
      */
     public function withGrox(MyClassGrox $grox)
@@ -524,7 +524,7 @@ class MyClass
     }
 
     /**
-     * @param MyClassGooks $gooks
+     * @param MyClassGooks|null $gooks
      * @return self
      */
     public function withGooks(MyClassGooks $gooks)

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
@@ -299,11 +299,11 @@ class MyClass
     }
 
     /**
-     * @param string $baz
+     * @param string|null $baz
      * @return self
      * @param bool $validate
      */
-    public function withBaz(string $baz, bool $validate = true): self
+    public function withBaz(?string $baz, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -343,11 +343,11 @@ class MyClass
     }
 
     /**
-     * @param string $qux
+     * @param string|null $qux
      * @return self
      * @param bool $validate
      */
-    public function withQux(string $qux, bool $validate = true): self
+    public function withQux(?string $qux, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -387,7 +387,7 @@ class MyClass
     }
 
     /**
-     * @param string $quux
+     * @param string|null $quux
      * @return self
      * @param bool $validate
      */
@@ -491,7 +491,7 @@ class MyClass
     }
 
     /**
-     * @param MyClassGrox $grox
+     * @param MyClassGrox|null $grox
      * @return self
      */
     public function withGrox(?MyClassGrox $grox): self
@@ -526,7 +526,7 @@ class MyClass
     }
 
     /**
-     * @param MyClassGooks $gooks
+     * @param MyClassGooks|null $gooks
      * @return self
      */
     public function withGooks(?MyClassGooks $gooks): self

--- a/tests/Generator/Fixtures/PropTypeIsSingleTypeArray/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsSingleTypeArray/Output-8.4/MyClass.php
@@ -579,7 +579,7 @@ class MyClass
     }
 
     /**
-     * @param string $nullFoo
+     * @param string|null $nullFoo
      * @return self
      * @param bool $validate
      */
@@ -608,7 +608,7 @@ class MyClass
     }
 
     /**
-     * @param int|float $nullBar
+     * @param int|float|null $nullBar
      * @return self
      * @param bool $validate
      */
@@ -637,7 +637,7 @@ class MyClass
     }
 
     /**
-     * @param int $nullBaz
+     * @param int|null $nullBaz
      * @return self
      * @param bool $validate
      */
@@ -666,7 +666,7 @@ class MyClass
     }
 
     /**
-     * @param bool $nullQux
+     * @param bool|null $nullQux
      * @return self
      * @param bool $validate
      */
@@ -695,7 +695,7 @@ class MyClass
     }
 
     /**
-     * @param MyClassNullQuux $nullQuux
+     * @param MyClassNullQuux|null $nullQuux
      * @return self
      */
     public function withNullQuux(?MyClassNullQuux $nullQuux): self
@@ -715,7 +715,7 @@ class MyClass
     }
 
     /**
-     * @param string[] $nullThud
+     * @param string[]|null $nullThud
      * @return self
      * @param bool $validate
      */
@@ -1017,11 +1017,11 @@ class MyClass
     }
 
     /**
-     * @param string $optNullFoo
+     * @param string|null $optNullFoo
      * @return self
      * @param bool $validate
      */
-    public function withOptNullFoo(string $optNullFoo, bool $validate = true): self
+    public function withOptNullFoo(?string $optNullFoo, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1059,11 +1059,11 @@ class MyClass
     }
 
     /**
-     * @param int|float $optNullBar
+     * @param int|float|null $optNullBar
      * @return self
      * @param bool $validate
      */
-    public function withOptNullBar(int|float $optNullBar, bool $validate = true): self
+    public function withOptNullBar(int|float|null $optNullBar, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1101,11 +1101,11 @@ class MyClass
     }
 
     /**
-     * @param int $optNullBaz
+     * @param int|null $optNullBaz
      * @return self
      * @param bool $validate
      */
-    public function withOptNullBaz(int $optNullBaz, bool $validate = true): self
+    public function withOptNullBaz(?int $optNullBaz, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1143,11 +1143,11 @@ class MyClass
     }
 
     /**
-     * @param bool $optNullQux
+     * @param bool|null $optNullQux
      * @return self
      * @param bool $validate
      */
-    public function withOptNullQux(bool $optNullQux, bool $validate = true): self
+    public function withOptNullQux(?bool $optNullQux, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -1185,7 +1185,7 @@ class MyClass
     }
 
     /**
-     * @param MyClassOptNullQuux $optNullQuux
+     * @param MyClassOptNullQuux|null $optNullQuux
      * @return self
      */
     public function withOptNullQuux(?MyClassOptNullQuux $optNullQuux): self
@@ -1218,7 +1218,7 @@ class MyClass
     }
 
     /**
-     * @param string[] $optNullThud
+     * @param string[]|null $optNullThud
      * @return self
      * @param bool $validate
      */

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -270,7 +270,7 @@ class MyClass
     }
 
     /**
-     * @param string|int|float|bool|array|object $thud
+     * @param string|int|float|bool|array|object|null $thud
      * @return self
      */
     public function withThud(bool|int|float|string|array|object|null $thud): self
@@ -414,10 +414,10 @@ class MyClass
     }
 
     /**
-     * @param string|int|float|bool|array|object $optThud
+     * @param string|int|float|bool|array|object|null $optThud
      * @return self
      */
-    public function withOptThud(bool|int|float|string|array|object $optThud): self
+    public function withOptThud(bool|int|float|string|array|object|null $optThud): self
     {
         $clone = clone $this;
         $clone->optThud = $optThud;

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
@@ -68,11 +68,11 @@ class Cat
     }
 
     /**
-     * @param bool $hasFur
+     * @param bool|null $hasFur
      * @return self
      * @param bool $validate
      */
-    public function withHasFur(bool $hasFur, bool $validate = true): self
+    public function withHasFur(?bool $hasFur, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
@@ -66,11 +66,11 @@ class GenericPet
     }
 
     /**
-     * @param bool $hasFur
+     * @param bool|null $hasFur
      * @return self
      * @param bool $validate
      */
-    public function withHasFur(bool $hasFur, bool $validate = true): self
+    public function withHasFur(?bool $hasFur, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -73,7 +73,7 @@ class Cat
     }
 
     /**
-     * @param bool|string|int|float $hasFur
+     * @param bool|null|string|int|float $hasFur
      * @return self
      */
     public function withHasFur(bool|int|float|string|null $hasFur): self


### PR DESCRIPTION
## Summary
- ensure setters only unwrap optional decorator when property isn't nullable
- align setter docblocks with parameter types and respect property nullability
- add tests covering setter nullability cases and update snapshots

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_689102aa0ec4832d89d6d42cfb8a9b10