### PR TITLE
Propagate includeDefaults flag to nested references

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,8 @@ you can resolve such references as desired by implementing the `ReferenceLookup`
 and registering your lookup on a `GeneratorRequest`.
 
 ```php
-use Helmich\Schema2Class\Generator\ReferencedType\ReferencedType;
+use Helmich\Schema2Class\Generator\GeneratorRequest;
+use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeInterface;
 use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeClass;
 use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeUnknown;
 use Helmich\Schema2Class\Generator\ReferenceLookup\DefinitionsReferenceLookup;
@@ -342,23 +343,24 @@ class MyReferenceLookup implements ReferenceLookup
 {
     public function __construct(private DefinitionsReferenceLookup $defaultLookup) {}
 
-    // Must return instance of a class implementing `ReferencedType` interface,
+    // Must return instance of a class implementing `ReferencedTypeInterface`,
     // including the `ReferencedTypeUnknown` when reference cannot be resolved
-    public function lookupReference(string $ref): ReferencedType
+    public function lookupReference(string $ref, GeneratorRequest $currentRequest): ReferencedTypeInterface
     {
         if ($ref === "#/properties/address") {
-            return new ReferencedTypeClass(CustomerAddress::class); // Point '#/properties/address' ref to existing class
+            // Point '#/properties/address' ref to existing class
+            return new ReferencedTypeClass(CustomerAddress::class, $currentRequest);
         }
 
         // resolve other refs by built-in Schema2Class lookup mechanism
-        $result = $this->defaultLookup->lookupReference($ref);
+        $result = $this->defaultLookup->lookupReference($ref, $currentRequest);
         if ($result instanceof ReferencedTypeUnknown) {
-            return new ReferencedTypeUnknown();
+            return new ReferencedTypeUnknown($currentRequest);
         }
         return $result;
     }
 
-    // Must returns the schema array referenced by the given `$ref` pointer,
+    // Must return the schema array referenced by the given `$ref` pointer,
     // or empty array if no schema available
     public function lookupSchema(string $ref): array
     {

--- a/src/Generator/GeneratorRequest.php
+++ b/src/Generator/GeneratorRequest.php
@@ -10,7 +10,7 @@ use Helmich\Schema2Class\Generator\Hook\AddPropertyHook;
 use Helmich\Schema2Class\Generator\Hook\GeneratorHookRunner;
 use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeInterface;
 use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeUnknown;
-use Helmich\Schema2Class\Generator\ReferenceLookup\ReferenceLookup;
+use Helmich\Schema2Class\Generator\ReferenceLookup\ReferenceLookupInterface;
 use Helmich\Schema2Class\Spec\SpecificationOptions;
 use Helmich\Schema2Class\Spec\OptionsDefaults;
 use Helmich\Schema2Class\Spec\ValidatedSpecificationFilesItem;
@@ -49,7 +49,7 @@ class GeneratorRequest
     private ValidatedSpecificationFilesItem $spec;
     private SpecificationOptions $opts;
 
-    /** @var array<class-string, ReferenceLookup> */
+    /** @var array<class-string, ReferenceLookupInterface> */
     private array $referenceLookup = [];
     
     /**
@@ -138,7 +138,7 @@ class GeneratorRequest
         };
     }
 
-    public function withReferenceLookup(ReferenceLookup $referenceLookup): self
+    public function withReferenceLookup(ReferenceLookupInterface $referenceLookup): self
     {
         $clone                  = clone $this;
         $clone->referenceLookup = [];
@@ -147,7 +147,7 @@ class GeneratorRequest
         return $clone;
     }
 
-    public function withAdditionalReferenceLookup(ReferenceLookup $referenceLookup): self
+    public function withAdditionalReferenceLookup(ReferenceLookupInterface $referenceLookup): self
     {
         $clone                  = clone $this;
         $clone->referenceLookup[$referenceLookup::class] = $referenceLookup;

--- a/src/Generator/GeneratorRequest.php
+++ b/src/Generator/GeneratorRequest.php
@@ -336,7 +336,7 @@ class GeneratorRequest
         }
 
         foreach ($this->referenceLookup as $lookup) {
-            $reference = $lookup->lookupReference($ref);
+            $reference = $lookup->lookupReference($ref, $this);
             if (!$reference instanceof ReferencedTypeUnknown) {
                 return $reference;
             }

--- a/src/Generator/ReferenceLookup/DefinitionsReferenceLookup.php
+++ b/src/Generator/ReferenceLookup/DefinitionsReferenceLookup.php
@@ -25,7 +25,6 @@ class DefinitionsReferenceLookup implements ReferenceLookup
      */
     public function __construct(
         private array $definitions,
-        private GeneratorRequest $request,
     ) {}
 
     private function canonicalize(string $ref): string
@@ -51,21 +50,21 @@ class DefinitionsReferenceLookup implements ReferenceLookup
         return $ref;
     }
 
-    public function lookupReference(string $ref): ReferencedTypeInterface
+    public function lookupReference(string $ref, GeneratorRequest $currentRequest): ReferencedTypeInterface
     {
         $ref = $this->canonicalize($ref);
 
         if (!isset($this->definitions[$ref])) {
-            return new ReferencedTypeUnknown($this->request);
+            return new ReferencedTypeUnknown($currentRequest);
         }
 
         $def = $this->definitions[$ref];
 
         if (isset($def->schema['enum'])) {
-            return new ReferencedTypeEnum($def->classFQN, $def->schema, $this->request);
+            return new ReferencedTypeEnum($def->classFQN, $def->schema, $currentRequest);
         }
 
-        return new ReferencedTypeClass($def->classFQN, $this->request);
+        return new ReferencedTypeClass($def->classFQN, $currentRequest);
     }
 
     public function lookupSchema(string $ref): array

--- a/src/Generator/ReferenceLookup/DefinitionsReferenceLookup.php
+++ b/src/Generator/ReferenceLookup/DefinitionsReferenceLookup.php
@@ -18,7 +18,7 @@ use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeEnum;
  * returns {@see ReferencedType} objects describing the target class or enum so that
  * property builders can correctly embed object and enum definitions while building nested classes.
  */
-class DefinitionsReferenceLookup implements ReferenceLookup
+class DefinitionsReferenceLookup implements ReferenceLookupInterface
 {
     /**
      * @param array<string,Definition> $definitions

--- a/src/Generator/ReferenceLookup/ReferenceLookup.php
+++ b/src/Generator/ReferenceLookup/ReferenceLookup.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Helmich\Schema2Class\Generator\ReferenceLookup;
 
+use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeInterface;
 
 /**
@@ -19,9 +20,12 @@ interface ReferenceLookup
     /**
      * Returns information about the PHP type referenced by the given `$ref` pointer.
      *
-     * When the reference cannot be resolved a {@link ReferencedTypeUnknown} instance should be returned.
+     * The current {@see GeneratorRequest} is provided so implementations can
+     * respect options such as the target namespace or PHP version. When the
+     * reference cannot be resolved a {@link ReferencedTypeUnknown} instance
+     * should be returned.
      */
-    public function lookupReference(string $ref): ReferencedTypeInterface;
+    public function lookupReference(string $ref, GeneratorRequest $currentRequest): ReferencedTypeInterface;
     
     /**
      * Returns the schema array referenced by the given `$ref` pointer.

--- a/src/Generator/ReferenceLookup/ReferenceLookupInterface.php
+++ b/src/Generator/ReferenceLookup/ReferenceLookupInterface.php
@@ -15,7 +15,7 @@ use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeInterface;
  * To customize resolution behavior, user can implement this interface
  * and register the instance on a {@link GeneratorRequest}.
  */
-interface ReferenceLookup
+interface ReferenceLookupInterface
 {
     /**
      * Returns information about the PHP type referenced by the given `$ref` pointer.

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -203,7 +203,7 @@ class SchemaToClass
         }
 
         $req = $req
-            ->withAdditionalReferenceLookup(new DefinitionsReferenceLookup($allDefinitions, $req))
+            ->withAdditionalReferenceLookup(new DefinitionsReferenceLookup($allDefinitions))
             ->withGeneratedClassNames($generatedClasses);
 
         $definitionsToGenerate = $allDefinitions;

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -860,24 +860,24 @@ class MyClass
         $xyyz = isset($input->{'xyyz'}) ? match (true) {
             is_string($input->{'xyyz'}),
             is_array($input->{'xyyz'}) => $input->{'xyyz'},
-            ObjDef::validateInput($input->{'xyyz'}, true) => ObjDef::fromInput($input->{'xyyz'}, $validate),
+            ObjDef::validateInput($input->{'xyyz'}, true) => ObjDef::fromInput($input->{'xyyz'}, $validate, $materializeDefaults),
             default => null,
         } : null;
         $buux = isset($input->{'buux'}) ? match (true) {
             is_string($input->{'buux'}),
             is_array($input->{'buux'}) => $input->{'buux'},
-            ObjDef::validateInput($input->{'buux'}, true) => ObjDef::fromInput($input->{'buux'}, $validate),
+            ObjDef::validateInput($input->{'buux'}, true) => ObjDef::fromInput($input->{'buux'}, $validate, $materializeDefaults),
             default => null,
         } : null;
         $boic = isset($input->{'boic'}) ? match (true) {
             is_string($input->{'boic'}),
             is_array($input->{'boic'}) => $input->{'boic'},
-            ObjDef::validateInput($input->{'boic'}, true) => ObjDef::fromInput($input->{'boic'}, $validate),
+            ObjDef::validateInput($input->{'boic'}, true) => ObjDef::fromInput($input->{'boic'}, $validate, $materializeDefaults),
             default => null,
         } : null;
         $poox = isset($input->{'poox'}) ? match (true) {
             is_string($input->{'poox'}) => $input->{'poox'},
-            NumericKeysObj::validateInput($input->{'poox'}, true) => NumericKeysObj::fromInput($input->{'poox'}, $validate),
+            NumericKeysObj::validateInput($input->{'poox'}, true) => NumericKeysObj::fromInput($input->{'poox'}, $validate, $materializeDefaults),
             default => null,
         } : null;
         $arrObjUnion = isset($input->{'arrObjUnion'}) ? match (true) {
@@ -935,27 +935,27 @@ class MyClass
             $output['xyyz'] = match (true) {
                 is_string($this->xyyz),
                 is_array($this->xyyz) => $this->xyyz,
-                ($this->xyyz) instanceof ObjDef => $this->xyyz->toArray(),
+                ($this->xyyz) instanceof ObjDef => $this->xyyz->toArray($includeDefaults),
             };
         }
         if (isset($this->buux)) {
             $output['buux'] = match (true) {
                 is_string($this->buux),
                 is_array($this->buux) => $this->buux,
-                ($this->buux) instanceof ObjDef => $this->buux->toArray(),
+                ($this->buux) instanceof ObjDef => $this->buux->toArray($includeDefaults),
             };
         }
         if (isset($this->boic)) {
             $output['boic'] = match (true) {
                 is_string($this->boic),
                 is_array($this->boic) => $this->boic,
-                ($this->boic) instanceof ObjDef => $this->boic->toArray(),
+                ($this->boic) instanceof ObjDef => $this->boic->toArray($includeDefaults),
             };
         }
         if (isset($this->poox)) {
             $output['poox'] = match (true) {
                 is_string($this->poox) => $this->poox,
-                ($this->poox) instanceof NumericKeysObj => $this->poox->toArray(),
+                ($this->poox) instanceof NumericKeysObj => $this->poox->toArray($includeDefaults),
             };
         }
         if (isset($this->arrObjUnion)) {
@@ -1012,27 +1012,27 @@ class MyClass
             $output->{'xyyz'} = match (true) {
                 is_string($this->xyyz),
                 is_array($this->xyyz) => $this->xyyz,
-                ($this->xyyz) instanceof ObjDef => $this->xyyz->toStdClass(),
+                ($this->xyyz) instanceof ObjDef => $this->xyyz->toStdClass($includeDefaults),
             };
         }
         if (isset($this->buux)) {
             $output->{'buux'} = match (true) {
                 is_string($this->buux),
                 is_array($this->buux) => $this->buux,
-                ($this->buux) instanceof ObjDef => $this->buux->toStdClass(),
+                ($this->buux) instanceof ObjDef => $this->buux->toStdClass($includeDefaults),
             };
         }
         if (isset($this->boic)) {
             $output->{'boic'} = match (true) {
                 is_string($this->boic),
                 is_array($this->boic) => $this->boic,
-                ($this->boic) instanceof ObjDef => $this->boic->toStdClass(),
+                ($this->boic) instanceof ObjDef => $this->boic->toStdClass($includeDefaults),
             };
         }
         if (isset($this->poox)) {
             $output->{'poox'} = match (true) {
                 is_string($this->poox) => $this->poox,
-                ($this->poox) instanceof NumericKeysObj => $this->poox->toStdClass(),
+                ($this->poox) instanceof NumericKeysObj => $this->poox->toStdClass($includeDefaults),
             };
         }
         if (isset($this->arrObjUnion)) {

--- a/tests/Generator/Fixtures/ReferenceArrayProperty/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ReferenceArrayProperty/Output-5.6/MyClass.php
@@ -132,7 +132,7 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'}) ? array_map(
-            fn($i) => FooItem::fromInput($i, $validate),
+            fn($i) => FooItem::fromInput($i, $validate, $materializeDefaults),
             $input->{'foo'}
         ) : null;
 
@@ -151,7 +151,7 @@ class MyClass
     {
         $output = [];
         if (isset($this->foo)) {
-            $output['foo'] = array_map(fn(FooItem $i): array => $i->toArray(), $this->foo);
+            $output['foo'] = array_map(fn(FooItem $i): array => $i->toArray($includeDefaults), $this->foo);
         }
 
         if ($includeDefaults) {
@@ -175,7 +175,7 @@ class MyClass
     {
         $output = new \stdClass();
         if (isset($this->foo)) {
-            $output->{'foo'} = array_map(fn(FooItem $i): object => $i->toStdClass(), $this->foo);
+            $output->{'foo'} = array_map(fn(FooItem $i): object => $i->toStdClass($includeDefaults), $this->foo);
         }
 
         if ($includeDefaults) {

--- a/tests/Generator/Fixtures/ReferenceArrayProperty/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ReferenceArrayProperty/Output-8.4/MyClass.php
@@ -128,7 +128,7 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'}) ? array_map(
-            fn(array|object $i): FooItem => FooItem::fromInput($i, $validate),
+            fn(array|object $i): FooItem => FooItem::fromInput($i, $validate, $materializeDefaults),
             $input->{'foo'}
         ) : null;
 
@@ -147,7 +147,7 @@ class MyClass
     {
         $output = [];
         if (isset($this->foo)) {
-            $output['foo'] = array_map(fn(FooItem $i): array => $i->toArray(), $this->foo);
+            $output['foo'] = array_map(fn(FooItem $i): array => $i->toArray($includeDefaults), $this->foo);
         }
 
         if ($includeDefaults) {
@@ -171,7 +171,7 @@ class MyClass
     {
         $output = new \stdClass();
         if (isset($this->foo)) {
-            $output->{'foo'} = array_map(fn(FooItem $i): object => $i->toStdClass(), $this->foo);
+            $output->{'foo'} = array_map(fn(FooItem $i): object => $i->toStdClass($includeDefaults), $this->foo);
         }
 
         if ($includeDefaults) {

--- a/tests/Generator/Property/UnionPropertyTest.php
+++ b/tests/Generator/Property/UnionPropertyTest.php
@@ -112,7 +112,7 @@ EOCODE;
             '#/definitions/bar' => new Definition('Ns', '', 'Ns\\Bar', 'Bar', ['type' => 'string']),
         ];
 
-        $lookup = new DefinitionsReferenceLookup($defs, $this->generatorRequest);
+        $lookup = new DefinitionsReferenceLookup($defs);
         $req    = $this->generatorRequest->withReferenceLookup($lookup);
 
         $prop = new UnionProperty('myPropertyName', [

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -270,24 +270,21 @@ class SchemaToClassTest extends TestCase
         );
 
         $definitions = $schema['definitions'] ?? [];
-        $definitionsLookup = new DefinitionsReferenceLookup($definitions, $req);
+        $definitionsLookup = new DefinitionsReferenceLookup($definitions);
 
         $req = $req->withReferenceLookup(
-            new class ($definitionsLookup, $req) implements ReferenceLookup {
-                public function __construct(
-                    private DefinitionsReferenceLookup $lookup,
-                    private GeneratorRequest $request,
-                ) {}
+            new class ($definitionsLookup) implements ReferenceLookup {
+                public function __construct(private DefinitionsReferenceLookup $lookup) {}
 
-                public function lookupReference(string $ref): ReferencedTypeInterface
+                public function lookupReference(string $ref, GeneratorRequest $currentRequest): ReferencedTypeInterface
                 {
                     if ($ref === "#/properties/address") {
-                        return new ReferencedTypeClass(CustomerAddress::class, $this->request);
+                        return new ReferencedTypeClass(CustomerAddress::class, $currentRequest);
                     }
 
-                    $result = $this->lookup->lookupReference($ref);
+                    $result = $this->lookup->lookupReference($ref, $currentRequest);
                     if ($result instanceof ReferencedTypeUnknown) {
-                        return new ReferencedTypeUnknown($this->request);
+                        return new ReferencedTypeUnknown($currentRequest);
                     }
                     return $result;
                 }

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -12,7 +12,7 @@ use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeInterface;
 use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeClass;
 use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeUnknown;
 use Helmich\Schema2Class\Generator\ReferenceLookup\DefinitionsReferenceLookup;
-use Helmich\Schema2Class\Generator\ReferenceLookup\ReferenceLookup;
+use Helmich\Schema2Class\Generator\ReferenceLookup\ReferenceLookupInterface;
 use Helmich\Schema2Class\Generator\SchemaToClassFactory;
 use Helmich\Schema2Class\Loader\SchemaLoader;
 use Helmich\Schema2Class\Spec\SpecificationOptions;
@@ -273,7 +273,7 @@ class SchemaToClassTest extends TestCase
         $definitionsLookup = new DefinitionsReferenceLookup($definitions);
 
         $req = $req->withReferenceLookup(
-            new class ($definitionsLookup) implements ReferenceLookup {
+            new class ($definitionsLookup) implements ReferenceLookupInterface {
                 public function __construct(private DefinitionsReferenceLookup $lookup) {}
 
                 public function lookupReference(string $ref, GeneratorRequest $currentRequest): ReferencedTypeInterface


### PR DESCRIPTION
## Summary
- pass current request to reference lookups so nested classes know about defaults
- regenerate snapshots and fixtures to forward `includeDefaults` in generated code

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(3 known match.unhandled errors)*


------
https://chatgpt.com/codex/tasks/task_e_6892177fb2b0832d8173697f60e9b8a5