### PR TITLE
Flatten single-option unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Now it:
 - Improves camelCase/PascalCase handling when generating identifier names.
 - Omits the default `null` value for properties listed in the `required` schema block.
 - Improves type hints and PHPDoc type generation for complex types like unions, nested arrays, etc.
+- Flattens `anyOf`/`oneOf` schemas with a single alternative before property generation to avoid unnecessary union types.
 - Adds a guard against passing anything other than an array/object to `fromInput`, building multi-line validation error messages.
 - Setter methods (`withX()`) now accept an optional `$validate` argument to be able skip validation, mirroring `fromInput()`.
 - Deterministic resolution of class property, accessor method and temporary variable names via a unified resolver, allowing case-sensitive properties and avoiding collisions with reserved names.

--- a/src/Generator/Property/PropertyBuilder.php
+++ b/src/Generator/Property/PropertyBuilder.php
@@ -83,6 +83,7 @@ class PropertyBuilder
 
         $definition = self::sanitizeEnum($definition);
         $definition = self::collapseSingleTypeArray($definition);
+        $definition = self::collapseSingleUnion($definition);
 
         if ($property = self::tryInlineReference($req, $name, $definition, $isRequired)) {
             return $property;
@@ -122,6 +123,32 @@ class PropertyBuilder
         $defType = $definition['type'] ?? null;
         if (is_array($defType) && count($defType) === 1) {
             $definition['type'] = $defType[0];
+        }
+
+        return $definition;
+    }
+
+    /** Collapse single-arm anyOf/oneOf schemas */
+    private static function collapseSingleUnion(array $definition): array
+    {
+        foreach (['anyOf', 'oneOf'] as $k) {
+            if (isset($definition[$k]) && is_array($definition[$k])) {
+                if (count($definition[$k]) === 1) {
+                    $single = $definition[$k][0];
+                    foreach (['description', 'title', 'default', 'deprecated'] as $meta) {
+                        if (isset($definition[$meta]) && !isset($single[$meta])) {
+                            $single[$meta] = $definition[$meta];
+                        }
+                    }
+
+                    return self::collapseSingleUnion($single);
+                }
+
+                $definition[$k] = array_map(
+                    fn ($sub) => self::collapseSingleUnion($sub),
+                    $definition[$k]
+                );
+            }
         }
 
         return $definition;

--- a/src/Generator/Property/Type/UnionProperty.php
+++ b/src/Generator/Property/Type/UnionProperty.php
@@ -267,10 +267,6 @@ class UnionProperty extends AbstractProperty
         $types = [];
 
         foreach ($this->subProperties as $prop) {
-            if ($this->propName() === 'UnionOfOneNull') {
-                echo "\n---\$prop::class:\n";  print_r($prop::class);  echo "\n---";
-            }
-
             $ann = $prop->typeAnnotation();
             foreach (explode('|', $ann) as $t) {
                 $types[$t] = true;
@@ -303,6 +299,12 @@ class UnionProperty extends AbstractProperty
                 foreach (explode('|', $hint) as $part) {
                     $subTypeHints[$part] = true;
                 }
+            }
+
+            if (isset($subTypeHints['null']) && count($subTypeHints) === 2) {
+                unset($subTypeHints['null']);
+                $t = array_keys($subTypeHints)[0];
+                return '?' . $t;
             }
 
             return join('|', array_keys($subTypeHints));

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -59,12 +59,12 @@ class BarTest
     /**
      * @var FooTest|MoiKlass|FooTest_1|null
      */
-    private $exampleProp = null;
+    private ?object $exampleProp = null;
 
     /**
      * @param FooTest|MoiKlass|FooTest_1|null $exampleProp
      */
-    public function __construct($exampleProp = null)
+    public function __construct(?object $exampleProp = null)
     {
         $this->exampleProp = $exampleProp;
     }
@@ -72,7 +72,7 @@ class BarTest
     /**
      * @return FooTest|MoiKlass|FooTest_1|null
      */
-    public function getExampleProp()
+    public function getExampleProp(): ?object
     {
         return $this->exampleProp;
     }
@@ -80,7 +80,7 @@ class BarTest
     /**
      * @param FooTest|MoiKlass|FooTest_1 $exampleProp
      */
-    public function withExampleProp($exampleProp, bool $validate = true): self
+    public function withExampleProp(object $exampleProp, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -59,12 +59,12 @@ class Baz
     /**
      * @var Foo|Bar|null
      */
-    private $grox = null;
+    private ?object $grox = null;
 
     /**
      * @param Foo|Bar|null $grox
      */
-    public function __construct($grox = null)
+    public function __construct(?object $grox = null)
     {
         $this->grox = $grox;
     }
@@ -72,7 +72,7 @@ class Baz
     /**
      * @return Foo|Bar|null
      */
-    public function getGrox()
+    public function getGrox(): ?object
     {
         return $this->grox;
     }
@@ -80,7 +80,7 @@ class Baz
     /**
      * @param Foo|Bar $grox
      */
-    public function withGrox($grox, bool $validate = true): self
+    public function withGrox(object $grox, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -100,9 +100,9 @@ class MyClass
 
     private string $baz;
 
-    private string|null $qux;
+    private ?string $qux;
 
-    public function __construct(string $foo, string $bar, string $baz, string|null $qux)
+    public function __construct(string $foo, string $bar, string $baz, ?string $qux)
     {
         $this->foo = $foo;
         $this->bar = $bar;
@@ -173,12 +173,12 @@ class MyClass
         return $clone;
     }
 
-    public function getQux(): string|null
+    public function getQux(): ?string
     {
         return $this->qux;
     }
 
-    public function withQux(string|null $qux, bool $validate = true): self
+    public function withQux(?string $qux, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
@@ -143,10 +143,7 @@ class MyClass
      */
     private $objAndStringUnion = null;
 
-    /**
-     * @var MyClassUnionOfOneObjAlternative1|null
-     */
-    private ?object $unionOfOneObj = null;
+    private ?MyClassUnionOfOneObj $unionOfOneObj = null;
 
     /**
      * @var null
@@ -158,10 +155,9 @@ class MyClass
      * @param SomeObj1|SomeObj2|null $refObjectsUnion
      * @param SomeObj1|MyClassRefAndNotRefObjectsUnionAlternative2|SomeObj2|MyClassRefAndNotRefObjectsUnionAlternative4|null $refAndNotRefObjectsUnion
      * @param MyClassObjAndStringUnionAlternative1|string|null $objAndStringUnion
-     * @param MyClassUnionOfOneObjAlternative1|null $unionOfOneObj
      * @param null $unionOfOneNull
      */
-    public function __construct(?object $objectsUnion = null, ?object $refObjectsUnion = null, ?object $refAndNotRefObjectsUnion = null, $objAndStringUnion = null, ?object $unionOfOneObj = null, $unionOfOneNull = null)
+    public function __construct(?object $objectsUnion = null, ?object $refObjectsUnion = null, ?object $refAndNotRefObjectsUnion = null, $objAndStringUnion = null, ?MyClassUnionOfOneObj $unionOfOneObj = null, $unionOfOneNull = null)
     {
         $this->objectsUnion = $objectsUnion;
         $this->refObjectsUnion = $refObjectsUnion;
@@ -311,27 +307,13 @@ class MyClass
         return $clone;
     }
 
-    /**
-     * @return MyClassUnionOfOneObjAlternative1|null
-     */
-    public function getUnionOfOneObj(): ?object
+    public function getUnionOfOneObj(): ?MyClassUnionOfOneObj
     {
         return $this->unionOfOneObj;
     }
 
-    /**
-     * @param MyClassUnionOfOneObjAlternative1 $unionOfOneObj
-     */
-    public function withUnionOfOneObj(object $unionOfOneObj, bool $validate = true): self
+    public function withUnionOfOneObj(MyClassUnionOfOneObj $unionOfOneObj): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($unionOfOneObj, self::$_schema['properties']['unionOfOneObj']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->unionOfOneObj = $unionOfOneObj;
 
@@ -409,10 +391,10 @@ class MyClass
         $refObjectsUnion = isset($input->{'refObjectsUnion'}) ? ((SomeObj2::validateInput($input->{'refObjectsUnion'}, true)) ? SomeObj2::fromInput($input->{'refObjectsUnion'}, $validate) : (((SomeObj1::validateInput($input->{'refObjectsUnion'}, true)) ? SomeObj1::fromInput($input->{'refObjectsUnion'}, $validate) : (null)))) : null;
         $refAndNotRefObjectsUnion = isset($input->{'refAndNotRefObjectsUnion'}) ? ((MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) ? MyClassRefAndNotRefObjectsUnionAlternative4::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate) : (((SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) ? SomeObj2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate) : (((MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) ? MyClassRefAndNotRefObjectsUnionAlternative2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate) : (((SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) ? SomeObj1::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate) : (null)))))))) : null;
         $objAndStringUnion = isset($input->{'objAndStringUnion'}) ? ((is_string($input->{'objAndStringUnion'})) ? $input->{'objAndStringUnion'} : (((MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true)) ? MyClassObjAndStringUnionAlternative1::fromInput($input->{'objAndStringUnion'}, $validate) : (null)))) : null;
-        $unionOfOneObj = isset($input->{'unionOfOneObj'}) ? ((MyClassUnionOfOneObjAlternative1::validateInput($input->{'unionOfOneObj'}, true)) ? MyClassUnionOfOneObjAlternative1::fromInput($input->{'unionOfOneObj'}, $validate) : (null)) : null;
+        $unionOfOneObj = isset($input->{'unionOfOneObj'}) ? MyClassUnionOfOneObj::fromInput($input->{'unionOfOneObj'}, $validate) : null;
         $unionOfOneNull = null;
         if (property_exists($input, 'unionOfOneNull')) {
-            $unionOfOneNull = ($input->{'unionOfOneNull'} !== null ? (((($input->{'unionOfOneNull'}) === null) || ($input->{'unionOfOneNull'} === null)) ? ($input->{'unionOfOneNull'} !== null ? $input->{'unionOfOneNull'} : null) : (null)) : null);
+            $unionOfOneNull = ($input->{'unionOfOneNull'} !== null ? $input->{'unionOfOneNull'} : null);
             $__providedOptionals['unionOfOneNull'] = true;
         }
 
@@ -461,12 +443,10 @@ class MyClass
             }
         }
         if (isset($this->unionOfOneObj)) {
-            if (($this->unionOfOneObj instanceof MyClassUnionOfOneObjAlternative1)) {
-                $output['unionOfOneObj'] = ($this->unionOfOneObj)->toArray();
-            }
+            $output['unionOfOneObj'] = ($this->unionOfOneObj)->toArray();
         }
         if (isset($this->unionOfOneNull) || array_key_exists('unionOfOneNull', $this->_providedOptionals)) {
-            $output['unionOfOneNull'] = ($this->unionOfOneNull !== null) ? (((($this->unionOfOneNull) === null) || ($this->unionOfOneNull === null)) ? (($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null) : (null)) : null;
+            $output['unionOfOneNull'] = ($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null;
         }
 
         return $output;
@@ -505,12 +485,10 @@ class MyClass
             }
         }
         if (isset($this->unionOfOneObj)) {
-            if (($this->unionOfOneObj instanceof MyClassUnionOfOneObjAlternative1)) {
             $output->{'unionOfOneObj'} = ($this->unionOfOneObj)->toStdClass();
-            }
         }
         if (isset($this->unionOfOneNull) || array_key_exists('unionOfOneNull', $this->_providedOptionals)) {
-            $output->{'unionOfOneNull'} = ($this->unionOfOneNull !== null) ? (((($this->unionOfOneNull) === null) || ($this->unionOfOneNull === null)) ? (($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null) : (null)) : null;
+            $output->{'unionOfOneNull'} = ($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null;
         }
 
         return $output;
@@ -555,10 +533,7 @@ class MyClass
             $this->objAndStringUnion = (is_string($this->objAndStringUnion)) ? ($this->objAndStringUnion) : (($this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1) ? (clone $this->objAndStringUnion) : ($this->objAndStringUnion));
         }
         if (isset($this->unionOfOneObj)) {
-            $this->unionOfOneObj = ($this->unionOfOneObj instanceof MyClassUnionOfOneObjAlternative1) ? (clone $this->unionOfOneObj) : ($this->unionOfOneObj);
-        }
-        if (isset($this->unionOfOneNull)) {
-            $this->unionOfOneNull = ((($this->unionOfOneNull) === null) || ($this->unionOfOneNull === null)) ? (isset($this->unionOfOneNull) ? (clone $this->unionOfOneNull) : null) : ($this->unionOfOneNull);
+            $this->unionOfOneObj = clone $this->unionOfOneObj;
         }
     }
 

--- a/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClassUnionOfOneObj.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClassUnionOfOneObj.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Ns\UnionObject_8_4;
+namespace Ns\UnionObject_7_4;
 
-class MyClassUnionOfOneObjAlternative1
+class MyClassUnionOfOneObj
 {
     /**
      * Schema used to validate input for creating instances of this class
@@ -68,11 +68,17 @@ class MyClassUnionOfOneObjAlternative1
      *
      * @param array|object $input Input data
      * @param bool $validate If `false`, validation against the schema will be skipped.
-     * @return MyClassUnionOfOneObjAlternative1 Created instance
+     * @return MyClassUnionOfOneObj Created instance
      * @throws \InvalidArgumentException
      */
-    public static function fromInput(array|object $input, bool $validate = true): MyClassUnionOfOneObjAlternative1
+    public static function fromInput($input, bool $validate = true): MyClassUnionOfOneObj
     {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
         $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
         if ($validate) {
             static::validateInput($input);
@@ -122,7 +128,7 @@ class MyClassUnionOfOneObjAlternative1
      * @return bool Validation result
      * @throws \InvalidArgumentException
      */
-    public static function validateInput(array|object $input, bool $return = false): bool
+    public static function validateInput($input, bool $return = false): bool
     {
         $validator = new \JsonSchema\Validator();
         $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;

--- a/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
@@ -131,7 +131,7 @@ class MyClass
 
     private MyClassObjAndStringUnionAlternative1|string|null $objAndStringUnion = null;
 
-    private ?MyClassUnionOfOneObjAlternative1 $unionOfOneObj = null;
+    private ?MyClassUnionOfOneObj $unionOfOneObj = null;
 
     /**
      * @var null
@@ -141,7 +141,7 @@ class MyClass
     /**
      * @param null $unionOfOneNull
      */
-    public function __construct(MyClassObjectsUnionAlternative1|MyClassObjectsUnionAlternative2|null $objectsUnion = null, SomeObj1|SomeObj2|null $refObjectsUnion = null, MyClassRefAndNotRefObjectsUnionAlternative2|MyClassRefAndNotRefObjectsUnionAlternative4|SomeObj1|SomeObj2|null $refAndNotRefObjectsUnion = null, MyClassObjAndStringUnionAlternative1|string|null $objAndStringUnion = null, ?MyClassUnionOfOneObjAlternative1 $unionOfOneObj = null, $unionOfOneNull = null)
+    public function __construct(MyClassObjectsUnionAlternative1|MyClassObjectsUnionAlternative2|null $objectsUnion = null, SomeObj1|SomeObj2|null $refObjectsUnion = null, MyClassRefAndNotRefObjectsUnionAlternative2|MyClassRefAndNotRefObjectsUnionAlternative4|SomeObj1|SomeObj2|null $refAndNotRefObjectsUnion = null, MyClassObjAndStringUnionAlternative1|string|null $objAndStringUnion = null, ?MyClassUnionOfOneObj $unionOfOneObj = null, $unionOfOneNull = null)
     {
         $this->objectsUnion = $objectsUnion;
         $this->refObjectsUnion = $refObjectsUnion;
@@ -235,12 +235,12 @@ class MyClass
         return $clone;
     }
 
-    public function getUnionOfOneObj(): ?MyClassUnionOfOneObjAlternative1
+    public function getUnionOfOneObj(): ?MyClassUnionOfOneObj
     {
         return $this->unionOfOneObj;
     }
 
-    public function withUnionOfOneObj(MyClassUnionOfOneObjAlternative1 $unionOfOneObj): self
+    public function withUnionOfOneObj(MyClassUnionOfOneObj $unionOfOneObj): self
     {
         $clone = clone $this;
         $clone->unionOfOneObj = $unionOfOneObj;
@@ -331,16 +331,10 @@ class MyClass
             is_string($input->{'objAndStringUnion'}) => $input->{'objAndStringUnion'},
             default => null,
         } : null;
-        $unionOfOneObj = isset($input->{'unionOfOneObj'}) ? match (true) {
-            MyClassUnionOfOneObjAlternative1::validateInput($input->{'unionOfOneObj'}, true) => MyClassUnionOfOneObjAlternative1::fromInput($input->{'unionOfOneObj'}, $validate),
-            default => null,
-        } : null;
+        $unionOfOneObj = isset($input->{'unionOfOneObj'}) ? MyClassUnionOfOneObj::fromInput($input->{'unionOfOneObj'}, $validate) : null;
         $unionOfOneNull = null;
         if (property_exists($input, 'unionOfOneNull')) {
-            $unionOfOneNull = ($input->{'unionOfOneNull'} !== null ? match (true) {
-            (($input->{'unionOfOneNull'}) === null) || ($input->{'unionOfOneNull'} === null) => ($input->{'unionOfOneNull'} !== null ? $input->{'unionOfOneNull'} : null),
-            default => null,
-        } : null);
+            $unionOfOneNull = ($input->{'unionOfOneNull'} !== null ? $input->{'unionOfOneNull'} : null);
             $__providedOptionals['unionOfOneNull'] = true;
         }
 
@@ -391,15 +385,10 @@ class MyClass
             };
         }
         if (isset($this->unionOfOneObj)) {
-            $output['unionOfOneObj'] = match (true) {
-                $this->unionOfOneObj instanceof MyClassUnionOfOneObjAlternative1 => ($this->unionOfOneObj)->toArray(),
-            };
+            $output['unionOfOneObj'] = ($this->unionOfOneObj)->toArray();
         }
         if (isset($this->unionOfOneNull) || array_key_exists('unionOfOneNull', $this->_providedOptionals)) {
-            $output['unionOfOneNull'] = ($this->unionOfOneNull !== null) ? (match (true) {
-                default => null,
-                (($this->unionOfOneNull) === null) || ($this->unionOfOneNull === null) => ($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null,
-            }) : null;
+            $output['unionOfOneNull'] = ($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null;
         }
 
         return $output;
@@ -440,15 +429,10 @@ class MyClass
             };
         }
         if (isset($this->unionOfOneObj)) {
-            $output->{'unionOfOneObj'} = match (true) {
-                $this->unionOfOneObj instanceof MyClassUnionOfOneObjAlternative1 => ($this->unionOfOneObj)->toStdClass(),
-            };
+            $output->{'unionOfOneObj'} = ($this->unionOfOneObj)->toStdClass();
         }
         if (isset($this->unionOfOneNull) || array_key_exists('unionOfOneNull', $this->_providedOptionals)) {
-            $output->{'unionOfOneNull'} = ($this->unionOfOneNull !== null) ? (match (true) {
-                default => null,
-                (($this->unionOfOneNull) === null) || ($this->unionOfOneNull === null) => ($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null,
-            }) : null;
+            $output->{'unionOfOneNull'} = ($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null;
         }
 
         return $output;
@@ -507,14 +491,7 @@ class MyClass
             };
         }
         if (isset($this->unionOfOneObj)) {
-            $this->unionOfOneObj = match (true) {
-                $this->unionOfOneObj instanceof MyClassUnionOfOneObjAlternative1 => clone $this->unionOfOneObj,
-            };
-        }
-        if (isset($this->unionOfOneNull)) {
-            $this->unionOfOneNull = match (true) {
-                (($this->unionOfOneNull) === null) || ($this->unionOfOneNull === null) => isset($this->unionOfOneNull) ? (clone $this->unionOfOneNull) : null,
-            };
+            $this->unionOfOneObj = clone $this->unionOfOneObj;
         }
     }
 

--- a/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClassUnionOfOneObj.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClassUnionOfOneObj.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Ns\UnionObject_7_4;
+namespace Ns\UnionObject_8_4;
 
-class MyClassUnionOfOneObjAlternative1
+class MyClassUnionOfOneObj
 {
     /**
      * Schema used to validate input for creating instances of this class
@@ -68,17 +68,11 @@ class MyClassUnionOfOneObjAlternative1
      *
      * @param array|object $input Input data
      * @param bool $validate If `false`, validation against the schema will be skipped.
-     * @return MyClassUnionOfOneObjAlternative1 Created instance
+     * @return MyClassUnionOfOneObj Created instance
      * @throws \InvalidArgumentException
      */
-    public static function fromInput($input, bool $validate = true): MyClassUnionOfOneObjAlternative1
+    public static function fromInput(array|object $input, bool $validate = true): MyClassUnionOfOneObj
     {
-        if (!is_array($input) && !is_object($input)) {
-            throw new \InvalidArgumentException(
-                'Input to fromInput must be array or object, got ' . gettype($input)
-            );
-        }
-
         $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
         if ($validate) {
             static::validateInput($input);
@@ -128,7 +122,7 @@ class MyClassUnionOfOneObjAlternative1
      * @return bool Validation result
      * @throws \InvalidArgumentException
      */
-    public static function validateInput($input, bool $return = false): bool
+    public static function validateInput(array|object $input, bool $return = false): bool
     {
         $validator = new \JsonSchema\Validator();
         $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;


### PR DESCRIPTION
## Summary
- flatten anyOf/oneOf with a single entry before building properties
- return shorthand nullable type hints when a union consists of one type plus null
- update fixtures and changelog

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68937deb3aa8832dbc246d636751963d