### PR TITLE
refactor: generate setter validation only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Now it:
 - Improves type hints and PHPDoc type generation for complex types like unions, nested arrays, etc.
 - Adds a guard against passing anything other than an array/object to `fromInput`, building multi-line validation error messages.
 - Setter methods (`withX()`) now accept an optional `$validate` argument to be able skip validation, mirroring `fromInput()`.
+- Setter validation is only generated when schema constraints aren't already covered by PHP type hints, reducing unnecessary validators.
 - Deterministic resolution of class property, accessor method and temporary variable names via a unified resolver, allowing case-sensitive properties and avoiding collisions with reserved names.
 - Option `mutableSetters` allows generating mutable `setX()` methods (optionally chainable).
 - Skips emitting empty `__construct` or `__clone` methods.

--- a/examples/advanced/generated/User.php
+++ b/examples/advanced/generated/User.php
@@ -314,18 +314,9 @@ class User
     /**
      * @param string $lastName
      * @return self
-     * @param bool $validate
      */
-    public function withLastName(string $lastName, bool $validate = true): self
+    public function withLastName(string $lastName): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($lastName, self::$_schema['properties']['lastName']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->lastName = $lastName;
 
@@ -414,9 +405,18 @@ class User
     /**
      * @param UserPaymentAlternative1|UserPaymentAlternative2|string $payment
      * @return self
+     * @param bool $validate
      */
-    public function withPayment(UserPaymentAlternative1|UserPaymentAlternative2|string $payment): self
+    public function withPayment(UserPaymentAlternative1|UserPaymentAlternative2|string $payment, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($payment, self::$_schema['properties']['payment']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->payment = $payment;
 

--- a/examples/advanced/generated/UserAddress.php
+++ b/examples/advanced/generated/UserAddress.php
@@ -87,18 +87,9 @@ class UserAddress
     /**
      * @param string $street
      * @return self
-     * @param bool $validate
      */
-    public function withStreet(string $street, bool $validate = true): self
+    public function withStreet(string $street): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($street, self::$_schema['properties']['street']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->street = $street;
 

--- a/examples/advanced/generated/UserBilling.php
+++ b/examples/advanced/generated/UserBilling.php
@@ -70,18 +70,9 @@ class UserBilling
     /**
      * @param string $vatID
      * @return self
-     * @param bool $validate
      */
-    public function withVatID(string $vatID, bool $validate = true): self
+    public function withVatID(string $vatID): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($vatID, self::$_schema['properties']['vatID']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->vatID = $vatID;
 
@@ -99,18 +90,9 @@ class UserBilling
     /**
      * @param int $creditLevel
      * @return self
-     * @param bool $validate
      */
-    public function withCreditLevel(int $creditLevel, bool $validate = true): self
+    public function withCreditLevel(int $creditLevel): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($creditLevel, self::$_schema['properties']['creditLevel']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->creditLevel = $creditLevel;
 
@@ -139,18 +121,9 @@ class UserBilling
     /**
      * @param int $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(int $foo, bool $validate = true): self
+    public function withFoo(int $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -179,18 +152,9 @@ class UserBilling
     /**
      * @param string $bar
      * @return self
-     * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/examples/advanced/generated/UserHobbiesItem.php
+++ b/examples/advanced/generated/UserHobbiesItem.php
@@ -35,18 +35,9 @@ class UserHobbiesItem
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function withName(string $name, bool $validate = true): self
+    public function withName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->name = $name;
 

--- a/examples/advanced/generated/UserPaymentAlternative2.php
+++ b/examples/advanced/generated/UserPaymentAlternative2.php
@@ -80,18 +80,9 @@ class UserPaymentAlternative2
     /**
      * @param string $accountNumber
      * @return self
-     * @param bool $validate
      */
-    public function withAccountNumber(string $accountNumber, bool $validate = true): self
+    public function withAccountNumber(string $accountNumber): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($accountNumber, self::$_schema['properties']['accountNumber']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->accountNumber = $accountNumber;
 

--- a/examples/basic/generated/Address.php
+++ b/examples/basic/generated/Address.php
@@ -34,18 +34,9 @@ class Address
     /**
      * @param string $street
      * @return self
-     * @param bool $validate
      */
-    public function withStreet(string $street, bool $validate = true): self
+    public function withStreet(string $street): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($street, self::$_schema['properties']['street']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->street = $street;
 
@@ -74,18 +65,9 @@ class Address
     /**
      * @param int $house
      * @return self
-     * @param bool $validate
      */
-    public function withHouse(int $house, bool $validate = true): self
+    public function withHouse(int $house): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($house, self::$_schema['properties']['house']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->house = $house;
 

--- a/examples/basic/generated/User.php
+++ b/examples/basic/generated/User.php
@@ -59,18 +59,9 @@ class User
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function withName(string $name, bool $validate = true): self
+    public function withName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->name = $name;
 

--- a/src/Generator/Class/Method/SetterFactory.php
+++ b/src/Generator/Class/Method/SetterFactory.php
@@ -13,6 +13,7 @@ use Helmich\Schema2Class\Generator\Property\Type\PrimitiveArrayProperty;
 use Helmich\Schema2Class\Generator\Property\Type\PropertyInterface;
 use Helmich\Schema2Class\Generator\Property\Type\ReferenceArrayProperty;
 use Helmich\Schema2Class\Generator\Property\Type\TypedArrayProperty;
+use Helmich\Schema2Class\Generator\Property\Type\UnionProperty;
 use Laminas\Code\Generator\DocBlock\Tag\GenericTag;
 use Laminas\Code\Generator\DocBlock\Tag\ParamTag;
 use Laminas\Code\Generator\DocBlock\Tag\ReturnTag;
@@ -56,6 +57,8 @@ class SetterFactory
         $propAnnotatedType = $paramProperty->typeAnnotation();
         $propTypeHint = $paramProperty->typeHint();
 
+        $hasConstraints = PropertyQuery::hasConstraints($paramProperty);
+
         // then we fully unwrap any other decorators to be able to see the real type
         $base = $property;
         while ($base instanceof PropertyDecoratorInterface) {
@@ -68,12 +71,16 @@ class SetterFactory
             || $base instanceof ReferenceArrayProperty
             || $base instanceof TypedArrayProperty;
 
-        $addValidation = true;
+        $addValidation = ($propTypeHint === null) || $hasConstraints;
 
-        // If property is complex (except arrays), no validation needed
-        // TODO: this is not right; Validation is not generated in some cases where it should've been
         if ($property->isComplex() && !$isArray) {
-            $addValidation = false;
+            // Complex properties like nested objects or enum classes are
+            // expected to validate themselves. Only validate here when we
+            // cannot enforce the type via a type hint (PHP <7 or union without
+            // native support).
+            if (!($base instanceof UnionProperty)) {
+                $addValidation = $propTypeHint === null;
+            }
         }
 
         $docBlock = $this->buildDocBlock($property, $varName, $propAnnotatedType, $addValidation);

--- a/src/Generator/Property/PropertyQuery.php
+++ b/src/Generator/Property/PropertyQuery.php
@@ -18,4 +18,63 @@ class PropertyQuery
         $schema = $property->schema();
         return isset($schema["deprecated"]) && $schema["deprecated"];
     }
+
+    /**
+     * Determines if the given property's schema contains validation constraints
+     * that go beyond a simple PHP type declaration.
+     *
+     * This is used to decide whether setter methods need to perform runtime
+     * validation in addition to the type hints. Only schema keywords that
+     * actually impose additional restrictions are considered. Metadata like
+     * "type" or "description" is ignored. Combinators are inspected
+     * recursively.
+     */
+    public static function hasConstraints(PropertyInterface $property): bool
+    {
+        return self::schemaHasConstraints($property->schema());
+    }
+
+    /**
+     * Recursively checks whether a schema contains validation keywords.
+     *
+     * @param array $schema
+     */
+    private static function schemaHasConstraints(array $schema): bool
+    {
+        // Keywords that do not impose validation requirements on their own.
+        static $ignored = [
+            'type' => true,
+            'title' => true,
+            'description' => true,
+            'default' => true,
+            'examples' => true,
+            '$id' => true,
+            '$schema' => true,
+            '$ref' => true,
+            'deprecated' => true,
+        ];
+
+        foreach ($schema as $key => $value) {
+            if (isset($ignored[$key])) {
+                continue;
+            }
+
+            // Combinators: inspect nested schemas and only treat them as
+            // constraints when the sub schemas impose their own restrictions.
+            if (in_array($key, ['oneOf', 'anyOf', 'allOf'], true) && is_array($value)) {
+                foreach ($value as $sub) {
+                    if (is_array($sub) && self::schemaHasConstraints($sub)) {
+                        return true;
+                    }
+                }
+                // No additional constraints detected in sub schemas.
+                continue;
+            }
+
+            // Any other keyword is treated as a constraint.
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/tests/Generator/Fixtures/AdditionalProps/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output-7.4/MyClass.php
@@ -47,18 +47,9 @@ class MyClass
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function withName(string $name, bool $validate = true): self
+    public function withName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->name = $name;
 

--- a/tests/Generator/Fixtures/AdditionalProps/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProps/Output-8.4/MyClass.php
@@ -47,18 +47,9 @@ class MyClass
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function withName(string $name, bool $validate = true): self
+    public function withName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->name = $name;
 

--- a/tests/Generator/Fixtures/AdditionalPropsRoot/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropsRoot/Output-7.4/MyClass.php
@@ -47,18 +47,9 @@ class MyClass
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function withName(string $name, bool $validate = true): self
+    public function withName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->name = $name;
 

--- a/tests/Generator/Fixtures/AdditionalPropsRoot/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropsRoot/Output-8.4/MyClass.php
@@ -47,18 +47,9 @@ class MyClass
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function withName(string $name, bool $validate = true): self
+    public function withName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->name = $name;
 
@@ -87,18 +78,9 @@ class MyClass
     /**
      * @param array|object $params
      * @return self
-     * @param bool $validate
      */
-    public function withParams(array|object $params, bool $validate = true): self
+    public function withParams(array|object $params): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($params, self::$_schema['properties']['params']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->params = $params;
 

--- a/tests/Generator/Fixtures/AllOfRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output-7.4/MyClass.php
@@ -98,18 +98,9 @@ class MyClass
     /**
      * @param string $street
      * @return self
-     * @param bool $validate
      */
-    public function withStreet(string $street, bool $validate = true): self
+    public function withStreet(string $street): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($street, self::$_schema['properties']['street']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->street = $street;
 
@@ -127,18 +118,9 @@ class MyClass
     /**
      * @param string $country
      * @return self
-     * @param bool $validate
      */
-    public function withCountry(string $country, bool $validate = true): self
+    public function withCountry(string $country): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($country, self::$_schema['properties']['country']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->country = $country;
 

--- a/tests/Generator/Fixtures/AllOfRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output-8.4/MyClass.php
@@ -98,18 +98,9 @@ class MyClass
     /**
      * @param string $street
      * @return self
-     * @param bool $validate
      */
-    public function withStreet(string $street, bool $validate = true): self
+    public function withStreet(string $street): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($street, self::$_schema['properties']['street']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->street = $street;
 
@@ -127,18 +118,9 @@ class MyClass
     /**
      * @param string $country
      * @return self
-     * @param bool $validate
      */
-    public function withCountry(string $country, bool $validate = true): self
+    public function withCountry(string $country): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($country, self::$_schema['properties']['country']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->country = $country;
 

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
@@ -54,9 +54,18 @@ class MyClass
     /**
      * @param string|int $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo($foo)
+    public function withFoo($foo, bool $validate = true)
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
@@ -51,9 +51,18 @@ class Cat
     /**
      * @param 'a'|'b'|string[] $hasFur
      * @return self
+     * @param bool $validate
      */
-    public function withHasFur(string|array $hasFur): self
+    public function withHasFur(string|array $hasFur, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($hasFur, self::$_schema['properties']['hasFur']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->hasFur = $hasFur;
 

--- a/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Phone.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Phone.php
@@ -36,18 +36,9 @@ class Phone
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -160,18 +160,9 @@ class MyClass
     /**
      * @param array $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(array $a, bool $validate = true): self
+    public function withA(array $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 
@@ -209,18 +200,9 @@ class MyClass
     /**
      * @param array|null $c
      * @return self
-     * @param bool $validate
      */
-    public function withC(?array $c, bool $validate = true): self
+    public function withC(?array $c): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($c, self::$_schema['properties']['c']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->c = $c;
 
@@ -258,18 +240,9 @@ class MyClass
     /**
      * @param array $e
      * @return self
-     * @param bool $validate
      */
-    public function withE(array $e, bool $validate = true): self
+    public function withE(array $e): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($e, self::$_schema['properties']['e']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->e = $e;
 
@@ -329,18 +302,9 @@ class MyClass
     /**
      * @param array|null $g
      * @return self
-     * @param bool $validate
      */
-    public function withG(?array $g, bool $validate = true): self
+    public function withG(?array $g): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($g, self::$_schema['properties']['g']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->g = $g;
         $clone->_providedOptionals['g'] = true;

--- a/tests/Generator/Fixtures/Basic/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Basic/Output-7.4/MyClass.php
@@ -54,18 +54,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -94,18 +85,9 @@ class MyClass
     /**
      * @param string $fooBar
      * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $fooBar, bool $validate = true): self
+    public function withFooBar(string $fooBar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($fooBar, self::$_schema['properties']['foo_bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->fooBar = $fooBar;
 

--- a/tests/Generator/Fixtures/Basic/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Basic/Output-8.4/MyClass.php
@@ -54,18 +54,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -94,18 +85,9 @@ class MyClass
     /**
      * @param string $fooBar
      * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $fooBar, bool $validate = true): self
+    public function withFooBar(string $fooBar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($fooBar, self::$_schema['properties']['foo_bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->fooBar = $fooBar;
 

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -211,18 +211,9 @@ class MyClass
     /**
      * @param string $bar
      * @return self
-     * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 
@@ -251,18 +242,9 @@ class MyClass
     /**
      * @param int|null $baz
      * @return self
-     * @param bool $validate
      */
-    public function withBaz(?int $baz, bool $validate = true): self
+    public function withBaz(?int $baz): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($baz, self::$_schema['properties']['baz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->baz = $baz;
         $clone->_providedOptionals['baz'] = true;
@@ -295,18 +277,9 @@ class MyClass
     /**
      * @param string $qux
      * @return self
-     * @param bool $validate
      */
-    public function withQux(string $qux, bool $validate = true): self
+    public function withQux(string $qux): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($qux, self::$_schema['properties']['qux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->qux = $qux;
 
@@ -337,18 +310,9 @@ class MyClass
     /**
      * @param string $thud
      * @return self
-     * @param bool $validate
      */
-    public function withThud(string $thud, bool $validate = true): self
+    public function withThud(string $thud): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($thud, self::$_schema['properties']['thud']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->thud = $thud;
 
@@ -379,18 +343,9 @@ class MyClass
     /**
      * @param string $grox
      * @return self
-     * @param bool $validate
      */
-    public function withGrox(string $grox, bool $validate = true): self
+    public function withGrox(string $grox): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($grox, self::$_schema['properties']['grox']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->grox = $grox;
 
@@ -450,18 +405,9 @@ class MyClass
     /**
      * @param string $zyx
      * @return self
-     * @param bool $validate
      */
-    public function withZyx(string $zyx, bool $validate = true): self
+    public function withZyx(string $zyx): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($zyx, self::$_schema['properties']['zyx']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->zyx = $zyx;
 

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/Address.php
@@ -96,18 +96,9 @@ class Address
     /**
      * @param string $city
      * @return self
-     * @param bool $validate
      */
-    public function withCity(string $city, bool $validate = true): self
+    public function withCity(string $city): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($city, self::$_schema['properties']['city']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->city = $city;
 

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/Address/Defs/Name.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/Address/Defs/Name.php
@@ -36,18 +36,9 @@ class Name
     /**
      * @param string $first
      * @return self
-     * @param bool $validate
      */
-    public function withFirst(string $first, bool $validate = true): self
+    public function withFirst(string $first): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($first, self::$_schema['properties']['first']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->first = $first;
 

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/MyClass.php
@@ -85,18 +85,9 @@ class MyClass
     /**
      * @param int $id
      * @return self
-     * @param bool $validate
      */
-    public function withId(int $id, bool $validate = true): self
+    public function withId(int $id): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($id, self::$_schema['properties']['id']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->id = $id;
 

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/Address.php
@@ -96,18 +96,9 @@ class Address
     /**
      * @param string $city
      * @return self
-     * @param bool $validate
      */
-    public function withCity(string $city, bool $validate = true): self
+    public function withCity(string $city): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($city, self::$_schema['properties']['city']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->city = $city;
 

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/Address/Defs/Name.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/Address/Defs/Name.php
@@ -36,18 +36,9 @@ class Name
     /**
      * @param string $first
      * @return self
-     * @param bool $validate
      */
-    public function withFirst(string $first, bool $validate = true): self
+    public function withFirst(string $first): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($first, self::$_schema['properties']['first']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->first = $first;
 

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/MyClass.php
@@ -85,18 +85,9 @@ class MyClass
     /**
      * @param int $id
      * @return self
-     * @param bool $validate
      */
-    public function withId(int $id, bool $validate = true): self
+    public function withId(int $id): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($id, self::$_schema['properties']['id']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->id = $id;
 

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-5.6/Foo.php
@@ -70,18 +70,9 @@ class Foo
     /**
      * @param 'red'|'green' $color
      * @return self
-     * @param bool $validate
      */
-    public function withColor(string $color, bool $validate = true)
+    public function withColor(string $color)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($color, self::$_schema['properties']['color']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->color = $color;
 
@@ -99,18 +90,9 @@ class Foo
     /**
      * @param 'small'|'big' $size
      * @return self
-     * @param bool $validate
      */
-    public function withSize(string $size, bool $validate = true)
+    public function withSize(string $size)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($size, self::$_schema['properties']['size']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->size = $size;
 

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-7.4/Foo.php
@@ -72,18 +72,9 @@ class Foo
     /**
      * @param 'red'|'green' $color
      * @return self
-     * @param bool $validate
      */
-    public function withColor(string $color, bool $validate = true): self
+    public function withColor(string $color): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($color, self::$_schema['properties']['color']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->color = $color;
 
@@ -101,18 +92,9 @@ class Foo
     /**
      * @param 'small'|'big' $size
      * @return self
-     * @param bool $validate
      */
-    public function withSize(string $size, bool $validate = true): self
+    public function withSize(string $size): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($size, self::$_schema['properties']['size']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->size = $size;
 

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Bar.php
@@ -36,18 +36,9 @@ class Bar
     /**
      * @param int $b
      * @return self
-     * @param bool $validate
      */
-    public function withB(int $b, bool $validate = true): self
+    public function withB(int $b): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($b, self::$_schema['properties']['b']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->b = $b;
 

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-7.4/Foo.php
@@ -36,18 +36,9 @@ class Foo
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Bar.php
@@ -36,18 +36,9 @@ class Bar
     /**
      * @param int $b
      * @return self
-     * @param bool $validate
      */
-    public function withB(int $b, bool $validate = true): self
+    public function withB(int $b): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($b, self::$_schema['properties']['b']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->b = $b;
 

--- a/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsIndependet/Output-8.4/Foo.php
@@ -36,18 +36,9 @@ class Foo
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-8.4/Foo.php
@@ -62,18 +62,9 @@ class Foo
     /**
      * @param 5|6|'5'|'6' $val
      * @return self
-     * @param bool $validate
      */
-    public function withVal(int|string $val, bool $validate = true): self
+    public function withVal(int|string $val): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($val, self::$_schema['properties']['val']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->val = $val;
 

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Foo.php
@@ -36,18 +36,9 @@ class Foo
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Foo.php
@@ -36,18 +36,9 @@ class Foo
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Bar.php
@@ -36,18 +36,9 @@ class Bar
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-7.4/Foo.php
@@ -36,18 +36,9 @@ class Foo
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Bar.php
@@ -36,18 +36,9 @@ class Bar
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsRefs/Output-8.4/Foo.php
@@ -36,18 +36,9 @@ class Foo
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/DefsRefs/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-7.4/Bar.php
@@ -36,18 +36,9 @@ class Bar
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/DefsRefs/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-7.4/Foo.php
@@ -36,18 +36,9 @@ class Foo
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/DefsRefs/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-8.4/Bar.php
@@ -36,18 +36,9 @@ class Bar
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/DefsRefs/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefsRefs/Output-8.4/Foo.php
@@ -36,18 +36,9 @@ class Foo
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/Descriptions/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-7.4/Baz.php
@@ -45,18 +45,9 @@ class Baz
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function withName(string $name, bool $validate = true): self
+    public function withName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->name = $name;
 

--- a/tests/Generator/Fixtures/Descriptions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-7.4/MyClass.php
@@ -65,18 +65,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/Descriptions/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-8.4/Baz.php
@@ -45,18 +45,9 @@ class Baz
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function withName(string $name, bool $validate = true): self
+    public function withName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->name = $name;
 

--- a/tests/Generator/Fixtures/Descriptions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-8.4/MyClass.php
@@ -65,18 +65,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-7.4/MyClass.php
@@ -57,18 +57,9 @@ class MyClass
     /**
      * @param string $_foo_bar
      * @return self
-     * @param bool $validate
      */
-    public function with_FooBar(string $_foo_bar, bool $validate = true): self
+    public function with_FooBar(string $_foo_bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_foo_bar = $_foo_bar;
 
@@ -86,18 +77,9 @@ class MyClass
     /**
      * @param string $foo_bar
      * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $foo_bar, bool $validate = true): self
+    public function withFooBar(string $foo_bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo_bar = $foo_bar;
 

--- a/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNames/Output-8.4/MyClass.php
@@ -57,18 +57,9 @@ class MyClass
     /**
      * @param string $_foo_bar
      * @return self
-     * @param bool $validate
      */
-    public function with_FooBar(string $_foo_bar, bool $validate = true): self
+    public function with_FooBar(string $_foo_bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_foo_bar = $_foo_bar;
 
@@ -86,18 +77,9 @@ class MyClass
     /**
      * @param string $foo_bar
      * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $foo_bar, bool $validate = true): self
+    public function withFooBar(string $foo_bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo_bar = $foo_bar;
 

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-7.4/MyClass.php
@@ -54,18 +54,9 @@ class MyClass
     /**
      * @param string $_foo_bar
      * @return self
-     * @param bool $validate
      */
-    public function with_FooBar(string $_foo_bar, bool $validate = true): self
+    public function with_FooBar(string $_foo_bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_foo_bar = $_foo_bar;
 
@@ -83,18 +74,9 @@ class MyClass
     /**
      * @param string $foo_bar
      * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $foo_bar, bool $validate = true): self
+    public function withFooBar(string $foo_bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo_bar = $foo_bar;
 

--- a/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateSanitizedNamesOptional/Output-8.4/MyClass.php
@@ -54,18 +54,9 @@ class MyClass
     /**
      * @param string $_foo_bar
      * @return self
-     * @param bool $validate
      */
-    public function with_FooBar(string $_foo_bar, bool $validate = true): self
+    public function with_FooBar(string $_foo_bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_foo_bar = $_foo_bar;
 
@@ -83,18 +74,9 @@ class MyClass
     /**
      * @param string $foo_bar
      * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $foo_bar, bool $validate = true): self
+    public function withFooBar(string $foo_bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo_bar = $foo_bar;
 

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-7.4/MyClass.php
@@ -66,18 +66,9 @@ class MyClass
     /**
      * @param string $fooBar
      * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $fooBar, bool $validate = true): self
+    public function withFooBar(string $fooBar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($fooBar, self::$_schema['properties']['fooBar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->fooBar = $fooBar;
 
@@ -97,18 +88,9 @@ class MyClass
      * @param string $bar
      * @return self
      * @deprecated
-     * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output-8.4/MyClass.php
@@ -66,18 +66,9 @@ class MyClass
     /**
      * @param string $fooBar
      * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $fooBar, bool $validate = true): self
+    public function withFooBar(string $fooBar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($fooBar, self::$_schema['properties']['fooBar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->fooBar = $fooBar;
 
@@ -97,18 +88,9 @@ class MyClass
      * @param string $bar
      * @return self
      * @deprecated
-     * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasingPreserve/Output-7.4/MyClass.php
@@ -66,18 +66,9 @@ class MyClass
     /**
      * @param string $fooBar
      * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $fooBar, bool $validate = true): self
+    public function withFooBar(string $fooBar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($fooBar, self::$_schema['properties']['fooBar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->fooBar = $fooBar;
 
@@ -97,18 +88,9 @@ class MyClass
      * @param string $bar
      * @return self
      * @deprecated
-     * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasingPreserve/Output-8.4/MyClass.php
@@ -66,18 +66,9 @@ class MyClass
     /**
      * @param string $fooBar
      * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $fooBar, bool $validate = true): self
+    public function withFooBar(string $fooBar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($fooBar, self::$_schema['properties']['fooBar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->fooBar = $fooBar;
 
@@ -97,18 +88,9 @@ class MyClass
      * @param string $bar
      * @return self
      * @deprecated
-     * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/EncodedRef/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-7.4/BarTest.php
@@ -36,18 +36,9 @@ class BarTest
     /**
      * @param string $bar
      * @return self
-     * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/EncodedRef/Output-7.4/FooTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-7.4/FooTest.php
@@ -36,18 +36,9 @@ class FooTest
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/EncodedRef/Output-8.4/BarTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-8.4/BarTest.php
@@ -36,18 +36,9 @@ class BarTest
     /**
      * @param string $bar
      * @return self
-     * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/EncodedRef/Output-8.4/FooTest.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-8.4/FooTest.php
@@ -36,18 +36,9 @@ class FooTest
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
@@ -223,18 +223,9 @@ class Foo
     /**
      * @param false $boolEnumRef
      * @return self
-     * @param bool $validate
      */
-    public function withBoolEnumRef(bool $boolEnumRef, bool $validate = true)
+    public function withBoolEnumRef(bool $boolEnumRef)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($boolEnumRef, self::$_schema['properties']['boolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->boolEnumRef = $boolEnumRef;
 
@@ -263,18 +254,9 @@ class Foo
     /**
      * @param false $requiredBoolEnumRef
      * @return self
-     * @param bool $validate
      */
-    public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef, bool $validate = true)
+    public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($requiredBoolEnumRef, self::$_schema['properties']['requiredBoolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->requiredBoolEnumRef = $requiredBoolEnumRef;
 

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
@@ -225,18 +225,9 @@ class Foo
     /**
      * @param false $boolEnumRef
      * @return self
-     * @param bool $validate
      */
-    public function withBoolEnumRef(bool $boolEnumRef, bool $validate = true): self
+    public function withBoolEnumRef(bool $boolEnumRef): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($boolEnumRef, self::$_schema['properties']['boolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->boolEnumRef = $boolEnumRef;
 
@@ -265,18 +256,9 @@ class Foo
     /**
      * @param false $requiredBoolEnumRef
      * @return self
-     * @param bool $validate
      */
-    public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef, bool $validate = true): self
+    public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($requiredBoolEnumRef, self::$_schema['properties']['requiredBoolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->requiredBoolEnumRef = $requiredBoolEnumRef;
 

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
@@ -145,18 +145,9 @@ class Foo
     /**
      * @param 0|1.5|2.5|3.5 $floatEnumRef
      * @return self
-     * @param bool $validate
      */
-    public function withFloatEnumRef(int|float $floatEnumRef, bool $validate = true): self
+    public function withFloatEnumRef(int|float $floatEnumRef): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($floatEnumRef, self::$_schema['properties']['floatEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->floatEnumRef = $floatEnumRef;
 
@@ -225,18 +216,9 @@ class Foo
     /**
      * @param false $boolEnumRef
      * @return self
-     * @param bool $validate
      */
-    public function withBoolEnumRef(bool $boolEnumRef, bool $validate = true): self
+    public function withBoolEnumRef(bool $boolEnumRef): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($boolEnumRef, self::$_schema['properties']['boolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->boolEnumRef = $boolEnumRef;
 
@@ -265,18 +247,9 @@ class Foo
     /**
      * @param false $requiredBoolEnumRef
      * @return self
-     * @param bool $validate
      */
-    public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef, bool $validate = true): self
+    public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($requiredBoolEnumRef, self::$_schema['properties']['requiredBoolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->requiredBoolEnumRef = $requiredBoolEnumRef;
 

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
@@ -70,9 +70,18 @@ class BarTest
     /**
      * @param FooTest|MoiKlass|FooTest_1 $exampleProp
      * @return self
+     * @param bool $validate
      */
-    public function withExampleProp($exampleProp)
+    public function withExampleProp($exampleProp, bool $validate = true)
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($exampleProp, self::$_schema['properties']['exampleProp']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->exampleProp = $exampleProp;
 

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -72,9 +72,18 @@ class BarTest
     /**
      * @param FooTest|MoiKlass|FooTest_1 $exampleProp
      * @return self
+     * @param bool $validate
      */
-    public function withExampleProp($exampleProp): self
+    public function withExampleProp($exampleProp, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($exampleProp, self::$_schema['properties']['exampleProp']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->exampleProp = $exampleProp;
 

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest.php
@@ -36,18 +36,9 @@ class FooTest
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest_1.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/FooTest_1.php
@@ -36,18 +36,9 @@ class FooTest_1
     /**
      * @param string $b
      * @return self
-     * @param bool $validate
      */
-    public function withB(string $b, bool $validate = true): self
+    public function withB(string $b): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($b, self::$_schema['properties']['b']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->b = $b;
 

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/MoiKlass.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/MoiKlass.php
@@ -36,18 +36,9 @@ class MoiKlass
     /**
      * @param string $c
      * @return self
-     * @param bool $validate
      */
-    public function withC(string $c, bool $validate = true): self
+    public function withC(string $c): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($c, self::$_schema['properties']['c']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->c = $c;
 

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest.php
@@ -36,18 +36,9 @@ class FooTest
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest_1.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/FooTest_1.php
@@ -36,18 +36,9 @@ class FooTest_1
     /**
      * @param string $b
      * @return self
-     * @param bool $validate
      */
-    public function withB(string $b, bool $validate = true): self
+    public function withB(string $b): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($b, self::$_schema['properties']['b']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->b = $b;
 

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/MoiKlass.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/MoiKlass.php
@@ -36,18 +36,9 @@ class MoiKlass
     /**
      * @param string $c
      * @return self
-     * @param bool $validate
      */
-    public function withC(string $c, bool $validate = true): self
+    public function withC(string $c): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($c, self::$_schema['properties']['c']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->c = $c;
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -2044,9 +2044,18 @@ class MyClass
     /**
      * @param MyClassEnsureArgs1Alternative1|MyClassEnsureArgs1Alternative2|string $ensureArgs1
      * @return self
+     * @param bool $validate
      */
-    public function withEnsureArgs1($ensureArgs1)
+    public function withEnsureArgs1($ensureArgs1, bool $validate = true)
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($ensureArgs1, self::$_schema['properties']['ensureArgs1']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->ensureArgs1 = $ensureArgs1;
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -646,18 +646,9 @@ class MyClass
     /**
      * @param string $_GLOBALS_1
      * @return self
-     * @param bool $validate
      */
-    public function with_GLOBALS(string $_GLOBALS_1, bool $validate = true): self
+    public function with_GLOBALS(string $_GLOBALS_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_1, self::$_schema['properties']['_GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_GLOBALS = $_GLOBALS_1;
 
@@ -675,18 +666,9 @@ class MyClass
     /**
      * @param string $_GLOBALS
      * @return self
-     * @param bool $validate
      */
-    public function withGLOBALS(string $_GLOBALS, bool $validate = true): self
+    public function withGLOBALS(string $_GLOBALS): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS, self::$_schema['properties']['GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->GLOBALS = $_GLOBALS;
 
@@ -704,18 +686,9 @@ class MyClass
     /**
      * @param string $GLOBALS1
      * @return self
-     * @param bool $validate
      */
-    public function withGLOBALS1(string $GLOBALS1, bool $validate = true): self
+    public function withGLOBALS1(string $GLOBALS1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($GLOBALS1, self::$_schema['properties']['GLOBALS_1']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->GLOBALS1 = $GLOBALS1;
 
@@ -733,18 +706,9 @@ class MyClass
     /**
      * @param string $SERVER
      * @return self
-     * @param bool $validate
      */
-    public function withSERVER(string $SERVER, bool $validate = true): self
+    public function withSERVER(string $SERVER): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($SERVER, self::$_schema['properties']['_SERVER']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->SERVER = $SERVER;
 
@@ -762,18 +726,9 @@ class MyClass
     /**
      * @param string $GET
      * @return self
-     * @param bool $validate
      */
-    public function withGET(string $GET, bool $validate = true): self
+    public function withGET(string $GET): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($GET, self::$_schema['properties']['_GET']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->GET = $GET;
 
@@ -791,18 +746,9 @@ class MyClass
     /**
      * @param string $POST
      * @return self
-     * @param bool $validate
      */
-    public function withPOST(string $POST, bool $validate = true): self
+    public function withPOST(string $POST): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($POST, self::$_schema['properties']['_POST']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->POST = $POST;
 
@@ -820,18 +766,9 @@ class MyClass
     /**
      * @param string $FILES
      * @return self
-     * @param bool $validate
      */
-    public function withFILES(string $FILES, bool $validate = true): self
+    public function withFILES(string $FILES): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($FILES, self::$_schema['properties']['_FILES']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->FILES = $FILES;
 
@@ -849,18 +786,9 @@ class MyClass
     /**
      * @param string $REQUEST
      * @return self
-     * @param bool $validate
      */
-    public function withREQUEST(string $REQUEST, bool $validate = true): self
+    public function withREQUEST(string $REQUEST): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($REQUEST, self::$_schema['properties']['_REQUEST']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->REQUEST = $REQUEST;
 
@@ -878,18 +806,9 @@ class MyClass
     /**
      * @param string $SESSION
      * @return self
-     * @param bool $validate
      */
-    public function withSESSION(string $SESSION, bool $validate = true): self
+    public function withSESSION(string $SESSION): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($SESSION, self::$_schema['properties']['_SESSION']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->SESSION = $SESSION;
 
@@ -907,18 +826,9 @@ class MyClass
     /**
      * @param string $ENV
      * @return self
-     * @param bool $validate
      */
-    public function withENV(string $ENV, bool $validate = true): self
+    public function withENV(string $ENV): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($ENV, self::$_schema['properties']['_ENV']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->ENV = $ENV;
 
@@ -936,18 +846,9 @@ class MyClass
     /**
      * @param string $COOKIE
      * @return self
-     * @param bool $validate
      */
-    public function withCOOKIE(string $COOKIE, bool $validate = true): self
+    public function withCOOKIE(string $COOKIE): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($COOKIE, self::$_schema['properties']['_COOKIE']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->COOKIE = $COOKIE;
 
@@ -965,18 +866,9 @@ class MyClass
     /**
      * @param string $phpErrormsg
      * @return self
-     * @param bool $validate
      */
-    public function withPhpErrormsg(string $phpErrormsg, bool $validate = true): self
+    public function withPhpErrormsg(string $phpErrormsg): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($phpErrormsg, self::$_schema['properties']['php_errormsg']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->phpErrormsg = $phpErrormsg;
 
@@ -994,18 +886,9 @@ class MyClass
     /**
      * @param string $httpResponseHeader
      * @return self
-     * @param bool $validate
      */
-    public function withHttpResponseHeader(string $httpResponseHeader, bool $validate = true): self
+    public function withHttpResponseHeader(string $httpResponseHeader): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($httpResponseHeader, self::$_schema['properties']['http_response_header']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->httpResponseHeader = $httpResponseHeader;
 
@@ -1023,18 +906,9 @@ class MyClass
     /**
      * @param string $_argc
      * @return self
-     * @param bool $validate
      */
-    public function withArgc(string $_argc, bool $validate = true): self
+    public function withArgc(string $_argc): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_argc, self::$_schema['properties']['argc']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->argc = $_argc;
 
@@ -1052,18 +926,9 @@ class MyClass
     /**
      * @param string $_argv
      * @return self
-     * @param bool $validate
      */
-    public function withArgv(string $_argv, bool $validate = true): self
+    public function withArgv(string $_argv): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_argv, self::$_schema['properties']['argv']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->argv = $_argv;
 
@@ -1081,18 +946,9 @@ class MyClass
     /**
      * @param string $_input
      * @return self
-     * @param bool $validate
      */
-    public function withInput(string $_input, bool $validate = true): self
+    public function withInput(string $_input): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_input, self::$_schema['properties']['input']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->input = $_input;
 
@@ -1110,18 +966,9 @@ class MyClass
     /**
      * @param string $_validate
      * @return self
-     * @param bool $validate
      */
-    public function withValidate(string $_validate, bool $validate = true): self
+    public function withValidate(string $_validate): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_validate, self::$_schema['properties']['validate']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->validate = $_validate;
 
@@ -1150,18 +997,9 @@ class MyClass
     /**
      * @param string|null $_materializeDefaults
      * @return self
-     * @param bool $validate
      */
-    public function withMaterializeDefaults(?string $_materializeDefaults, bool $validate = true): self
+    public function withMaterializeDefaults(?string $_materializeDefaults): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_materializeDefaults, self::$_schema['properties']['materializeDefaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->materializeDefaults = $_materializeDefaults;
         $clone->_providedOptionals['materializeDefaults'] = true;
@@ -1192,18 +1030,9 @@ class MyClass
     /**
      * @param string $_obj
      * @return self
-     * @param bool $validate
      */
-    public function withObj(string $_obj, bool $validate = true): self
+    public function withObj(string $_obj): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_obj, self::$_schema['properties']['obj']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->obj = $_obj;
 
@@ -1221,18 +1050,9 @@ class MyClass
     /**
      * @param string $_includeDefaults
      * @return self
-     * @param bool $validate
      */
-    public function withIncludeDefaults(string $_includeDefaults, bool $validate = true): self
+    public function withIncludeDefaults(string $_includeDefaults): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_includeDefaults, self::$_schema['properties']['includeDefaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->includeDefaults = $_includeDefaults;
 
@@ -1281,18 +1101,9 @@ class MyClass
     /**
      * @param string $fromInput
      * @return self
-     * @param bool $validate
      */
-    public function withFromInput(string $fromInput, bool $validate = true): self
+    public function withFromInput(string $fromInput): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($fromInput, self::$_schema['properties']['fromInput']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->fromInput = $fromInput;
 
@@ -1310,18 +1121,9 @@ class MyClass
     /**
      * @param string $toArray
      * @return self
-     * @param bool $validate
      */
-    public function withToArray(string $toArray, bool $validate = true): self
+    public function withToArray(string $toArray): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($toArray, self::$_schema['properties']['toArray']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->toArray = $toArray;
 
@@ -1339,18 +1141,9 @@ class MyClass
     /**
      * @param string $toStdClass
      * @return self
-     * @param bool $validate
      */
-    public function withToStdClass(string $toStdClass, bool $validate = true): self
+    public function withToStdClass(string $toStdClass): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($toStdClass, self::$_schema['properties']['toStdClass']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->toStdClass = $toStdClass;
 
@@ -1368,18 +1161,9 @@ class MyClass
     /**
      * @param string $validateInput
      * @return self
-     * @param bool $validate
      */
-    public function withValidateInput(string $validateInput, bool $validate = true): self
+    public function withValidateInput(string $validateInput): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($validateInput, self::$_schema['properties']['validateInput']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->validateInput = $validateInput;
 
@@ -1397,18 +1181,9 @@ class MyClass
     /**
      * @param string $_schema_1
      * @return self
-     * @param bool $validate
      */
-    public function withSchema1(string $_schema_1, bool $validate = true): self
+    public function withSchema1(string $_schema_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_1, self::$_schema['properties']['_schema']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_schema_1 = $_schema_1;
 
@@ -1426,18 +1201,9 @@ class MyClass
     /**
      * @param string $schema
      * @return self
-     * @param bool $validate
      */
-    public function withSchema(string $schema, bool $validate = true): self
+    public function withSchema(string $schema): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($schema, self::$_schema['properties']['schema']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->schema = $schema;
 
@@ -1455,18 +1221,9 @@ class MyClass
     /**
      * @param string $_defaults_1
      * @return self
-     * @param bool $validate
      */
-    public function withDefaults1(string $_defaults_1, bool $validate = true): self
+    public function withDefaults1(string $_defaults_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_1, self::$_schema['properties']['_defaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_defaults_1 = $_defaults_1;
 
@@ -1484,18 +1241,9 @@ class MyClass
     /**
      * @param string $defaults
      * @return self
-     * @param bool $validate
      */
-    public function withDefaults(string $defaults, bool $validate = true): self
+    public function withDefaults(string $defaults): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($defaults, self::$_schema['properties']['defaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->defaults = $defaults;
 
@@ -1513,18 +1261,9 @@ class MyClass
     /**
      * @param string $providedOptionals
      * @return self
-     * @param bool $validate
      */
-    public function withProvidedOptionals(string $providedOptionals, bool $validate = true): self
+    public function withProvidedOptionals(string $providedOptionals): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($providedOptionals, self::$_schema['properties']['_providedOptionals']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->providedOptionals = $providedOptionals;
 
@@ -1542,18 +1281,9 @@ class MyClass
     /**
      * @param string $_providedOptionals_1
      * @return self
-     * @param bool $validate
      */
-    public function withProvidedOptionals1(string $_providedOptionals_1, bool $validate = true): self
+    public function withProvidedOptionals1(string $_providedOptionals_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_providedOptionals_1, self::$_schema['properties']['__providedOptionals']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_providedOptionals_1 = $_providedOptionals_1;
 
@@ -1582,18 +1312,9 @@ class MyClass
     /**
      * @param string $_clone
      * @return self
-     * @param bool $validate
      */
-    public function withClone(string $_clone, bool $validate = true): self
+    public function withClone(string $_clone): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone, self::$_schema['properties']['clone']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->clone = $_clone;
 
@@ -1611,18 +1332,9 @@ class MyClass
     /**
      * @param string $_clone_1
      * @return self
-     * @param bool $validate
      */
-    public function with_Clone(string $_clone_1, bool $validate = true): self
+    public function with_Clone(string $_clone_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone_1, self::$_schema['properties']['__clone']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_clone = $_clone_1;
 
@@ -1640,18 +1352,9 @@ class MyClass
     /**
      * @param string $construct
      * @return self
-     * @param bool $validate
      */
-    public function withConstruct(string $construct, bool $validate = true): self
+    public function withConstruct(string $construct): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($construct, self::$_schema['properties']['__construct']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->construct = $construct;
 
@@ -1669,18 +1372,9 @@ class MyClass
     /**
      * @param string $destruct
      * @return self
-     * @param bool $validate
      */
-    public function withDestruct(string $destruct, bool $validate = true): self
+    public function withDestruct(string $destruct): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($destruct, self::$_schema['properties']['__destruct']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->destruct = $destruct;
 
@@ -1698,18 +1392,9 @@ class MyClass
     /**
      * @param string $get
      * @return self
-     * @param bool $validate
      */
-    public function with_Get(string $get, bool $validate = true): self
+    public function with_Get(string $get): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($get, self::$_schema['properties']['__get']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->get = $get;
 
@@ -1727,18 +1412,9 @@ class MyClass
     /**
      * @param string $set
      * @return self
-     * @param bool $validate
      */
-    public function withSet(string $set, bool $validate = true): self
+    public function withSet(string $set): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($set, self::$_schema['properties']['__set']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->set = $set;
 
@@ -1756,18 +1432,9 @@ class MyClass
     /**
      * @param string $call
      * @return self
-     * @param bool $validate
      */
-    public function withCall(string $call, bool $validate = true): self
+    public function withCall(string $call): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($call, self::$_schema['properties']['__call']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->call = $call;
 
@@ -1785,18 +1452,9 @@ class MyClass
     /**
      * @param string $isset
      * @return self
-     * @param bool $validate
      */
-    public function withIsset(string $isset, bool $validate = true): self
+    public function withIsset(string $isset): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($isset, self::$_schema['properties']['__isset']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->isset = $isset;
 
@@ -1814,18 +1472,9 @@ class MyClass
     /**
      * @param string $unset
      * @return self
-     * @param bool $validate
      */
-    public function withUnset(string $unset, bool $validate = true): self
+    public function withUnset(string $unset): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($unset, self::$_schema['properties']['__unset']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->unset = $unset;
 
@@ -1843,18 +1492,9 @@ class MyClass
     /**
      * @param string $sleep
      * @return self
-     * @param bool $validate
      */
-    public function withSleep(string $sleep, bool $validate = true): self
+    public function withSleep(string $sleep): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($sleep, self::$_schema['properties']['__sleep']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->sleep = $sleep;
 
@@ -1872,18 +1512,9 @@ class MyClass
     /**
      * @param string $wakeup
      * @return self
-     * @param bool $validate
      */
-    public function withWakeup(string $wakeup, bool $validate = true): self
+    public function withWakeup(string $wakeup): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($wakeup, self::$_schema['properties']['__wakeup']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->wakeup = $wakeup;
 
@@ -1901,18 +1532,9 @@ class MyClass
     /**
      * @param string $toString
      * @return self
-     * @param bool $validate
      */
-    public function withToString(string $toString, bool $validate = true): self
+    public function withToString(string $toString): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($toString, self::$_schema['properties']['__toString']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->toString = $toString;
 
@@ -1930,18 +1552,9 @@ class MyClass
     /**
      * @param string $invoke
      * @return self
-     * @param bool $validate
      */
-    public function withInvoke(string $invoke, bool $validate = true): self
+    public function withInvoke(string $invoke): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($invoke, self::$_schema['properties']['__invoke']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->invoke = $invoke;
 
@@ -1959,18 +1572,9 @@ class MyClass
     /**
      * @param string $debugInfo
      * @return self
-     * @param bool $validate
      */
-    public function withDebugInfo(string $debugInfo, bool $validate = true): self
+    public function withDebugInfo(string $debugInfo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($debugInfo, self::$_schema['properties']['__debugInfo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->debugInfo = $debugInfo;
 
@@ -1988,18 +1592,9 @@ class MyClass
     /**
      * @param string $files
      * @return self
-     * @param bool $validate
      */
-    public function with_Files(string $files, bool $validate = true): self
+    public function with_Files(string $files): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
 
@@ -2017,18 +1612,9 @@ class MyClass
     /**
      * @param string $_this
      * @return self
-     * @param bool $validate
      */
-    public function withThis(string $_this, bool $validate = true): self
+    public function withThis(string $_this): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_this, self::$_schema['properties']['this']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_this = $_this;
 
@@ -2046,9 +1632,18 @@ class MyClass
     /**
      * @param MyClassEnsureArgs1Alternative1|MyClassEnsureArgs1Alternative2|string $ensureArgs1
      * @return self
+     * @param bool $validate
      */
-    public function withEnsureArgs1($ensureArgs1): self
+    public function withEnsureArgs1($ensureArgs1, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($ensureArgs1, self::$_schema['properties']['ensureArgs1']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->ensureArgs1 = $ensureArgs1;
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs1Alternative2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs1Alternative2.php
@@ -69,18 +69,9 @@ class MyClassEnsureArgs1Alternative2
     /**
      * @param string $type
      * @return self
-     * @param bool $validate
      */
-    public function withType(string $type, bool $validate = true): self
+    public function withType(string $type): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($type, self::$_schema['properties']['type']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->type = $type;
 
@@ -98,18 +89,9 @@ class MyClassEnsureArgs1Alternative2
     /**
      * @param string $accountNumber
      * @return self
-     * @param bool $validate
      */
-    public function withAccountNumber(string $accountNumber, bool $validate = true): self
+    public function withAccountNumber(string $accountNumber): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($accountNumber, self::$_schema['properties']['accountNumber']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->accountNumber = $accountNumber;
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs2.php
@@ -99,18 +99,9 @@ class MyClassEnsureArgs2
     /**
      * @param string $street
      * @return self
-     * @param bool $validate
      */
-    public function withStreet(string $street, bool $validate = true): self
+    public function withStreet(string $street): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($street, self::$_schema['properties']['street']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->street = $street;
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassEnsureArgs3Item.php
@@ -47,18 +47,9 @@ class MyClassEnsureArgs3Item
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function withName(string $name, bool $validate = true): self
+    public function withName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->name = $name;
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClassTestObj.php
@@ -36,18 +36,9 @@ class MyClassTestObj
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
@@ -646,18 +646,9 @@ class MyClass
     /**
      * @param string $_GLOBALS_1
      * @return self
-     * @param bool $validate
      */
-    public function with_GLOBALS(string $_GLOBALS_1, bool $validate = true): self
+    public function with_GLOBALS(string $_GLOBALS_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_1, self::$_schema['properties']['_GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_GLOBALS = $_GLOBALS_1;
 
@@ -675,18 +666,9 @@ class MyClass
     /**
      * @param string $_GLOBALS
      * @return self
-     * @param bool $validate
      */
-    public function withGLOBALS(string $_GLOBALS, bool $validate = true): self
+    public function withGLOBALS(string $_GLOBALS): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS, self::$_schema['properties']['GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->GLOBALS = $_GLOBALS;
 
@@ -704,18 +686,9 @@ class MyClass
     /**
      * @param string $GLOBALS1
      * @return self
-     * @param bool $validate
      */
-    public function withGLOBALS1(string $GLOBALS1, bool $validate = true): self
+    public function withGLOBALS1(string $GLOBALS1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($GLOBALS1, self::$_schema['properties']['GLOBALS_1']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->GLOBALS1 = $GLOBALS1;
 
@@ -733,18 +706,9 @@ class MyClass
     /**
      * @param string $SERVER
      * @return self
-     * @param bool $validate
      */
-    public function withSERVER(string $SERVER, bool $validate = true): self
+    public function withSERVER(string $SERVER): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($SERVER, self::$_schema['properties']['_SERVER']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->SERVER = $SERVER;
 
@@ -762,18 +726,9 @@ class MyClass
     /**
      * @param string $GET
      * @return self
-     * @param bool $validate
      */
-    public function withGET(string $GET, bool $validate = true): self
+    public function withGET(string $GET): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($GET, self::$_schema['properties']['_GET']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->GET = $GET;
 
@@ -791,18 +746,9 @@ class MyClass
     /**
      * @param string $POST
      * @return self
-     * @param bool $validate
      */
-    public function withPOST(string $POST, bool $validate = true): self
+    public function withPOST(string $POST): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($POST, self::$_schema['properties']['_POST']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->POST = $POST;
 
@@ -820,18 +766,9 @@ class MyClass
     /**
      * @param string $FILES
      * @return self
-     * @param bool $validate
      */
-    public function withFILES(string $FILES, bool $validate = true): self
+    public function withFILES(string $FILES): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($FILES, self::$_schema['properties']['_FILES']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->FILES = $FILES;
 
@@ -849,18 +786,9 @@ class MyClass
     /**
      * @param string $REQUEST
      * @return self
-     * @param bool $validate
      */
-    public function withREQUEST(string $REQUEST, bool $validate = true): self
+    public function withREQUEST(string $REQUEST): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($REQUEST, self::$_schema['properties']['_REQUEST']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->REQUEST = $REQUEST;
 
@@ -878,18 +806,9 @@ class MyClass
     /**
      * @param string $SESSION
      * @return self
-     * @param bool $validate
      */
-    public function withSESSION(string $SESSION, bool $validate = true): self
+    public function withSESSION(string $SESSION): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($SESSION, self::$_schema['properties']['_SESSION']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->SESSION = $SESSION;
 
@@ -907,18 +826,9 @@ class MyClass
     /**
      * @param string $ENV
      * @return self
-     * @param bool $validate
      */
-    public function withENV(string $ENV, bool $validate = true): self
+    public function withENV(string $ENV): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($ENV, self::$_schema['properties']['_ENV']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->ENV = $ENV;
 
@@ -936,18 +846,9 @@ class MyClass
     /**
      * @param string $COOKIE
      * @return self
-     * @param bool $validate
      */
-    public function withCOOKIE(string $COOKIE, bool $validate = true): self
+    public function withCOOKIE(string $COOKIE): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($COOKIE, self::$_schema['properties']['_COOKIE']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->COOKIE = $COOKIE;
 
@@ -965,18 +866,9 @@ class MyClass
     /**
      * @param string $phpErrormsg
      * @return self
-     * @param bool $validate
      */
-    public function withPhpErrormsg(string $phpErrormsg, bool $validate = true): self
+    public function withPhpErrormsg(string $phpErrormsg): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($phpErrormsg, self::$_schema['properties']['php_errormsg']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->phpErrormsg = $phpErrormsg;
 
@@ -994,18 +886,9 @@ class MyClass
     /**
      * @param string $httpResponseHeader
      * @return self
-     * @param bool $validate
      */
-    public function withHttpResponseHeader(string $httpResponseHeader, bool $validate = true): self
+    public function withHttpResponseHeader(string $httpResponseHeader): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($httpResponseHeader, self::$_schema['properties']['http_response_header']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->httpResponseHeader = $httpResponseHeader;
 
@@ -1023,18 +906,9 @@ class MyClass
     /**
      * @param string $_argc
      * @return self
-     * @param bool $validate
      */
-    public function withArgc(string $_argc, bool $validate = true): self
+    public function withArgc(string $_argc): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_argc, self::$_schema['properties']['argc']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->argc = $_argc;
 
@@ -1052,18 +926,9 @@ class MyClass
     /**
      * @param string $_argv
      * @return self
-     * @param bool $validate
      */
-    public function withArgv(string $_argv, bool $validate = true): self
+    public function withArgv(string $_argv): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_argv, self::$_schema['properties']['argv']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->argv = $_argv;
 
@@ -1081,18 +946,9 @@ class MyClass
     /**
      * @param string $_input
      * @return self
-     * @param bool $validate
      */
-    public function withInput(string $_input, bool $validate = true): self
+    public function withInput(string $_input): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_input, self::$_schema['properties']['input']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->input = $_input;
 
@@ -1110,18 +966,9 @@ class MyClass
     /**
      * @param string $_validate
      * @return self
-     * @param bool $validate
      */
-    public function withValidate(string $_validate, bool $validate = true): self
+    public function withValidate(string $_validate): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_validate, self::$_schema['properties']['validate']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->validate = $_validate;
 
@@ -1150,18 +997,9 @@ class MyClass
     /**
      * @param string|null $_materializeDefaults
      * @return self
-     * @param bool $validate
      */
-    public function withMaterializeDefaults(?string $_materializeDefaults, bool $validate = true): self
+    public function withMaterializeDefaults(?string $_materializeDefaults): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_materializeDefaults, self::$_schema['properties']['materializeDefaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->materializeDefaults = $_materializeDefaults;
         $clone->_providedOptionals['materializeDefaults'] = true;
@@ -1192,18 +1030,9 @@ class MyClass
     /**
      * @param string $_obj
      * @return self
-     * @param bool $validate
      */
-    public function withObj(string $_obj, bool $validate = true): self
+    public function withObj(string $_obj): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_obj, self::$_schema['properties']['obj']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->obj = $_obj;
 
@@ -1221,18 +1050,9 @@ class MyClass
     /**
      * @param string $_includeDefaults
      * @return self
-     * @param bool $validate
      */
-    public function withIncludeDefaults(string $_includeDefaults, bool $validate = true): self
+    public function withIncludeDefaults(string $_includeDefaults): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_includeDefaults, self::$_schema['properties']['includeDefaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->includeDefaults = $_includeDefaults;
 
@@ -1281,18 +1101,9 @@ class MyClass
     /**
      * @param string $fromInput
      * @return self
-     * @param bool $validate
      */
-    public function withFromInput(string $fromInput, bool $validate = true): self
+    public function withFromInput(string $fromInput): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($fromInput, self::$_schema['properties']['fromInput']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->fromInput = $fromInput;
 
@@ -1310,18 +1121,9 @@ class MyClass
     /**
      * @param string $toArray
      * @return self
-     * @param bool $validate
      */
-    public function withToArray(string $toArray, bool $validate = true): self
+    public function withToArray(string $toArray): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($toArray, self::$_schema['properties']['toArray']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->toArray = $toArray;
 
@@ -1339,18 +1141,9 @@ class MyClass
     /**
      * @param string $toStdClass
      * @return self
-     * @param bool $validate
      */
-    public function withToStdClass(string $toStdClass, bool $validate = true): self
+    public function withToStdClass(string $toStdClass): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($toStdClass, self::$_schema['properties']['toStdClass']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->toStdClass = $toStdClass;
 
@@ -1368,18 +1161,9 @@ class MyClass
     /**
      * @param string $validateInput
      * @return self
-     * @param bool $validate
      */
-    public function withValidateInput(string $validateInput, bool $validate = true): self
+    public function withValidateInput(string $validateInput): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($validateInput, self::$_schema['properties']['validateInput']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->validateInput = $validateInput;
 
@@ -1397,18 +1181,9 @@ class MyClass
     /**
      * @param string $_schema_1
      * @return self
-     * @param bool $validate
      */
-    public function withSchema1(string $_schema_1, bool $validate = true): self
+    public function withSchema1(string $_schema_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_1, self::$_schema['properties']['_schema']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_schema_1 = $_schema_1;
 
@@ -1426,18 +1201,9 @@ class MyClass
     /**
      * @param string $schema
      * @return self
-     * @param bool $validate
      */
-    public function withSchema(string $schema, bool $validate = true): self
+    public function withSchema(string $schema): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($schema, self::$_schema['properties']['schema']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->schema = $schema;
 
@@ -1455,18 +1221,9 @@ class MyClass
     /**
      * @param string $_defaults_1
      * @return self
-     * @param bool $validate
      */
-    public function withDefaults1(string $_defaults_1, bool $validate = true): self
+    public function withDefaults1(string $_defaults_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_1, self::$_schema['properties']['_defaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_defaults_1 = $_defaults_1;
 
@@ -1484,18 +1241,9 @@ class MyClass
     /**
      * @param string $defaults
      * @return self
-     * @param bool $validate
      */
-    public function withDefaults(string $defaults, bool $validate = true): self
+    public function withDefaults(string $defaults): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($defaults, self::$_schema['properties']['defaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->defaults = $defaults;
 
@@ -1513,18 +1261,9 @@ class MyClass
     /**
      * @param string $providedOptionals
      * @return self
-     * @param bool $validate
      */
-    public function withProvidedOptionals(string $providedOptionals, bool $validate = true): self
+    public function withProvidedOptionals(string $providedOptionals): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($providedOptionals, self::$_schema['properties']['_providedOptionals']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->providedOptionals = $providedOptionals;
 
@@ -1542,18 +1281,9 @@ class MyClass
     /**
      * @param string $_providedOptionals_1
      * @return self
-     * @param bool $validate
      */
-    public function withProvidedOptionals1(string $_providedOptionals_1, bool $validate = true): self
+    public function withProvidedOptionals1(string $_providedOptionals_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_providedOptionals_1, self::$_schema['properties']['__providedOptionals']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_providedOptionals_1 = $_providedOptionals_1;
 
@@ -1582,18 +1312,9 @@ class MyClass
     /**
      * @param string $_clone
      * @return self
-     * @param bool $validate
      */
-    public function withClone(string $_clone, bool $validate = true): self
+    public function withClone(string $_clone): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone, self::$_schema['properties']['clone']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->clone = $_clone;
 
@@ -1611,18 +1332,9 @@ class MyClass
     /**
      * @param string $_clone_1
      * @return self
-     * @param bool $validate
      */
-    public function with_Clone(string $_clone_1, bool $validate = true): self
+    public function with_Clone(string $_clone_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone_1, self::$_schema['properties']['__clone']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_clone = $_clone_1;
 
@@ -1640,18 +1352,9 @@ class MyClass
     /**
      * @param string $construct
      * @return self
-     * @param bool $validate
      */
-    public function withConstruct(string $construct, bool $validate = true): self
+    public function withConstruct(string $construct): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($construct, self::$_schema['properties']['__construct']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->construct = $construct;
 
@@ -1669,18 +1372,9 @@ class MyClass
     /**
      * @param string $destruct
      * @return self
-     * @param bool $validate
      */
-    public function withDestruct(string $destruct, bool $validate = true): self
+    public function withDestruct(string $destruct): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($destruct, self::$_schema['properties']['__destruct']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->destruct = $destruct;
 
@@ -1698,18 +1392,9 @@ class MyClass
     /**
      * @param string $get
      * @return self
-     * @param bool $validate
      */
-    public function with_Get(string $get, bool $validate = true): self
+    public function with_Get(string $get): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($get, self::$_schema['properties']['__get']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->get = $get;
 
@@ -1727,18 +1412,9 @@ class MyClass
     /**
      * @param string $set
      * @return self
-     * @param bool $validate
      */
-    public function withSet(string $set, bool $validate = true): self
+    public function withSet(string $set): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($set, self::$_schema['properties']['__set']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->set = $set;
 
@@ -1756,18 +1432,9 @@ class MyClass
     /**
      * @param string $call
      * @return self
-     * @param bool $validate
      */
-    public function withCall(string $call, bool $validate = true): self
+    public function withCall(string $call): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($call, self::$_schema['properties']['__call']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->call = $call;
 
@@ -1785,18 +1452,9 @@ class MyClass
     /**
      * @param string $isset
      * @return self
-     * @param bool $validate
      */
-    public function withIsset(string $isset, bool $validate = true): self
+    public function withIsset(string $isset): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($isset, self::$_schema['properties']['__isset']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->isset = $isset;
 
@@ -1814,18 +1472,9 @@ class MyClass
     /**
      * @param string $unset
      * @return self
-     * @param bool $validate
      */
-    public function withUnset(string $unset, bool $validate = true): self
+    public function withUnset(string $unset): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($unset, self::$_schema['properties']['__unset']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->unset = $unset;
 
@@ -1843,18 +1492,9 @@ class MyClass
     /**
      * @param string $sleep
      * @return self
-     * @param bool $validate
      */
-    public function withSleep(string $sleep, bool $validate = true): self
+    public function withSleep(string $sleep): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($sleep, self::$_schema['properties']['__sleep']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->sleep = $sleep;
 
@@ -1872,18 +1512,9 @@ class MyClass
     /**
      * @param string $wakeup
      * @return self
-     * @param bool $validate
      */
-    public function withWakeup(string $wakeup, bool $validate = true): self
+    public function withWakeup(string $wakeup): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($wakeup, self::$_schema['properties']['__wakeup']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->wakeup = $wakeup;
 
@@ -1901,18 +1532,9 @@ class MyClass
     /**
      * @param string $toString
      * @return self
-     * @param bool $validate
      */
-    public function withToString(string $toString, bool $validate = true): self
+    public function withToString(string $toString): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($toString, self::$_schema['properties']['__toString']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->toString = $toString;
 
@@ -1930,18 +1552,9 @@ class MyClass
     /**
      * @param string $invoke
      * @return self
-     * @param bool $validate
      */
-    public function withInvoke(string $invoke, bool $validate = true): self
+    public function withInvoke(string $invoke): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($invoke, self::$_schema['properties']['__invoke']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->invoke = $invoke;
 
@@ -1959,18 +1572,9 @@ class MyClass
     /**
      * @param string $debugInfo
      * @return self
-     * @param bool $validate
      */
-    public function withDebugInfo(string $debugInfo, bool $validate = true): self
+    public function withDebugInfo(string $debugInfo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($debugInfo, self::$_schema['properties']['__debugInfo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->debugInfo = $debugInfo;
 
@@ -1988,18 +1592,9 @@ class MyClass
     /**
      * @param string $files
      * @return self
-     * @param bool $validate
      */
-    public function with_Files(string $files, bool $validate = true): self
+    public function with_Files(string $files): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
 
@@ -2017,18 +1612,9 @@ class MyClass
     /**
      * @param string $_this
      * @return self
-     * @param bool $validate
      */
-    public function withThis(string $_this, bool $validate = true): self
+    public function withThis(string $_this): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_this, self::$_schema['properties']['this']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_this = $_this;
 
@@ -2046,9 +1632,18 @@ class MyClass
     /**
      * @param MyClassEnsureArgs1Alternative1|MyClassEnsureArgs1Alternative2|string $ensureArgs1
      * @return self
+     * @param bool $validate
      */
-    public function withEnsureArgs1(MyClassEnsureArgs1Alternative1|MyClassEnsureArgs1Alternative2|string $ensureArgs1): self
+    public function withEnsureArgs1(MyClassEnsureArgs1Alternative1|MyClassEnsureArgs1Alternative2|string $ensureArgs1, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($ensureArgs1, self::$_schema['properties']['ensureArgs1']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->ensureArgs1 = $ensureArgs1;
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs1Alternative2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs1Alternative2.php
@@ -69,18 +69,9 @@ class MyClassEnsureArgs1Alternative2
     /**
      * @param string $type
      * @return self
-     * @param bool $validate
      */
-    public function withType(string $type, bool $validate = true): self
+    public function withType(string $type): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($type, self::$_schema['properties']['type']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->type = $type;
 
@@ -98,18 +89,9 @@ class MyClassEnsureArgs1Alternative2
     /**
      * @param string $accountNumber
      * @return self
-     * @param bool $validate
      */
-    public function withAccountNumber(string $accountNumber, bool $validate = true): self
+    public function withAccountNumber(string $accountNumber): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($accountNumber, self::$_schema['properties']['accountNumber']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->accountNumber = $accountNumber;
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs2.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs2.php
@@ -99,18 +99,9 @@ class MyClassEnsureArgs2
     /**
      * @param string $street
      * @return self
-     * @param bool $validate
      */
-    public function withStreet(string $street, bool $validate = true): self
+    public function withStreet(string $street): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($street, self::$_schema['properties']['street']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->street = $street;
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassEnsureArgs3Item.php
@@ -47,18 +47,9 @@ class MyClassEnsureArgs3Item
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function withName(string $name, bool $validate = true): self
+    public function withName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->name = $name;
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClassTestObj.php
@@ -36,18 +36,9 @@ class MyClassTestObj
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-7.4/MyClass.php
@@ -51,18 +51,9 @@ class MyClass
     /**
      * @param string $bound
      * @return self
-     * @param bool $validate
      */
-    public function withBound(string $bound, bool $validate = true): self
+    public function withBound(string $bound): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bound, self::$_schema['properties']['bound']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bound = $bound;
 
@@ -91,18 +82,9 @@ class MyClass
     /**
      * @param string $outbound
      * @return self
-     * @param bool $validate
      */
-    public function with_Outbound(string $outbound, bool $validate = true): self
+    public function with_Outbound(string $outbound): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($outbound, self::$_schema['properties']['outbound']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->outbound = $outbound;
 
@@ -131,18 +113,9 @@ class MyClass
     /**
      * @param string $_outbound
      * @return self
-     * @param bool $validate
      */
-    public function with_Outbound_1(string $_outbound, bool $validate = true): self
+    public function with_Outbound_1(string $_outbound): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_outbound, self::$_schema['properties']['_outbound']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_outbound = $_outbound;
 

--- a/tests/Generator/Fixtures/FallbackNamingMethods/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingMethods/Output-8.4/MyClass.php
@@ -51,18 +51,9 @@ class MyClass
     /**
      * @param string $bound
      * @return self
-     * @param bool $validate
      */
-    public function withBound(string $bound, bool $validate = true): self
+    public function withBound(string $bound): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bound, self::$_schema['properties']['bound']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bound = $bound;
 
@@ -91,18 +82,9 @@ class MyClass
     /**
      * @param string $outbound
      * @return self
-     * @param bool $validate
      */
-    public function with_Outbound(string $outbound, bool $validate = true): self
+    public function with_Outbound(string $outbound): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($outbound, self::$_schema['properties']['outbound']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->outbound = $outbound;
 
@@ -131,18 +113,9 @@ class MyClass
     /**
      * @param string $_outbound
      * @return self
-     * @param bool $validate
      */
-    public function with_Outbound_1(string $_outbound, bool $validate = true): self
+    public function with_Outbound_1(string $_outbound): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_outbound, self::$_schema['properties']['_outbound']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_outbound = $_outbound;
 

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -2044,9 +2044,18 @@ class MyClass
     /**
      * @param MyClassEnsureArgs1Alternative1|MyClassEnsureArgs1Alternative2|string $ensureArgs1
      * @return self
+     * @param bool $validate
      */
-    public function withEnsureArgs1($ensureArgs1)
+    public function withEnsureArgs1($ensureArgs1, bool $validate = true)
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($ensureArgs1, self::$_schema['properties']['ensureArgs1']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->ensureArgs1 = $ensureArgs1;
 

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -646,18 +646,9 @@ class MyClass
     /**
      * @param string $_GLOBALS_1
      * @return self
-     * @param bool $validate
      */
-    public function with_GLOBALS(string $_GLOBALS_1, bool $validate = true): self
+    public function with_GLOBALS(string $_GLOBALS_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_1, self::$_schema['properties']['_GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_GLOBALS = $_GLOBALS_1;
 
@@ -675,18 +666,9 @@ class MyClass
     /**
      * @param string $_GLOBALS
      * @return self
-     * @param bool $validate
      */
-    public function withGLOBALS(string $_GLOBALS, bool $validate = true): self
+    public function withGLOBALS(string $_GLOBALS): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS, self::$_schema['properties']['GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->GLOBALS = $_GLOBALS;
 
@@ -704,18 +686,9 @@ class MyClass
     /**
      * @param string $GLOBALS_1
      * @return self
-     * @param bool $validate
      */
-    public function withGLOBALS1(string $GLOBALS_1, bool $validate = true): self
+    public function withGLOBALS1(string $GLOBALS_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($GLOBALS_1, self::$_schema['properties']['GLOBALS_1']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->GLOBALS_1 = $GLOBALS_1;
 
@@ -733,18 +706,9 @@ class MyClass
     /**
      * @param string $_SERVER_1
      * @return self
-     * @param bool $validate
      */
-    public function with_SERVER(string $_SERVER_1, bool $validate = true): self
+    public function with_SERVER(string $_SERVER_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_SERVER_1, self::$_schema['properties']['_SERVER']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_SERVER = $_SERVER_1;
 
@@ -762,18 +726,9 @@ class MyClass
     /**
      * @param string $_GET_1
      * @return self
-     * @param bool $validate
      */
-    public function with_GET(string $_GET_1, bool $validate = true): self
+    public function with_GET(string $_GET_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GET_1, self::$_schema['properties']['_GET']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_GET = $_GET_1;
 
@@ -791,18 +746,9 @@ class MyClass
     /**
      * @param string $_POST_1
      * @return self
-     * @param bool $validate
      */
-    public function with_POST(string $_POST_1, bool $validate = true): self
+    public function with_POST(string $_POST_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_POST_1, self::$_schema['properties']['_POST']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_POST = $_POST_1;
 
@@ -820,18 +766,9 @@ class MyClass
     /**
      * @param string $_FILES_1
      * @return self
-     * @param bool $validate
      */
-    public function with_FILES(string $_FILES_1, bool $validate = true): self
+    public function with_FILES(string $_FILES_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_FILES_1, self::$_schema['properties']['_FILES']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_FILES = $_FILES_1;
 
@@ -849,18 +786,9 @@ class MyClass
     /**
      * @param string $_REQUEST_1
      * @return self
-     * @param bool $validate
      */
-    public function with_REQUEST(string $_REQUEST_1, bool $validate = true): self
+    public function with_REQUEST(string $_REQUEST_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_REQUEST_1, self::$_schema['properties']['_REQUEST']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_REQUEST = $_REQUEST_1;
 
@@ -878,18 +806,9 @@ class MyClass
     /**
      * @param string $_SESSION_1
      * @return self
-     * @param bool $validate
      */
-    public function with_SESSION(string $_SESSION_1, bool $validate = true): self
+    public function with_SESSION(string $_SESSION_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_SESSION_1, self::$_schema['properties']['_SESSION']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_SESSION = $_SESSION_1;
 
@@ -907,18 +826,9 @@ class MyClass
     /**
      * @param string $_ENV_1
      * @return self
-     * @param bool $validate
      */
-    public function with_ENV(string $_ENV_1, bool $validate = true): self
+    public function with_ENV(string $_ENV_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_ENV_1, self::$_schema['properties']['_ENV']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_ENV = $_ENV_1;
 
@@ -936,18 +846,9 @@ class MyClass
     /**
      * @param string $_COOKIE_1
      * @return self
-     * @param bool $validate
      */
-    public function with_COOKIE(string $_COOKIE_1, bool $validate = true): self
+    public function with_COOKIE(string $_COOKIE_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_COOKIE_1, self::$_schema['properties']['_COOKIE']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_COOKIE = $_COOKIE_1;
 
@@ -965,18 +866,9 @@ class MyClass
     /**
      * @param string $_php_errormsg
      * @return self
-     * @param bool $validate
      */
-    public function withPhpErrormsg(string $_php_errormsg, bool $validate = true): self
+    public function withPhpErrormsg(string $_php_errormsg): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_php_errormsg, self::$_schema['properties']['php_errormsg']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->php_errormsg = $_php_errormsg;
 
@@ -994,18 +886,9 @@ class MyClass
     /**
      * @param string $_http_response_header
      * @return self
-     * @param bool $validate
      */
-    public function withHttpResponseHeader(string $_http_response_header, bool $validate = true): self
+    public function withHttpResponseHeader(string $_http_response_header): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_http_response_header, self::$_schema['properties']['http_response_header']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->http_response_header = $_http_response_header;
 
@@ -1023,18 +906,9 @@ class MyClass
     /**
      * @param string $_argc
      * @return self
-     * @param bool $validate
      */
-    public function withArgc(string $_argc, bool $validate = true): self
+    public function withArgc(string $_argc): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_argc, self::$_schema['properties']['argc']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->argc = $_argc;
 
@@ -1052,18 +926,9 @@ class MyClass
     /**
      * @param string $_argv
      * @return self
-     * @param bool $validate
      */
-    public function withArgv(string $_argv, bool $validate = true): self
+    public function withArgv(string $_argv): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_argv, self::$_schema['properties']['argv']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->argv = $_argv;
 
@@ -1081,18 +946,9 @@ class MyClass
     /**
      * @param string $_input
      * @return self
-     * @param bool $validate
      */
-    public function withInput(string $_input, bool $validate = true): self
+    public function withInput(string $_input): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_input, self::$_schema['properties']['input']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->input = $_input;
 
@@ -1110,18 +966,9 @@ class MyClass
     /**
      * @param string $_validate
      * @return self
-     * @param bool $validate
      */
-    public function withValidate(string $_validate, bool $validate = true): self
+    public function withValidate(string $_validate): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_validate, self::$_schema['properties']['validate']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->validate = $_validate;
 
@@ -1150,18 +997,9 @@ class MyClass
     /**
      * @param string|null $_materializeDefaults
      * @return self
-     * @param bool $validate
      */
-    public function withMaterializeDefaults(?string $_materializeDefaults, bool $validate = true): self
+    public function withMaterializeDefaults(?string $_materializeDefaults): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_materializeDefaults, self::$_schema['properties']['materializeDefaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->materializeDefaults = $_materializeDefaults;
         $clone->_providedOptionals['materializeDefaults'] = true;
@@ -1192,18 +1030,9 @@ class MyClass
     /**
      * @param string $_obj
      * @return self
-     * @param bool $validate
      */
-    public function withObj(string $_obj, bool $validate = true): self
+    public function withObj(string $_obj): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_obj, self::$_schema['properties']['obj']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->obj = $_obj;
 
@@ -1221,18 +1050,9 @@ class MyClass
     /**
      * @param string $_includeDefaults
      * @return self
-     * @param bool $validate
      */
-    public function withIncludeDefaults(string $_includeDefaults, bool $validate = true): self
+    public function withIncludeDefaults(string $_includeDefaults): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_includeDefaults, self::$_schema['properties']['includeDefaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->includeDefaults = $_includeDefaults;
 
@@ -1281,18 +1101,9 @@ class MyClass
     /**
      * @param string $fromInput
      * @return self
-     * @param bool $validate
      */
-    public function withFromInput(string $fromInput, bool $validate = true): self
+    public function withFromInput(string $fromInput): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($fromInput, self::$_schema['properties']['fromInput']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->fromInput = $fromInput;
 
@@ -1310,18 +1121,9 @@ class MyClass
     /**
      * @param string $toArray
      * @return self
-     * @param bool $validate
      */
-    public function withToArray(string $toArray, bool $validate = true): self
+    public function withToArray(string $toArray): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($toArray, self::$_schema['properties']['toArray']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->toArray = $toArray;
 
@@ -1339,18 +1141,9 @@ class MyClass
     /**
      * @param string $toStdClass
      * @return self
-     * @param bool $validate
      */
-    public function withToStdClass(string $toStdClass, bool $validate = true): self
+    public function withToStdClass(string $toStdClass): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($toStdClass, self::$_schema['properties']['toStdClass']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->toStdClass = $toStdClass;
 
@@ -1368,18 +1161,9 @@ class MyClass
     /**
      * @param string $validateInput
      * @return self
-     * @param bool $validate
      */
-    public function withValidateInput(string $validateInput, bool $validate = true): self
+    public function withValidateInput(string $validateInput): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($validateInput, self::$_schema['properties']['validateInput']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->validateInput = $validateInput;
 
@@ -1397,18 +1181,9 @@ class MyClass
     /**
      * @param string $_schema_1
      * @return self
-     * @param bool $validate
      */
-    public function with_Schema1(string $_schema_1, bool $validate = true): self
+    public function with_Schema1(string $_schema_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_1, self::$_schema['properties']['_schema']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_schema_1 = $_schema_1;
 
@@ -1426,18 +1201,9 @@ class MyClass
     /**
      * @param string $schema
      * @return self
-     * @param bool $validate
      */
-    public function withSchema(string $schema, bool $validate = true): self
+    public function withSchema(string $schema): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($schema, self::$_schema['properties']['schema']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->schema = $schema;
 
@@ -1455,18 +1221,9 @@ class MyClass
     /**
      * @param string $_defaults_1
      * @return self
-     * @param bool $validate
      */
-    public function with_Defaults1(string $_defaults_1, bool $validate = true): self
+    public function with_Defaults1(string $_defaults_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_1, self::$_schema['properties']['_defaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_defaults_1 = $_defaults_1;
 
@@ -1484,18 +1241,9 @@ class MyClass
     /**
      * @param string $defaults
      * @return self
-     * @param bool $validate
      */
-    public function withDefaults(string $defaults, bool $validate = true): self
+    public function withDefaults(string $defaults): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($defaults, self::$_schema['properties']['defaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->defaults = $defaults;
 
@@ -1513,18 +1261,9 @@ class MyClass
     /**
      * @param string $_providedOptionals_1
      * @return self
-     * @param bool $validate
      */
-    public function with_ProvidedOptionals1(string $_providedOptionals_1, bool $validate = true): self
+    public function with_ProvidedOptionals1(string $_providedOptionals_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_providedOptionals_1, self::$_schema['properties']['_providedOptionals']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_providedOptionals_1 = $_providedOptionals_1;
 
@@ -1542,18 +1281,9 @@ class MyClass
     /**
      * @param string $__providedOptionals_1
      * @return self
-     * @param bool $validate
      */
-    public function with__ProvidedOptionals(string $__providedOptionals_1, bool $validate = true): self
+    public function with__ProvidedOptionals(string $__providedOptionals_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__providedOptionals_1, self::$_schema['properties']['__providedOptionals']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__providedOptionals = $__providedOptionals_1;
 
@@ -1582,18 +1312,9 @@ class MyClass
     /**
      * @param string $_clone
      * @return self
-     * @param bool $validate
      */
-    public function withClone(string $_clone, bool $validate = true): self
+    public function withClone(string $_clone): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone, self::$_schema['properties']['clone']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->clone = $_clone;
 
@@ -1611,18 +1332,9 @@ class MyClass
     /**
      * @param string $__clone
      * @return self
-     * @param bool $validate
      */
-    public function with__Clone(string $__clone, bool $validate = true): self
+    public function with__Clone(string $__clone): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__clone, self::$_schema['properties']['__clone']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__clone = $__clone;
 
@@ -1640,18 +1352,9 @@ class MyClass
     /**
      * @param string $__construct
      * @return self
-     * @param bool $validate
      */
-    public function with__Construct(string $__construct, bool $validate = true): self
+    public function with__Construct(string $__construct): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__construct, self::$_schema['properties']['__construct']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__construct = $__construct;
 
@@ -1669,18 +1372,9 @@ class MyClass
     /**
      * @param string $__destruct
      * @return self
-     * @param bool $validate
      */
-    public function with__Destruct(string $__destruct, bool $validate = true): self
+    public function with__Destruct(string $__destruct): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__destruct, self::$_schema['properties']['__destruct']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__destruct = $__destruct;
 
@@ -1698,18 +1392,9 @@ class MyClass
     /**
      * @param string $__get
      * @return self
-     * @param bool $validate
      */
-    public function with__Get(string $__get, bool $validate = true): self
+    public function with__Get(string $__get): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__get, self::$_schema['properties']['__get']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__get = $__get;
 
@@ -1727,18 +1412,9 @@ class MyClass
     /**
      * @param string $__set
      * @return self
-     * @param bool $validate
      */
-    public function with__Set(string $__set, bool $validate = true): self
+    public function with__Set(string $__set): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__set, self::$_schema['properties']['__set']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__set = $__set;
 
@@ -1756,18 +1432,9 @@ class MyClass
     /**
      * @param string $__call
      * @return self
-     * @param bool $validate
      */
-    public function with__Call(string $__call, bool $validate = true): self
+    public function with__Call(string $__call): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__call, self::$_schema['properties']['__call']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__call = $__call;
 
@@ -1785,18 +1452,9 @@ class MyClass
     /**
      * @param string $__isset
      * @return self
-     * @param bool $validate
      */
-    public function with__Isset(string $__isset, bool $validate = true): self
+    public function with__Isset(string $__isset): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__isset, self::$_schema['properties']['__isset']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__isset = $__isset;
 
@@ -1814,18 +1472,9 @@ class MyClass
     /**
      * @param string $__unset
      * @return self
-     * @param bool $validate
      */
-    public function with__Unset(string $__unset, bool $validate = true): self
+    public function with__Unset(string $__unset): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__unset, self::$_schema['properties']['__unset']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__unset = $__unset;
 
@@ -1843,18 +1492,9 @@ class MyClass
     /**
      * @param string $__sleep
      * @return self
-     * @param bool $validate
      */
-    public function with__Sleep(string $__sleep, bool $validate = true): self
+    public function with__Sleep(string $__sleep): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__sleep, self::$_schema['properties']['__sleep']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__sleep = $__sleep;
 
@@ -1872,18 +1512,9 @@ class MyClass
     /**
      * @param string $__wakeup
      * @return self
-     * @param bool $validate
      */
-    public function with__Wakeup(string $__wakeup, bool $validate = true): self
+    public function with__Wakeup(string $__wakeup): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__wakeup, self::$_schema['properties']['__wakeup']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__wakeup = $__wakeup;
 
@@ -1901,18 +1532,9 @@ class MyClass
     /**
      * @param string $__toString
      * @return self
-     * @param bool $validate
      */
-    public function with__ToString(string $__toString, bool $validate = true): self
+    public function with__ToString(string $__toString): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__toString, self::$_schema['properties']['__toString']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__toString = $__toString;
 
@@ -1930,18 +1552,9 @@ class MyClass
     /**
      * @param string $__invoke
      * @return self
-     * @param bool $validate
      */
-    public function with__Invoke(string $__invoke, bool $validate = true): self
+    public function with__Invoke(string $__invoke): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__invoke, self::$_schema['properties']['__invoke']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__invoke = $__invoke;
 
@@ -1959,18 +1572,9 @@ class MyClass
     /**
      * @param string $__debugInfo
      * @return self
-     * @param bool $validate
      */
-    public function with__DebugInfo(string $__debugInfo, bool $validate = true): self
+    public function with__DebugInfo(string $__debugInfo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__debugInfo, self::$_schema['properties']['__debugInfo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__debugInfo = $__debugInfo;
 
@@ -1988,18 +1592,9 @@ class MyClass
     /**
      * @param string $files
      * @return self
-     * @param bool $validate
      */
-    public function withFiles(string $files, bool $validate = true): self
+    public function withFiles(string $files): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
 
@@ -2017,18 +1612,9 @@ class MyClass
     /**
      * @param string $_this
      * @return self
-     * @param bool $validate
      */
-    public function with_This(string $_this, bool $validate = true): self
+    public function with_This(string $_this): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_this, self::$_schema['properties']['this']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_this = $_this;
 
@@ -2046,9 +1632,18 @@ class MyClass
     /**
      * @param MyClassEnsureArgs1Alternative1|MyClassEnsureArgs1Alternative2|string $ensureArgs1
      * @return self
+     * @param bool $validate
      */
-    public function withEnsureArgs1($ensureArgs1): self
+    public function withEnsureArgs1($ensureArgs1, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($ensureArgs1, self::$_schema['properties']['ensureArgs1']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->ensureArgs1 = $ensureArgs1;
 

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassEnsureArgs1Alternative2.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassEnsureArgs1Alternative2.php
@@ -69,18 +69,9 @@ class MyClassEnsureArgs1Alternative2
     /**
      * @param string $type
      * @return self
-     * @param bool $validate
      */
-    public function withType(string $type, bool $validate = true): self
+    public function withType(string $type): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($type, self::$_schema['properties']['type']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->type = $type;
 
@@ -98,18 +89,9 @@ class MyClassEnsureArgs1Alternative2
     /**
      * @param string $accountNumber
      * @return self
-     * @param bool $validate
      */
-    public function withAccountNumber(string $accountNumber, bool $validate = true): self
+    public function withAccountNumber(string $accountNumber): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($accountNumber, self::$_schema['properties']['accountNumber']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->accountNumber = $accountNumber;
 

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassEnsureArgs2.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassEnsureArgs2.php
@@ -99,18 +99,9 @@ class MyClassEnsureArgs2
     /**
      * @param string $street
      * @return self
-     * @param bool $validate
      */
-    public function withStreet(string $street, bool $validate = true): self
+    public function withStreet(string $street): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($street, self::$_schema['properties']['street']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->street = $street;
 

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassEnsureArgs3Item.php
@@ -47,18 +47,9 @@ class MyClassEnsureArgs3Item
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function withName(string $name, bool $validate = true): self
+    public function withName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->name = $name;
 

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClassTestObj.php
@@ -36,18 +36,9 @@ class MyClassTestObj
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
@@ -646,18 +646,9 @@ class MyClass
     /**
      * @param string $_GLOBALS_1
      * @return self
-     * @param bool $validate
      */
-    public function with_GLOBALS(string $_GLOBALS_1, bool $validate = true): self
+    public function with_GLOBALS(string $_GLOBALS_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS_1, self::$_schema['properties']['_GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_GLOBALS = $_GLOBALS_1;
 
@@ -675,18 +666,9 @@ class MyClass
     /**
      * @param string $_GLOBALS
      * @return self
-     * @param bool $validate
      */
-    public function withGLOBALS(string $_GLOBALS, bool $validate = true): self
+    public function withGLOBALS(string $_GLOBALS): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GLOBALS, self::$_schema['properties']['GLOBALS']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->GLOBALS = $_GLOBALS;
 
@@ -704,18 +686,9 @@ class MyClass
     /**
      * @param string $GLOBALS_1
      * @return self
-     * @param bool $validate
      */
-    public function withGLOBALS1(string $GLOBALS_1, bool $validate = true): self
+    public function withGLOBALS1(string $GLOBALS_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($GLOBALS_1, self::$_schema['properties']['GLOBALS_1']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->GLOBALS_1 = $GLOBALS_1;
 
@@ -733,18 +706,9 @@ class MyClass
     /**
      * @param string $_SERVER_1
      * @return self
-     * @param bool $validate
      */
-    public function with_SERVER(string $_SERVER_1, bool $validate = true): self
+    public function with_SERVER(string $_SERVER_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_SERVER_1, self::$_schema['properties']['_SERVER']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_SERVER = $_SERVER_1;
 
@@ -762,18 +726,9 @@ class MyClass
     /**
      * @param string $_GET_1
      * @return self
-     * @param bool $validate
      */
-    public function with_GET(string $_GET_1, bool $validate = true): self
+    public function with_GET(string $_GET_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_GET_1, self::$_schema['properties']['_GET']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_GET = $_GET_1;
 
@@ -791,18 +746,9 @@ class MyClass
     /**
      * @param string $_POST_1
      * @return self
-     * @param bool $validate
      */
-    public function with_POST(string $_POST_1, bool $validate = true): self
+    public function with_POST(string $_POST_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_POST_1, self::$_schema['properties']['_POST']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_POST = $_POST_1;
 
@@ -820,18 +766,9 @@ class MyClass
     /**
      * @param string $_FILES_1
      * @return self
-     * @param bool $validate
      */
-    public function with_FILES(string $_FILES_1, bool $validate = true): self
+    public function with_FILES(string $_FILES_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_FILES_1, self::$_schema['properties']['_FILES']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_FILES = $_FILES_1;
 
@@ -849,18 +786,9 @@ class MyClass
     /**
      * @param string $_REQUEST_1
      * @return self
-     * @param bool $validate
      */
-    public function with_REQUEST(string $_REQUEST_1, bool $validate = true): self
+    public function with_REQUEST(string $_REQUEST_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_REQUEST_1, self::$_schema['properties']['_REQUEST']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_REQUEST = $_REQUEST_1;
 
@@ -878,18 +806,9 @@ class MyClass
     /**
      * @param string $_SESSION_1
      * @return self
-     * @param bool $validate
      */
-    public function with_SESSION(string $_SESSION_1, bool $validate = true): self
+    public function with_SESSION(string $_SESSION_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_SESSION_1, self::$_schema['properties']['_SESSION']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_SESSION = $_SESSION_1;
 
@@ -907,18 +826,9 @@ class MyClass
     /**
      * @param string $_ENV_1
      * @return self
-     * @param bool $validate
      */
-    public function with_ENV(string $_ENV_1, bool $validate = true): self
+    public function with_ENV(string $_ENV_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_ENV_1, self::$_schema['properties']['_ENV']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_ENV = $_ENV_1;
 
@@ -936,18 +846,9 @@ class MyClass
     /**
      * @param string $_COOKIE_1
      * @return self
-     * @param bool $validate
      */
-    public function with_COOKIE(string $_COOKIE_1, bool $validate = true): self
+    public function with_COOKIE(string $_COOKIE_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_COOKIE_1, self::$_schema['properties']['_COOKIE']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_COOKIE = $_COOKIE_1;
 
@@ -965,18 +866,9 @@ class MyClass
     /**
      * @param string $_php_errormsg
      * @return self
-     * @param bool $validate
      */
-    public function withPhpErrormsg(string $_php_errormsg, bool $validate = true): self
+    public function withPhpErrormsg(string $_php_errormsg): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_php_errormsg, self::$_schema['properties']['php_errormsg']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->php_errormsg = $_php_errormsg;
 
@@ -994,18 +886,9 @@ class MyClass
     /**
      * @param string $_http_response_header
      * @return self
-     * @param bool $validate
      */
-    public function withHttpResponseHeader(string $_http_response_header, bool $validate = true): self
+    public function withHttpResponseHeader(string $_http_response_header): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_http_response_header, self::$_schema['properties']['http_response_header']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->http_response_header = $_http_response_header;
 
@@ -1023,18 +906,9 @@ class MyClass
     /**
      * @param string $_argc
      * @return self
-     * @param bool $validate
      */
-    public function withArgc(string $_argc, bool $validate = true): self
+    public function withArgc(string $_argc): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_argc, self::$_schema['properties']['argc']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->argc = $_argc;
 
@@ -1052,18 +926,9 @@ class MyClass
     /**
      * @param string $_argv
      * @return self
-     * @param bool $validate
      */
-    public function withArgv(string $_argv, bool $validate = true): self
+    public function withArgv(string $_argv): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_argv, self::$_schema['properties']['argv']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->argv = $_argv;
 
@@ -1081,18 +946,9 @@ class MyClass
     /**
      * @param string $_input
      * @return self
-     * @param bool $validate
      */
-    public function withInput(string $_input, bool $validate = true): self
+    public function withInput(string $_input): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_input, self::$_schema['properties']['input']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->input = $_input;
 
@@ -1110,18 +966,9 @@ class MyClass
     /**
      * @param string $_validate
      * @return self
-     * @param bool $validate
      */
-    public function withValidate(string $_validate, bool $validate = true): self
+    public function withValidate(string $_validate): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_validate, self::$_schema['properties']['validate']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->validate = $_validate;
 
@@ -1150,18 +997,9 @@ class MyClass
     /**
      * @param string|null $_materializeDefaults
      * @return self
-     * @param bool $validate
      */
-    public function withMaterializeDefaults(?string $_materializeDefaults, bool $validate = true): self
+    public function withMaterializeDefaults(?string $_materializeDefaults): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_materializeDefaults, self::$_schema['properties']['materializeDefaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->materializeDefaults = $_materializeDefaults;
         $clone->_providedOptionals['materializeDefaults'] = true;
@@ -1192,18 +1030,9 @@ class MyClass
     /**
      * @param string $_obj
      * @return self
-     * @param bool $validate
      */
-    public function withObj(string $_obj, bool $validate = true): self
+    public function withObj(string $_obj): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_obj, self::$_schema['properties']['obj']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->obj = $_obj;
 
@@ -1221,18 +1050,9 @@ class MyClass
     /**
      * @param string $_includeDefaults
      * @return self
-     * @param bool $validate
      */
-    public function withIncludeDefaults(string $_includeDefaults, bool $validate = true): self
+    public function withIncludeDefaults(string $_includeDefaults): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_includeDefaults, self::$_schema['properties']['includeDefaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->includeDefaults = $_includeDefaults;
 
@@ -1281,18 +1101,9 @@ class MyClass
     /**
      * @param string $fromInput
      * @return self
-     * @param bool $validate
      */
-    public function withFromInput(string $fromInput, bool $validate = true): self
+    public function withFromInput(string $fromInput): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($fromInput, self::$_schema['properties']['fromInput']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->fromInput = $fromInput;
 
@@ -1310,18 +1121,9 @@ class MyClass
     /**
      * @param string $toArray
      * @return self
-     * @param bool $validate
      */
-    public function withToArray(string $toArray, bool $validate = true): self
+    public function withToArray(string $toArray): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($toArray, self::$_schema['properties']['toArray']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->toArray = $toArray;
 
@@ -1339,18 +1141,9 @@ class MyClass
     /**
      * @param string $toStdClass
      * @return self
-     * @param bool $validate
      */
-    public function withToStdClass(string $toStdClass, bool $validate = true): self
+    public function withToStdClass(string $toStdClass): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($toStdClass, self::$_schema['properties']['toStdClass']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->toStdClass = $toStdClass;
 
@@ -1368,18 +1161,9 @@ class MyClass
     /**
      * @param string $validateInput
      * @return self
-     * @param bool $validate
      */
-    public function withValidateInput(string $validateInput, bool $validate = true): self
+    public function withValidateInput(string $validateInput): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($validateInput, self::$_schema['properties']['validateInput']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->validateInput = $validateInput;
 
@@ -1397,18 +1181,9 @@ class MyClass
     /**
      * @param string $_schema_1
      * @return self
-     * @param bool $validate
      */
-    public function with_Schema1(string $_schema_1, bool $validate = true): self
+    public function with_Schema1(string $_schema_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_schema_1, self::$_schema['properties']['_schema']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_schema_1 = $_schema_1;
 
@@ -1426,18 +1201,9 @@ class MyClass
     /**
      * @param string $schema
      * @return self
-     * @param bool $validate
      */
-    public function withSchema(string $schema, bool $validate = true): self
+    public function withSchema(string $schema): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($schema, self::$_schema['properties']['schema']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->schema = $schema;
 
@@ -1455,18 +1221,9 @@ class MyClass
     /**
      * @param string $_defaults_1
      * @return self
-     * @param bool $validate
      */
-    public function with_Defaults1(string $_defaults_1, bool $validate = true): self
+    public function with_Defaults1(string $_defaults_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_defaults_1, self::$_schema['properties']['_defaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_defaults_1 = $_defaults_1;
 
@@ -1484,18 +1241,9 @@ class MyClass
     /**
      * @param string $defaults
      * @return self
-     * @param bool $validate
      */
-    public function withDefaults(string $defaults, bool $validate = true): self
+    public function withDefaults(string $defaults): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($defaults, self::$_schema['properties']['defaults']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->defaults = $defaults;
 
@@ -1513,18 +1261,9 @@ class MyClass
     /**
      * @param string $_providedOptionals_1
      * @return self
-     * @param bool $validate
      */
-    public function with_ProvidedOptionals1(string $_providedOptionals_1, bool $validate = true): self
+    public function with_ProvidedOptionals1(string $_providedOptionals_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_providedOptionals_1, self::$_schema['properties']['_providedOptionals']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_providedOptionals_1 = $_providedOptionals_1;
 
@@ -1542,18 +1281,9 @@ class MyClass
     /**
      * @param string $__providedOptionals_1
      * @return self
-     * @param bool $validate
      */
-    public function with__ProvidedOptionals(string $__providedOptionals_1, bool $validate = true): self
+    public function with__ProvidedOptionals(string $__providedOptionals_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__providedOptionals_1, self::$_schema['properties']['__providedOptionals']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__providedOptionals = $__providedOptionals_1;
 
@@ -1582,18 +1312,9 @@ class MyClass
     /**
      * @param string $_clone
      * @return self
-     * @param bool $validate
      */
-    public function withClone(string $_clone, bool $validate = true): self
+    public function withClone(string $_clone): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_clone, self::$_schema['properties']['clone']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->clone = $_clone;
 
@@ -1611,18 +1332,9 @@ class MyClass
     /**
      * @param string $__clone
      * @return self
-     * @param bool $validate
      */
-    public function with__Clone(string $__clone, bool $validate = true): self
+    public function with__Clone(string $__clone): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__clone, self::$_schema['properties']['__clone']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__clone = $__clone;
 
@@ -1640,18 +1352,9 @@ class MyClass
     /**
      * @param string $__construct
      * @return self
-     * @param bool $validate
      */
-    public function with__Construct(string $__construct, bool $validate = true): self
+    public function with__Construct(string $__construct): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__construct, self::$_schema['properties']['__construct']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__construct = $__construct;
 
@@ -1669,18 +1372,9 @@ class MyClass
     /**
      * @param string $__destruct
      * @return self
-     * @param bool $validate
      */
-    public function with__Destruct(string $__destruct, bool $validate = true): self
+    public function with__Destruct(string $__destruct): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__destruct, self::$_schema['properties']['__destruct']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__destruct = $__destruct;
 
@@ -1698,18 +1392,9 @@ class MyClass
     /**
      * @param string $__get
      * @return self
-     * @param bool $validate
      */
-    public function with__Get(string $__get, bool $validate = true): self
+    public function with__Get(string $__get): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__get, self::$_schema['properties']['__get']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__get = $__get;
 
@@ -1727,18 +1412,9 @@ class MyClass
     /**
      * @param string $__set
      * @return self
-     * @param bool $validate
      */
-    public function with__Set(string $__set, bool $validate = true): self
+    public function with__Set(string $__set): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__set, self::$_schema['properties']['__set']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__set = $__set;
 
@@ -1756,18 +1432,9 @@ class MyClass
     /**
      * @param string $__call
      * @return self
-     * @param bool $validate
      */
-    public function with__Call(string $__call, bool $validate = true): self
+    public function with__Call(string $__call): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__call, self::$_schema['properties']['__call']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__call = $__call;
 
@@ -1785,18 +1452,9 @@ class MyClass
     /**
      * @param string $__isset
      * @return self
-     * @param bool $validate
      */
-    public function with__Isset(string $__isset, bool $validate = true): self
+    public function with__Isset(string $__isset): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__isset, self::$_schema['properties']['__isset']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__isset = $__isset;
 
@@ -1814,18 +1472,9 @@ class MyClass
     /**
      * @param string $__unset
      * @return self
-     * @param bool $validate
      */
-    public function with__Unset(string $__unset, bool $validate = true): self
+    public function with__Unset(string $__unset): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__unset, self::$_schema['properties']['__unset']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__unset = $__unset;
 
@@ -1843,18 +1492,9 @@ class MyClass
     /**
      * @param string $__sleep
      * @return self
-     * @param bool $validate
      */
-    public function with__Sleep(string $__sleep, bool $validate = true): self
+    public function with__Sleep(string $__sleep): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__sleep, self::$_schema['properties']['__sleep']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__sleep = $__sleep;
 
@@ -1872,18 +1512,9 @@ class MyClass
     /**
      * @param string $__wakeup
      * @return self
-     * @param bool $validate
      */
-    public function with__Wakeup(string $__wakeup, bool $validate = true): self
+    public function with__Wakeup(string $__wakeup): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__wakeup, self::$_schema['properties']['__wakeup']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__wakeup = $__wakeup;
 
@@ -1901,18 +1532,9 @@ class MyClass
     /**
      * @param string $__toString
      * @return self
-     * @param bool $validate
      */
-    public function with__ToString(string $__toString, bool $validate = true): self
+    public function with__ToString(string $__toString): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__toString, self::$_schema['properties']['__toString']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__toString = $__toString;
 
@@ -1930,18 +1552,9 @@ class MyClass
     /**
      * @param string $__invoke
      * @return self
-     * @param bool $validate
      */
-    public function with__Invoke(string $__invoke, bool $validate = true): self
+    public function with__Invoke(string $__invoke): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__invoke, self::$_schema['properties']['__invoke']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__invoke = $__invoke;
 
@@ -1959,18 +1572,9 @@ class MyClass
     /**
      * @param string $__debugInfo
      * @return self
-     * @param bool $validate
      */
-    public function with__DebugInfo(string $__debugInfo, bool $validate = true): self
+    public function with__DebugInfo(string $__debugInfo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__debugInfo, self::$_schema['properties']['__debugInfo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__debugInfo = $__debugInfo;
 
@@ -1988,18 +1592,9 @@ class MyClass
     /**
      * @param string $files
      * @return self
-     * @param bool $validate
      */
-    public function withFiles(string $files, bool $validate = true): self
+    public function withFiles(string $files): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
 
@@ -2017,18 +1612,9 @@ class MyClass
     /**
      * @param string $_this
      * @return self
-     * @param bool $validate
      */
-    public function with_This(string $_this, bool $validate = true): self
+    public function with_This(string $_this): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_this, self::$_schema['properties']['this']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_this = $_this;
 
@@ -2046,9 +1632,18 @@ class MyClass
     /**
      * @param MyClassEnsureArgs1Alternative1|MyClassEnsureArgs1Alternative2|string $ensureArgs1
      * @return self
+     * @param bool $validate
      */
-    public function withEnsureArgs1(MyClassEnsureArgs1Alternative1|MyClassEnsureArgs1Alternative2|string $ensureArgs1): self
+    public function withEnsureArgs1(MyClassEnsureArgs1Alternative1|MyClassEnsureArgs1Alternative2|string $ensureArgs1, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($ensureArgs1, self::$_schema['properties']['ensureArgs1']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->ensureArgs1 = $ensureArgs1;
 

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassEnsureArgs1Alternative2.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassEnsureArgs1Alternative2.php
@@ -69,18 +69,9 @@ class MyClassEnsureArgs1Alternative2
     /**
      * @param string $type
      * @return self
-     * @param bool $validate
      */
-    public function withType(string $type, bool $validate = true): self
+    public function withType(string $type): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($type, self::$_schema['properties']['type']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->type = $type;
 
@@ -98,18 +89,9 @@ class MyClassEnsureArgs1Alternative2
     /**
      * @param string $accountNumber
      * @return self
-     * @param bool $validate
      */
-    public function withAccountNumber(string $accountNumber, bool $validate = true): self
+    public function withAccountNumber(string $accountNumber): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($accountNumber, self::$_schema['properties']['accountNumber']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->accountNumber = $accountNumber;
 

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassEnsureArgs2.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassEnsureArgs2.php
@@ -99,18 +99,9 @@ class MyClassEnsureArgs2
     /**
      * @param string $street
      * @return self
-     * @param bool $validate
      */
-    public function withStreet(string $street, bool $validate = true): self
+    public function withStreet(string $street): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($street, self::$_schema['properties']['street']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->street = $street;
 

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassEnsureArgs3Item.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassEnsureArgs3Item.php
@@ -47,18 +47,9 @@ class MyClassEnsureArgs3Item
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function withName(string $name, bool $validate = true): self
+    public function withName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->name = $name;
 

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassTestObj.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClassTestObj.php
@@ -36,18 +36,9 @@ class MyClassTestObj
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/JsonFile/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/JsonFile/Output-7.4/MyClass.php
@@ -51,18 +51,9 @@ class MyClass
     /**
      * @param int $id
      * @return self
-     * @param bool $validate
      */
-    public function withId(int $id, bool $validate = true): self
+    public function withId(int $id): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($id, self::$_schema['properties']['id']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->id = $id;
 

--- a/tests/Generator/Fixtures/JsonFile/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/JsonFile/Output-8.4/MyClass.php
@@ -51,18 +51,9 @@ class MyClass
     /**
      * @param int $id
      * @return self
-     * @param bool $validate
      */
-    public function withId(int $id, bool $validate = true): self
+    public function withId(int $id): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($id, self::$_schema['properties']['id']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->id = $id;
 

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -394,18 +394,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -423,18 +414,9 @@ class MyClass
     /**
      * @param string $bar
      * @return self
-     * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassBaz.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassBaz.php
@@ -93,18 +93,9 @@ class MyClassBaz
     /**
      * @param string $nestedFoo
      * @return self
-     * @param bool $validate
      */
-    public function withNestedFoo(string $nestedFoo, bool $validate = true): self
+    public function withNestedFoo(string $nestedFoo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($nestedFoo, self::$_schema['properties']['nestedFoo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->nestedFoo = $nestedFoo;
 

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassNumKeysDefaults.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassNumKeysDefaults.php
@@ -118,18 +118,9 @@ class MyClassNumKeysDefaults
     /**
      * @param string $_0
      * @return self
-     * @param bool $validate
      */
-    public function with_0(string $_0, bool $validate = true): self
+    public function with_0(string $_0): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_0, self::$_schema['properties']['0']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_0 = $_0;
 
@@ -158,18 +149,9 @@ class MyClassNumKeysDefaults
     /**
      * @param string $_1
      * @return self
-     * @param bool $validate
      */
-    public function with_1(string $_1, bool $validate = true): self
+    public function with_1(string $_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_1, self::$_schema['properties']['1']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_1 = $_1;
 
@@ -198,18 +180,9 @@ class MyClassNumKeysDefaults
     /**
      * @param string $_2
      * @return self
-     * @param bool $validate
      */
-    public function with_2(string $_2, bool $validate = true): self
+    public function with_2(string $_2): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_2, self::$_schema['properties']['2']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_2 = $_2;
 

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObj.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObj.php
@@ -86,18 +86,9 @@ class MyClassQuxObj
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObjNest.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObjNest.php
@@ -103,18 +103,9 @@ class MyClassQuxObjNest
     /**
      * @param array|object $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(array|object $a, bool $validate = true): self
+    public function withA(array|object $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/NumericKeysObj.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/NumericKeysObj.php
@@ -57,18 +57,9 @@ class NumericKeysObj
     /**
      * @param string $_0
      * @return self
-     * @param bool $validate
      */
-    public function with_0(string $_0, bool $validate = true): self
+    public function with_0(string $_0): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_0, self::$_schema['properties']['0']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_0 = $_0;
 
@@ -97,18 +88,9 @@ class NumericKeysObj
     /**
      * @param string $_1
      * @return self
-     * @param bool $validate
      */
-    public function with_1(string $_1, bool $validate = true): self
+    public function with_1(string $_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_1, self::$_schema['properties']['1']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_1 = $_1;
 
@@ -137,18 +119,9 @@ class NumericKeysObj
     /**
      * @param string $_2
      * @return self
-     * @param bool $validate
      */
-    public function with_2(string $_2, bool $validate = true): self
+    public function with_2(string $_2): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_2, self::$_schema['properties']['2']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_2 = $_2;
 

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/ObjDef.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/ObjDef.php
@@ -43,18 +43,9 @@ class ObjDef
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/MutableSetters/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-7.4/Baz.php
@@ -35,18 +35,9 @@ class Baz
 
     /**
      * @param string $name
-     * @param bool $validate
      */
-    public function setName(string $name, bool $validate = true): void
+    public function setName(string $name): void
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $this->name = $name;
     }
 

--- a/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
@@ -81,18 +81,9 @@ class MyClass
 
     /**
      * @param string $foo
-     * @param bool $validate
      */
-    public function setFoo(string $foo, bool $validate = true): void
+    public function setFoo(string $foo): void
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $this->foo = $foo;
     }
 
@@ -122,18 +113,9 @@ class MyClass
 
     /**
      * @param string|null $opt
-     * @param bool $validate
      */
-    public function setOpt(?string $opt, bool $validate = true): void
+    public function setOpt(?string $opt): void
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($opt, self::$_schema['properties']['opt']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $this->opt = $opt;
         $this->_providedOptionals['opt'] = true;
     }

--- a/tests/Generator/Fixtures/MutableSetters/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-8.4/Baz.php
@@ -35,18 +35,9 @@ class Baz
 
     /**
      * @param string $name
-     * @param bool $validate
      */
-    public function setName(string $name, bool $validate = true): void
+    public function setName(string $name): void
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $this->name = $name;
     }
 

--- a/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
@@ -81,18 +81,9 @@ class MyClass
 
     /**
      * @param string $foo
-     * @param bool $validate
      */
-    public function setFoo(string $foo, bool $validate = true): void
+    public function setFoo(string $foo): void
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $this->foo = $foo;
     }
 
@@ -122,18 +113,9 @@ class MyClass
 
     /**
      * @param string|null $opt
-     * @param bool $validate
      */
-    public function setOpt(?string $opt, bool $validate = true): void
+    public function setOpt(?string $opt): void
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($opt, self::$_schema['properties']['opt']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $this->opt = $opt;
         $this->_providedOptionals['opt'] = true;
     }

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/Baz.php
@@ -36,18 +36,9 @@ class Baz
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function setName(string $name, bool $validate = true): self
+    public function setName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $this->name = $name;
 
         return $this;

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
@@ -82,18 +82,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function setFoo(string $foo, bool $validate = true): self
+    public function setFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $this->foo = $foo;
 
         return $this;
@@ -129,18 +120,9 @@ class MyClass
     /**
      * @param string|null $opt
      * @return self
-     * @param bool $validate
      */
-    public function setOpt(?string $opt, bool $validate = true): self
+    public function setOpt(?string $opt): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($opt, self::$_schema['properties']['opt']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $this->opt = $opt;
         $this->_providedOptionals['opt'] = true;
 

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/Baz.php
@@ -36,18 +36,9 @@ class Baz
     /**
      * @param string $name
      * @return self
-     * @param bool $validate
      */
-    public function setName(string $name, bool $validate = true): self
+    public function setName(string $name): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($name, self::$_schema['properties']['name']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $this->name = $name;
 
         return $this;

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
@@ -82,18 +82,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function setFoo(string $foo, bool $validate = true): self
+    public function setFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $this->foo = $foo;
 
         return $this;
@@ -129,18 +120,9 @@ class MyClass
     /**
      * @param string|null $opt
      * @return self
-     * @param bool $validate
      */
-    public function setOpt(?string $opt, bool $validate = true): self
+    public function setOpt(?string $opt): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($opt, self::$_schema['properties']['opt']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $this->opt = $opt;
         $this->_providedOptionals['opt'] = true;
 

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
@@ -52,18 +52,9 @@ class MyClassFilesItem
     /**
      * @param string $_input
      * @return self
-     * @param bool $validate
      */
-    public function withInput(string $_input, bool $validate = true): self
+    public function withInput(string $_input): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_input, self::$_schema['properties']['input']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->input = $_input;
 

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/OptionsObject.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/OptionsObject.php
@@ -35,18 +35,9 @@ class OptionsObject
     /**
      * @param string $_output
      * @return self
-     * @param bool $validate
      */
-    public function withOutput(string $_output, bool $validate = true): self
+    public function withOutput(string $_output): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_output, self::$_schema['properties']['output']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->output = $_output;
 

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
@@ -52,18 +52,9 @@ class MyClassFilesItem
     /**
      * @param string $_input
      * @return self
-     * @param bool $validate
      */
-    public function withInput(string $_input, bool $validate = true): self
+    public function withInput(string $_input): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_input, self::$_schema['properties']['input']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->input = $_input;
 

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/OptionsObject.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/OptionsObject.php
@@ -35,18 +35,9 @@ class OptionsObject
     /**
      * @param string $_output
      * @return self
-     * @param bool $validate
      */
-    public function withOutput(string $_output, bool $validate = true): self
+    public function withOutput(string $_output): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_output, self::$_schema['properties']['output']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->output = $_output;
 

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Fio.php
@@ -46,18 +46,9 @@ class Fio
     /**
      * @param string|null $bar
      * @return self
-     * @param bool $validate
      */
-    public function withBar(?string $bar, bool $validate = true): self
+    public function withBar(?string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
         $clone->_providedOptionals['bar'] = true;

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Phone.php
@@ -36,18 +36,9 @@ class Phone
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Fio.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Fio.php
@@ -46,18 +46,9 @@ class Fio
     /**
      * @param string|null $bar
      * @return self
-     * @param bool $validate
      */
-    public function withBar(?string $bar, bool $validate = true): self
+    public function withBar(?string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
         $clone->_providedOptionals['bar'] = true;

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Phone.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Phone.php
@@ -36,18 +36,9 @@ class Phone
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/NoGetters/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoGetters/Output-7.4/MyClass.php
@@ -38,18 +38,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/NoGetters/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoGetters/Output-8.4/MyClass.php
@@ -38,18 +38,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/NoSchemaMetadata/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoSchemaMetadata/Output-7.4/MyClass.php
@@ -61,18 +61,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -94,18 +85,9 @@ class MyClass
      * @param int $bar
      * @return self
      * @deprecated
-     * @param bool $validate
      */
-    public function withBar(int $bar, bool $validate = true): self
+    public function withBar(int $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/NoSchemaMetadata/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NoSchemaMetadata/Output-8.4/MyClass.php
@@ -61,18 +61,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -94,18 +85,9 @@ class MyClass
      * @param int $bar
      * @return self
      * @deprecated
-     * @param bool $validate
      */
-    public function withBar(int $bar, bool $validate = true): self
+    public function withBar(int $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/NonAsciiProperty/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NonAsciiProperty/Output-7.4/MyClass.php
@@ -68,18 +68,9 @@ class MyClass
     /**
      * @param string $Gorod
      * @return self
-     * @param bool $validate
      */
-    public function withGorod(string $Gorod, bool $validate = true): self
+    public function withGorod(string $Gorod): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($Gorod, self::$_schema['properties']['Город']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->Gorod = $Gorod;
 
@@ -97,18 +88,9 @@ class MyClass
     /**
      * @param string $nazvanieIurLitsa
      * @return self
-     * @param bool $validate
      */
-    public function withNazvanieIurLitsa(string $nazvanieIurLitsa, bool $validate = true): self
+    public function withNazvanieIurLitsa(string $nazvanieIurLitsa): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($nazvanieIurLitsa, self::$_schema['properties']['название юр.лица']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->nazvanieIurLitsa = $nazvanieIurLitsa;
 
@@ -126,18 +108,9 @@ class MyClass
     /**
      * @param string $IPAdres
      * @return self
-     * @param bool $validate
      */
-    public function withIPAdres(string $IPAdres, bool $validate = true): self
+    public function withIPAdres(string $IPAdres): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($IPAdres, self::$_schema['properties']['IP-адрес']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->IPAdres = $IPAdres;
 

--- a/tests/Generator/Fixtures/NonAsciiProperty/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NonAsciiProperty/Output-8.4/MyClass.php
@@ -68,18 +68,9 @@ class MyClass
     /**
      * @param string $Gorod
      * @return self
-     * @param bool $validate
      */
-    public function withGorod(string $Gorod, bool $validate = true): self
+    public function withGorod(string $Gorod): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($Gorod, self::$_schema['properties']['Город']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->Gorod = $Gorod;
 
@@ -97,18 +88,9 @@ class MyClass
     /**
      * @param string $nazvanieIurLitsa
      * @return self
-     * @param bool $validate
      */
-    public function withNazvanieIurLitsa(string $nazvanieIurLitsa, bool $validate = true): self
+    public function withNazvanieIurLitsa(string $nazvanieIurLitsa): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($nazvanieIurLitsa, self::$_schema['properties']['название юр.лица']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->nazvanieIurLitsa = $nazvanieIurLitsa;
 
@@ -126,18 +108,9 @@ class MyClass
     /**
      * @param string $IPAdres
      * @return self
-     * @param bool $validate
      */
-    public function withIPAdres(string $IPAdres, bool $validate = true): self
+    public function withIPAdres(string $IPAdres): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($IPAdres, self::$_schema['properties']['IP-адрес']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->IPAdres = $IPAdres;
 

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
@@ -70,9 +70,18 @@ class Baz
     /**
      * @param Foo|Bar $grox
      * @return self
+     * @param bool $validate
      */
-    public function withGrox($grox)
+    public function withGrox($grox, bool $validate = true)
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($grox, self::$_schema['properties']['grox']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->grox = $grox;
 

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -83,9 +83,18 @@ class Qux
     /**
      * @param string|string[]|Foo|Bar $grox
      * @return self
+     * @param bool $validate
      */
-    public function withGrox($grox)
+    public function withGrox($grox, bool $validate = true)
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($grox, self::$_schema['properties']['grox']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->grox = $grox;
 

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -72,9 +72,18 @@ class Baz
     /**
      * @param Foo|Bar $grox
      * @return self
+     * @param bool $validate
      */
-    public function withGrox($grox): self
+    public function withGrox($grox, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($grox, self::$_schema['properties']['grox']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->grox = $grox;
 

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Foo.php
@@ -41,18 +41,9 @@ class Foo
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -85,9 +85,18 @@ class Qux
     /**
      * @param string|string[]|Foo|Bar $grox
      * @return self
+     * @param bool $validate
      */
-    public function withGrox($grox): self
+    public function withGrox($grox, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($grox, self::$_schema['properties']['grox']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->grox = $grox;
 

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Foo.php
@@ -41,18 +41,9 @@ class Foo
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass.php
@@ -55,18 +55,9 @@ class MyClass
     /**
      * @param string $_1
      * @return self
-     * @param bool $validate
      */
-    public function with_1(string $_1, bool $validate = true): self
+    public function with_1(string $_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_1, self::$_schema['properties']['1']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_1 = $_1;
 

--- a/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass_2.php
+++ b/tests/Generator/Fixtures/ObjectWithNumericKeys/Output-8.4/MyClass_2.php
@@ -52,18 +52,9 @@ class MyClass_2
     /**
      * @param string $_1
      * @return self
-     * @param bool $validate
      */
-    public function with_1(string $_1, bool $validate = true): self
+    public function with_1(string $_1): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_1, self::$_schema['properties']['1']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_1 = $_1;
 
@@ -92,18 +83,9 @@ class MyClass_2
     /**
      * @param string $_2
      * @return self
-     * @param bool $validate
      */
-    public function with_2(string $_2, bool $validate = true): self
+    public function with_2(string $_2): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_2, self::$_schema['properties']['2']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_2 = $_2;
 
@@ -132,18 +114,9 @@ class MyClass_2
     /**
      * @param string $_3
      * @return self
-     * @param bool $validate
      */
-    public function with_3(string $_3, bool $validate = true): self
+    public function with_3(string $_3): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_3, self::$_schema['properties']['3']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_3 = $_3;
 

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
@@ -54,18 +54,9 @@ class MyClass
     /**
      * @param array|object $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(array|object $foo, bool $validate = true): self
+    public function withFoo(array|object $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -94,18 +85,9 @@ class MyClass
     /**
      * @param array|object $bar
      * @return self
-     * @param bool $validate
      */
-    public function withBar(array|object $bar, bool $validate = true): self
+    public function withBar(array|object $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -58,9 +58,18 @@ class MyClass
     /**
      * @param string|array|object $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo($foo)
+    public function withFoo($foo, bool $validate = true)
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -78,9 +87,18 @@ class MyClass
     /**
      * @param string|array|object $bar
      * @return self
+     * @param bool $validate
      */
-    public function withBar($bar)
+    public function withBar($bar, bool $validate = true)
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($bar, self::$_schema['properties']['bar']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -60,9 +60,18 @@ class MyClass
     /**
      * @param string|array|object $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo($foo): self
+    public function withFoo($foo, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -80,9 +89,18 @@ class MyClass
     /**
      * @param string|array|object $bar
      * @return self
+     * @param bool $validate
      */
-    public function withBar($bar): self
+    public function withBar($bar, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($bar, self::$_schema['properties']['bar']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
@@ -228,18 +228,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -259,18 +250,9 @@ class MyClass
     /**
      * @param string $bar
      * @return self
-     * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 
@@ -301,18 +283,9 @@ class MyClass
     /**
      * @param string|null $baz
      * @return self
-     * @param bool $validate
      */
-    public function withBaz(?string $baz, bool $validate = true): self
+    public function withBaz(?string $baz): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($baz, self::$_schema['properties']['baz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->baz = $baz;
         $clone->_providedOptionals['baz'] = true;
@@ -345,18 +318,9 @@ class MyClass
     /**
      * @param string|null $qux
      * @return self
-     * @param bool $validate
      */
-    public function withQux(?string $qux, bool $validate = true): self
+    public function withQux(?string $qux): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($qux, self::$_schema['properties']['qux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->qux = $qux;
         $clone->_providedOptionals['qux'] = true;
@@ -389,18 +353,9 @@ class MyClass
     /**
      * @param string|null $quux
      * @return self
-     * @param bool $validate
      */
-    public function withQuux(?string $quux, bool $validate = true): self
+    public function withQuux(?string $quux): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($quux, self::$_schema['properties']['quux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->quux = $quux;
 
@@ -420,18 +375,9 @@ class MyClass
     /**
      * @param string $xyyz
      * @return self
-     * @param bool $validate
      */
-    public function withXyyz(string $xyyz, bool $validate = true): self
+    public function withXyyz(string $xyyz): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($xyyz, self::$_schema['properties']['xyyz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->xyyz = $xyyz;
 
@@ -462,18 +408,9 @@ class MyClass
     /**
      * @param string $thud
      * @return self
-     * @param bool $validate
      */
-    public function withThud(string $thud, bool $validate = true): self
+    public function withThud(string $thud): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($thud, self::$_schema['properties']['thud']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->thud = $thud;
 

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClassGooks.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClassGooks.php
@@ -51,18 +51,9 @@ class MyClassGooks
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 
@@ -91,18 +82,9 @@ class MyClassGooks
     /**
      * @param int|float $b
      * @return self
-     * @param bool $validate
      */
-    public function withB(int|float $b, bool $validate = true): self
+    public function withB(int|float $b): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($b, self::$_schema['properties']['b']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->b = $b;
 

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClassGrox.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClassGrox.php
@@ -52,18 +52,9 @@ class MyClassGrox
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 
@@ -92,18 +83,9 @@ class MyClassGrox
     /**
      * @param int|float $b
      * @return self
-     * @param bool $validate
      */
-    public function withB(int|float $b, bool $validate = true): self
+    public function withB(int|float $b): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($b, self::$_schema['properties']['b']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->b = $b;
 

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-7.4/MyClass.php
@@ -208,18 +208,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -237,18 +228,9 @@ class MyClass
     /**
      * @param string $_foo
      * @return self
-     * @param bool $validate
      */
-    public function with_Foo(string $_foo, bool $validate = true): self
+    public function with_Foo(string $_foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo, self::$_schema['properties']['_foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_foo = $_foo;
 
@@ -266,18 +248,9 @@ class MyClass
     /**
      * @param string $__foo
      * @return self
-     * @param bool $validate
      */
-    public function with__Foo(string $__foo, bool $validate = true): self
+    public function with__Foo(string $__foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__foo, self::$_schema['properties']['__foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__foo = $__foo;
 
@@ -295,18 +268,9 @@ class MyClass
     /**
      * @param string $foo_
      * @return self
-     * @param bool $validate
      */
-    public function withFoo_(string $foo_, bool $validate = true): self
+    public function withFoo_(string $foo_): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_, self::$_schema['properties']['foo_']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo_ = $foo_;
 
@@ -324,18 +288,9 @@ class MyClass
     /**
      * @param string $foo__
      * @return self
-     * @param bool $validate
      */
-    public function withFoo__(string $foo__, bool $validate = true): self
+    public function withFoo__(string $foo__): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo__, self::$_schema['properties']['foo__']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo__ = $foo__;
 
@@ -353,18 +308,9 @@ class MyClass
     /**
      * @param string $_foo_
      * @return self
-     * @param bool $validate
      */
-    public function with_Foo_(string $_foo_, bool $validate = true): self
+    public function with_Foo_(string $_foo_): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_, self::$_schema['properties']['_foo_']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_foo_ = $_foo_;
 
@@ -382,18 +328,9 @@ class MyClass
     /**
      * @param string $__foo__
      * @return self
-     * @param bool $validate
      */
-    public function with__Foo__(string $__foo__, bool $validate = true): self
+    public function with__Foo__(string $__foo__): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__foo__, self::$_schema['properties']['__foo__']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__foo__ = $__foo__;
 
@@ -411,18 +348,9 @@ class MyClass
     /**
      * @param string $_foo_bar
      * @return self
-     * @param bool $validate
      */
-    public function with_FooBar(string $_foo_bar, bool $validate = true): self
+    public function with_FooBar(string $_foo_bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_foo_bar = $_foo_bar;
 
@@ -440,18 +368,9 @@ class MyClass
     /**
      * @param string $foo_bar
      * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $foo_bar, bool $validate = true): self
+    public function withFooBar(string $foo_bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo_bar = $foo_bar;
 
@@ -469,18 +388,9 @@ class MyClass
     /**
      * @param string $baz_qux
      * @return self
-     * @param bool $validate
      */
-    public function withBazQux(string $baz_qux, bool $validate = true): self
+    public function withBazQux(string $baz_qux): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($baz_qux, self::$_schema['properties']['baz qux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->baz_qux = $baz_qux;
 
@@ -498,18 +408,9 @@ class MyClass
     /**
      * @param string $_123_qwe
      * @return self
-     * @param bool $validate
      */
-    public function with_123Qwe(string $_123_qwe, bool $validate = true): self
+    public function with_123Qwe(string $_123_qwe): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_123_qwe, self::$_schema['properties']['123 qwe']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_123_qwe = $_123_qwe;
 
@@ -527,18 +428,9 @@ class MyClass
     /**
      * @param string $Gorod
      * @return self
-     * @param bool $validate
      */
-    public function withGorod(string $Gorod, bool $validate = true): self
+    public function withGorod(string $Gorod): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($Gorod, self::$_schema['properties']['Город']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->Gorod = $Gorod;
 
@@ -556,18 +448,9 @@ class MyClass
     /**
      * @param string $nazvanie_iur_litsa
      * @return self
-     * @param bool $validate
      */
-    public function withNazvanieIurLitsa(string $nazvanie_iur_litsa, bool $validate = true): self
+    public function withNazvanieIurLitsa(string $nazvanie_iur_litsa): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($nazvanie_iur_litsa, self::$_schema['properties']['название юр.лица']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->nazvanie_iur_litsa = $nazvanie_iur_litsa;
 
@@ -585,18 +468,9 @@ class MyClass
     /**
      * @param string $IP_adres
      * @return self
-     * @param bool $validate
      */
-    public function withIPAdres(string $IP_adres, bool $validate = true): self
+    public function withIPAdres(string $IP_adres): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($IP_adres, self::$_schema['properties']['IP-адрес']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->IP_adres = $IP_adres;
 
@@ -614,18 +488,9 @@ class MyClass
     /**
      * @param string $_tildas
      * @return self
-     * @param bool $validate
      */
-    public function withTildas(string $_tildas, bool $validate = true): self
+    public function withTildas(string $_tildas): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_tildas, self::$_schema['properties']['~~tildas~~']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_tildas = $_tildas;
 
@@ -643,18 +508,9 @@ class MyClass
     /**
      * @param string $it_s_A
      * @return self
-     * @param bool $validate
      */
-    public function withItSA(string $it_s_A, bool $validate = true): self
+    public function withItSA(string $it_s_A): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($it_s_A, self::$_schema['properties']['it\'s "A"']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->it_s_A = $it_s_A;
 

--- a/tests/Generator/Fixtures/PreservePropertyNames/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PreservePropertyNames/Output-8.4/MyClass.php
@@ -208,18 +208,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -237,18 +228,9 @@ class MyClass
     /**
      * @param string $_foo
      * @return self
-     * @param bool $validate
      */
-    public function with_Foo(string $_foo, bool $validate = true): self
+    public function with_Foo(string $_foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo, self::$_schema['properties']['_foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_foo = $_foo;
 
@@ -266,18 +248,9 @@ class MyClass
     /**
      * @param string $__foo
      * @return self
-     * @param bool $validate
      */
-    public function with__Foo(string $__foo, bool $validate = true): self
+    public function with__Foo(string $__foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__foo, self::$_schema['properties']['__foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__foo = $__foo;
 
@@ -295,18 +268,9 @@ class MyClass
     /**
      * @param string $foo_
      * @return self
-     * @param bool $validate
      */
-    public function withFoo_(string $foo_, bool $validate = true): self
+    public function withFoo_(string $foo_): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_, self::$_schema['properties']['foo_']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo_ = $foo_;
 
@@ -324,18 +288,9 @@ class MyClass
     /**
      * @param string $foo__
      * @return self
-     * @param bool $validate
      */
-    public function withFoo__(string $foo__, bool $validate = true): self
+    public function withFoo__(string $foo__): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo__, self::$_schema['properties']['foo__']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo__ = $foo__;
 
@@ -353,18 +308,9 @@ class MyClass
     /**
      * @param string $_foo_
      * @return self
-     * @param bool $validate
      */
-    public function with_Foo_(string $_foo_, bool $validate = true): self
+    public function with_Foo_(string $_foo_): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_, self::$_schema['properties']['_foo_']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_foo_ = $_foo_;
 
@@ -382,18 +328,9 @@ class MyClass
     /**
      * @param string $__foo__
      * @return self
-     * @param bool $validate
      */
-    public function with__Foo__(string $__foo__, bool $validate = true): self
+    public function with__Foo__(string $__foo__): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($__foo__, self::$_schema['properties']['__foo__']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->__foo__ = $__foo__;
 
@@ -411,18 +348,9 @@ class MyClass
     /**
      * @param string $_foo_bar
      * @return self
-     * @param bool $validate
      */
-    public function with_FooBar(string $_foo_bar, bool $validate = true): self
+    public function with_FooBar(string $_foo_bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_foo_bar, self::$_schema['properties']['foo-bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_foo_bar = $_foo_bar;
 
@@ -440,18 +368,9 @@ class MyClass
     /**
      * @param string $foo_bar
      * @return self
-     * @param bool $validate
      */
-    public function withFooBar(string $foo_bar, bool $validate = true): self
+    public function withFooBar(string $foo_bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo_bar, self::$_schema['properties']['foo bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo_bar = $foo_bar;
 
@@ -469,18 +388,9 @@ class MyClass
     /**
      * @param string $baz_qux
      * @return self
-     * @param bool $validate
      */
-    public function withBazQux(string $baz_qux, bool $validate = true): self
+    public function withBazQux(string $baz_qux): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($baz_qux, self::$_schema['properties']['baz qux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->baz_qux = $baz_qux;
 
@@ -498,18 +408,9 @@ class MyClass
     /**
      * @param string $_123_qwe
      * @return self
-     * @param bool $validate
      */
-    public function with_123Qwe(string $_123_qwe, bool $validate = true): self
+    public function with_123Qwe(string $_123_qwe): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_123_qwe, self::$_schema['properties']['123 qwe']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_123_qwe = $_123_qwe;
 
@@ -527,18 +428,9 @@ class MyClass
     /**
      * @param string $Gorod
      * @return self
-     * @param bool $validate
      */
-    public function withGorod(string $Gorod, bool $validate = true): self
+    public function withGorod(string $Gorod): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($Gorod, self::$_schema['properties']['Город']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->Gorod = $Gorod;
 
@@ -556,18 +448,9 @@ class MyClass
     /**
      * @param string $nazvanie_iur_litsa
      * @return self
-     * @param bool $validate
      */
-    public function withNazvanieIurLitsa(string $nazvanie_iur_litsa, bool $validate = true): self
+    public function withNazvanieIurLitsa(string $nazvanie_iur_litsa): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($nazvanie_iur_litsa, self::$_schema['properties']['название юр.лица']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->nazvanie_iur_litsa = $nazvanie_iur_litsa;
 
@@ -585,18 +468,9 @@ class MyClass
     /**
      * @param string $IP_adres
      * @return self
-     * @param bool $validate
      */
-    public function withIPAdres(string $IP_adres, bool $validate = true): self
+    public function withIPAdres(string $IP_adres): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($IP_adres, self::$_schema['properties']['IP-адрес']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->IP_adres = $IP_adres;
 
@@ -614,18 +488,9 @@ class MyClass
     /**
      * @param string $_tildas
      * @return self
-     * @param bool $validate
      */
-    public function withTildas(string $_tildas, bool $validate = true): self
+    public function withTildas(string $_tildas): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($_tildas, self::$_schema['properties']['~~tildas~~']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->_tildas = $_tildas;
 
@@ -643,18 +508,9 @@ class MyClass
     /**
      * @param string $it_s_A
      * @return self
-     * @param bool $validate
      */
-    public function withItSA(string $it_s_A, bool $validate = true): self
+    public function withItSA(string $it_s_A): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($it_s_A, self::$_schema['properties']['it\'s "A"']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->it_s_A = $it_s_A;
 

--- a/tests/Generator/Fixtures/PropTypeIsSingleTypeArray/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsSingleTypeArray/Output-8.4/MyClass.php
@@ -387,18 +387,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -416,18 +407,9 @@ class MyClass
     /**
      * @param int|float $bar
      * @return self
-     * @param bool $validate
      */
-    public function withBar(int|float $bar, bool $validate = true): self
+    public function withBar(int|float $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 
@@ -445,18 +427,9 @@ class MyClass
     /**
      * @param int $baz
      * @return self
-     * @param bool $validate
      */
-    public function withBaz(int $baz, bool $validate = true): self
+    public function withBaz(int $baz): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($baz, self::$_schema['properties']['baz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->baz = $baz;
 
@@ -474,18 +447,9 @@ class MyClass
     /**
      * @param bool $qux
      * @return self
-     * @param bool $validate
      */
-    public function withQux(bool $qux, bool $validate = true): self
+    public function withQux(bool $qux): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($qux, self::$_schema['properties']['qux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->qux = $qux;
 
@@ -581,18 +545,9 @@ class MyClass
     /**
      * @param string|null $nullFoo
      * @return self
-     * @param bool $validate
      */
-    public function withNullFoo(?string $nullFoo, bool $validate = true): self
+    public function withNullFoo(?string $nullFoo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($nullFoo, self::$_schema['properties']['nullFoo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->nullFoo = $nullFoo;
 
@@ -610,18 +565,9 @@ class MyClass
     /**
      * @param int|float|null $nullBar
      * @return self
-     * @param bool $validate
      */
-    public function withNullBar(int|float|null $nullBar, bool $validate = true): self
+    public function withNullBar(int|float|null $nullBar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($nullBar, self::$_schema['properties']['nullBar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->nullBar = $nullBar;
 
@@ -639,18 +585,9 @@ class MyClass
     /**
      * @param int|null $nullBaz
      * @return self
-     * @param bool $validate
      */
-    public function withNullBaz(?int $nullBaz, bool $validate = true): self
+    public function withNullBaz(?int $nullBaz): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($nullBaz, self::$_schema['properties']['nullBaz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->nullBaz = $nullBaz;
 
@@ -668,18 +605,9 @@ class MyClass
     /**
      * @param bool|null $nullQux
      * @return self
-     * @param bool $validate
      */
-    public function withNullQux(?bool $nullQux, bool $validate = true): self
+    public function withNullQux(?bool $nullQux): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($nullQux, self::$_schema['properties']['nullQux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->nullQux = $nullQux;
 
@@ -746,18 +674,9 @@ class MyClass
     /**
      * @param string $optFoo
      * @return self
-     * @param bool $validate
      */
-    public function withOptFoo(string $optFoo, bool $validate = true): self
+    public function withOptFoo(string $optFoo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($optFoo, self::$_schema['properties']['optFoo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->optFoo = $optFoo;
 
@@ -786,18 +705,9 @@ class MyClass
     /**
      * @param int|float $optBar
      * @return self
-     * @param bool $validate
      */
-    public function withOptBar(int|float $optBar, bool $validate = true): self
+    public function withOptBar(int|float $optBar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($optBar, self::$_schema['properties']['optBar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->optBar = $optBar;
 
@@ -826,18 +736,9 @@ class MyClass
     /**
      * @param int $optBaz
      * @return self
-     * @param bool $validate
      */
-    public function withOptBaz(int $optBaz, bool $validate = true): self
+    public function withOptBaz(int $optBaz): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($optBaz, self::$_schema['properties']['optBaz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->optBaz = $optBaz;
 
@@ -866,18 +767,9 @@ class MyClass
     /**
      * @param bool $optQux
      * @return self
-     * @param bool $validate
      */
-    public function withOptQux(bool $optQux, bool $validate = true): self
+    public function withOptQux(bool $optQux): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($optQux, self::$_schema['properties']['optQux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->optQux = $optQux;
 
@@ -1019,18 +911,9 @@ class MyClass
     /**
      * @param string|null $optNullFoo
      * @return self
-     * @param bool $validate
      */
-    public function withOptNullFoo(?string $optNullFoo, bool $validate = true): self
+    public function withOptNullFoo(?string $optNullFoo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($optNullFoo, self::$_schema['properties']['optNullFoo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->optNullFoo = $optNullFoo;
         $clone->_providedOptionals['optNullFoo'] = true;
@@ -1061,18 +944,9 @@ class MyClass
     /**
      * @param int|float|null $optNullBar
      * @return self
-     * @param bool $validate
      */
-    public function withOptNullBar(int|float|null $optNullBar, bool $validate = true): self
+    public function withOptNullBar(int|float|null $optNullBar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($optNullBar, self::$_schema['properties']['optNullBar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->optNullBar = $optNullBar;
         $clone->_providedOptionals['optNullBar'] = true;
@@ -1103,18 +977,9 @@ class MyClass
     /**
      * @param int|null $optNullBaz
      * @return self
-     * @param bool $validate
      */
-    public function withOptNullBaz(?int $optNullBaz, bool $validate = true): self
+    public function withOptNullBaz(?int $optNullBaz): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($optNullBaz, self::$_schema['properties']['optNullBaz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->optNullBaz = $optNullBaz;
         $clone->_providedOptionals['optNullBaz'] = true;
@@ -1145,18 +1010,9 @@ class MyClass
     /**
      * @param bool|null $optNullQux
      * @return self
-     * @param bool $validate
      */
-    public function withOptNullQux(?bool $optNullQux, bool $validate = true): self
+    public function withOptNullQux(?bool $optNullQux): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($optNullQux, self::$_schema['properties']['optNullQux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->optNullQux = $optNullQux;
         $clone->_providedOptionals['optNullQux'] = true;

--- a/tests/Generator/Fixtures/PropTypeIsSingleTypeArray/Output-8.4/MyClassNullQuux.php
+++ b/tests/Generator/Fixtures/PropTypeIsSingleTypeArray/Output-8.4/MyClassNullQuux.php
@@ -36,18 +36,9 @@ class MyClassNullQuux
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/PropTypeIsSingleTypeArray/Output-8.4/MyClassOptNullQuux.php
+++ b/tests/Generator/Fixtures/PropTypeIsSingleTypeArray/Output-8.4/MyClassOptNullQuux.php
@@ -36,18 +36,9 @@ class MyClassOptNullQuux
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/PropTypeIsSingleTypeArray/Output-8.4/MyClassOptQuux.php
+++ b/tests/Generator/Fixtures/PropTypeIsSingleTypeArray/Output-8.4/MyClassOptQuux.php
@@ -36,18 +36,9 @@ class MyClassOptQuux
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/PropTypeIsSingleTypeArray/Output-8.4/MyClassQuux.php
+++ b/tests/Generator/Fixtures/PropTypeIsSingleTypeArray/Output-8.4/MyClassQuux.php
@@ -36,18 +36,9 @@ class MyClassQuux
     /**
      * @param string $a
      * @return self
-     * @param bool $validate
      */
-    public function withA(string $a, bool $validate = true): self
+    public function withA(string $a): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($a, self::$_schema['properties']['a']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->a = $a;
 

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-5.6/MyClass.php
@@ -55,9 +55,18 @@ class MyClass
     /**
      * @param string|MyClassFooAlternative2 $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo($foo)
+    public function withFoo($foo, bool $validate = true)
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClass.php
@@ -57,9 +57,18 @@ class MyClass
     /**
      * @param string|MyClassFooAlternative2 $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo($foo): self
+    public function withFoo($foo, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClassFooAlternative2.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClassFooAlternative2.php
@@ -47,18 +47,9 @@ class MyClassFooAlternative2
     /**
      * @param string $bar
      * @return self
-     * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-8.4/MyClass.php
@@ -57,9 +57,18 @@ class MyClass
     /**
      * @param string|MyClassFooAlternative2 $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo(MyClassFooAlternative2|string $foo): self
+    public function withFoo(MyClassFooAlternative2|string $foo, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-8.4/MyClassFooAlternative2.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-8.4/MyClassFooAlternative2.php
@@ -47,18 +47,9 @@ class MyClassFooAlternative2
     /**
      * @param string $bar
      * @return self
-     * @param bool $validate
      */
-    public function withBar(string $bar, bool $validate = true): self
+    public function withBar(string $bar): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
 

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Cat.php
@@ -70,18 +70,9 @@ class Cat
     /**
      * @param bool|null $hasFur
      * @return self
-     * @param bool $validate
      */
-    public function withHasFur(?bool $hasFur, bool $validate = true): self
+    public function withHasFur(?bool $hasFur): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($hasFur, self::$_schema['properties']['hasFur']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->hasFur = $hasFur;
         $clone->_providedOptionals['hasFur'] = true;

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/GenericPet.php
@@ -68,18 +68,9 @@ class GenericPet
     /**
      * @param bool|null $hasFur
      * @return self
-     * @param bool $validate
      */
-    public function withHasFur(?bool $hasFur, bool $validate = true): self
+    public function withHasFur(?bool $hasFur): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($hasFur, self::$_schema['properties']['hasFur']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->hasFur = $hasFur;
         $clone->_providedOptionals['hasFur'] = true;

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
@@ -72,9 +72,18 @@ class MyObject
     /**
      * @param 'foo'|'bar'|'baz'|'quz' $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo($foo)
+    public function withFoo($foo, bool $validate = true)
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
@@ -74,9 +74,18 @@ class MyObject
     /**
      * @param 'foo'|'bar'|'baz'|'quz' $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo($foo): self
+    public function withFoo($foo, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/SingleLineSchema/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/SingleLineSchema/Output-7.4/MyClass.php
@@ -37,18 +37,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/SingleLineSchema/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/SingleLineSchema/Output-8.4/MyClass.php
@@ -37,18 +37,9 @@ class MyClass
     /**
      * @param string $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(string $foo, bool $validate = true): self
+    public function withFoo(string $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/SuperglobalCollision/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/SuperglobalCollision/Output-7.4/MyClass.php
@@ -46,18 +46,9 @@ class MyClass
     /**
      * @param string $files
      * @return self
-     * @param bool $validate
      */
-    public function withFiles(string $files, bool $validate = true): self
+    public function withFiles(string $files): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
 

--- a/tests/Generator/Fixtures/SuperglobalCollision/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/SuperglobalCollision/Output-8.4/MyClass.php
@@ -46,18 +46,9 @@ class MyClass
     /**
      * @param string $files
      * @return self
-     * @param bool $validate
      */
-    public function withFiles(string $files, bool $validate = true): self
+    public function withFiles(string $files): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
 

--- a/tests/Generator/Fixtures/TempTest/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TempTest/Output-8.4/MyClass.php
@@ -46,18 +46,9 @@ class MyClass
     /**
      * @param string $schema
      * @return self
-     * @param bool $validate
      */
-    public function withSchema(string $schema, bool $validate = true): self
+    public function withSchema(string $schema): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($schema, self::$_schema['properties']['schema']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->schema = $schema;
 

--- a/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
@@ -37,9 +37,18 @@ class MyClass
     /**
      * @param string|int|float $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo($foo)
+    public function withFoo($foo, bool $validate = true)
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
@@ -39,9 +39,18 @@ class MyClass
     /**
      * @param string|int|float $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo($foo): self
+    public function withFoo($foo, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
@@ -61,18 +61,9 @@ class MyClass
     /**
      * @param array|object $foo
      * @return self
-     * @param bool $validate
      */
-    public function withFoo(array|object $foo, bool $validate = true): self
+    public function withFoo(array|object $foo): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
 
@@ -101,18 +92,9 @@ class MyClass
     /**
      * @param array|object $encoded
      * @return self
-     * @param bool $validate
      */
-    public function withEncoded(array|object $encoded, bool $validate = true): self
+    public function withEncoded(array|object $encoded): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($encoded, self::$_schema['properties']['encoded']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->encoded = $encoded;
 

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
@@ -53,9 +53,18 @@ class MyClass
     /**
      * @param string $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo($foo)
+    public function withFoo($foo, bool $validate = true)
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -55,9 +55,18 @@ class MyClass
     /**
      * @param string $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo($foo): self
+    public function withFoo($foo, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -55,9 +55,18 @@ class MyClass
     /**
      * @param string $foo
      * @return self
+     * @param bool $validate
      */
-    public function withFoo(string $foo): self
+    public function withFoo(string $foo, bool $validate = true): self
     {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($foo, self::$_schema['properties']['foo']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
         $clone = clone $this;
         $clone->foo = $foo;
 


### PR DESCRIPTION
## Summary
- add `PropertyQuery::hasConstraints` to detect schema restrictions beyond simple type
- emit setter validation only if type hints can't cover schema constraints
- refresh generated fixtures and examples

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: 3 errors: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_6891131ad548832dbac7934b330395d7