### PR TITLE
Flatten single-arm unions and refine union type hints

### DIFF
--- a/src/Generator/Property/PropertyBuilder.php
+++ b/src/Generator/Property/PropertyBuilder.php
@@ -79,11 +79,12 @@ class PropertyBuilder
         bool $isRequired
     ): PropertyInterface
     {
-        self::assertNoPropertiesWithAdditional($definition);
-
+        $definition = self::collapseSingleUnion($definition);
         $definition = self::sanitizeEnum($definition);
         $definition = self::collapseSingleTypeArray($definition);
-
+        
+        self::assertNoPropertiesWithAdditional($definition);
+        
         if ($property = self::tryInlineReference($req, $name, $definition, $isRequired)) {
             return $property;
         }
@@ -105,10 +106,6 @@ class PropertyBuilder
             return $property;
         }
 
-        if ($property = self::trySingleUnion($req, $name, $definition, $isRequired)) {
-            return $property;
-        }
-
         foreach (self::$propertyTypes as $propertyType) {
             if ($propertyType::canHandleSchema($definition)) {
                 /** @var PropertyInterface $property */
@@ -118,6 +115,29 @@ class PropertyBuilder
         }
 
         throw new GeneratorException("cannot map type " . (string) json_encode($definition));
+    }
+
+    /** Collapse oneOf/anyOf unions with a single element */
+    private static function collapseSingleUnion(array $definition): array
+    {
+        $unionKey = isset($definition['anyOf']) ? 'anyOf' : (isset($definition['oneOf']) ? 'oneOf' : null);
+        if (!$unionKey) {
+            return $definition;
+        }
+
+        $subs = $definition[$unionKey];
+        if (!is_array($subs) || count($subs) !== 1) {
+            return $definition;
+        }
+
+        $single = $subs[0];
+        foreach (['description', 'title', 'default', 'deprecated'] as $k) {
+            if (isset($definition[$k]) && !isset($single[$k])) {
+                $single[$k] = $definition[$k];
+            }
+        }
+
+        return self::collapseSingleUnion($single);
     }
 
     /** Collapse single-element type arrays (e.g. ["string"] -> "string") */
@@ -263,21 +283,37 @@ class PropertyBuilder
             return null;
         }
 
-        $subs   = $definition[$unionKey];
-        $nullIx = null;
-        foreach ($subs as $i => $sub) {
-            if (isset($sub['type']) && $sub['type'] === 'null') {
-                $nullIx = $i;
-                break;
+        $subs      = $definition[$unionKey];
+        $otherArms = [];
+        $hasNull   = false;
+        foreach ($subs as $sub) {
+            if (!isset($sub['type'])) {
+                $otherArms[] = $sub;
+                continue;
             }
+
+            $type = $sub['type'];
+            if ($type === 'null') {
+                $hasNull = true;
+                continue;
+            }
+
+            if (is_array($type) && ($nullPos = array_search('null', $type, true)) !== false) {
+                $hasNull = true;
+                unset($type[$nullPos]);
+                $type = array_values($type);
+                if (count($type) === 0) {
+                    continue;
+                }
+                $sub['type'] = count($type) === 1 ? $type[0] : $type;
+            }
+
+            $otherArms[] = $sub;
         }
 
-        if ($nullIx === null || count($subs) <= 1) {
+        if (!$hasNull || count($subs) <= 1) {
             return null;
         }
-
-        $otherArms = $subs;
-        array_splice($otherArms, $nullIx, 1);
 
         if (count($otherArms) === 1) {
             $singleSchema = $otherArms[0];
@@ -299,33 +335,6 @@ class PropertyBuilder
         return $isRequired
             ? new NullablePropertyDecorator($name, $unionProp, $req)
             : self::wrapProperty($req, $unionProp, $definition, $name, false);
-    }
-
-    /** Flatten anyOf/oneOf definitions with a single schema */
-    private static function trySingleUnion(
-        GeneratorRequest $req,
-        string $name,
-        array $definition,
-        bool $isRequired
-    ): ?PropertyInterface {
-        $unionKey = isset($definition['anyOf']) ? 'anyOf' : (isset($definition['oneOf']) ? 'oneOf' : null);
-        if (!$unionKey) {
-            return null;
-        }
-
-        $subs = $definition[$unionKey];
-        if (!is_array($subs) || count($subs) !== 1) {
-            return null;
-        }
-
-        $single = $subs[0];
-        foreach (['description', 'title', 'default', 'deprecated'] as $k) {
-            if (isset($definition[$k]) && !isset($single[$k])) {
-                $single[$k] = $definition[$k];
-            }
-        }
-
-        return self::buildPropertyFromSchema($req, $name, $single, $isRequired);
     }
 
     /** Apply optional/nullable decorators around a property */

--- a/src/Generator/Property/PropertyBuilder.php
+++ b/src/Generator/Property/PropertyBuilder.php
@@ -105,6 +105,10 @@ class PropertyBuilder
             return $property;
         }
 
+        if ($property = self::trySingleUnion($req, $name, $definition, $isRequired)) {
+            return $property;
+        }
+
         foreach (self::$propertyTypes as $propertyType) {
             if ($propertyType::canHandleSchema($definition)) {
                 /** @var PropertyInterface $property */
@@ -295,6 +299,33 @@ class PropertyBuilder
         return $isRequired
             ? new NullablePropertyDecorator($name, $unionProp, $req)
             : self::wrapProperty($req, $unionProp, $definition, $name, false);
+    }
+
+    /** Flatten anyOf/oneOf definitions with a single schema */
+    private static function trySingleUnion(
+        GeneratorRequest $req,
+        string $name,
+        array $definition,
+        bool $isRequired
+    ): ?PropertyInterface {
+        $unionKey = isset($definition['anyOf']) ? 'anyOf' : (isset($definition['oneOf']) ? 'oneOf' : null);
+        if (!$unionKey) {
+            return null;
+        }
+
+        $subs = $definition[$unionKey];
+        if (!is_array($subs) || count($subs) !== 1) {
+            return null;
+        }
+
+        $single = $subs[0];
+        foreach (['description', 'title', 'default', 'deprecated'] as $k) {
+            if (isset($definition[$k]) && !isset($single[$k])) {
+                $single[$k] = $definition[$k];
+            }
+        }
+
+        return self::buildPropertyFromSchema($req, $name, $single, $isRequired);
     }
 
     /** Apply optional/nullable decorators around a property */

--- a/src/Generator/Property/Type/UnionProperty.php
+++ b/src/Generator/Property/Type/UnionProperty.php
@@ -282,45 +282,70 @@ class UnionProperty extends AbstractProperty
 
     public function typeHint(): ?string
     {
-        if ($this->request->isAtLeastPHP("8.0")) {
-            $subTypeHints = [];
+        $subTypeHints = [];
 
-            foreach ($this->subProperties as $subProp) {
-                $hint = $subProp->typeHint();
-                if ($hint === null) {
-                    if ($subProp instanceof NullProperty) {
-                        $subTypeHints['null'] = true;
-                        continue;
-                    }
-                    return null;
-                }
-
-                if (str_starts_with($hint, '?')) {
+        foreach ($this->subProperties as $subProp) {
+            $hint = $subProp->typeHint();
+            if ($hint === null) {
+                if ($subProp instanceof NullProperty) {
                     $subTypeHints['null'] = true;
-                    $hint = substr($hint, 1);
+                    continue;
                 }
-
-                foreach (explode('|', $hint) as $part) {
-                    $subTypeHints[$part] = true;
-                }
+                $subTypeHints = [];
+                break;
             }
 
-            return join('|', array_keys($subTypeHints));
+            if (str_starts_with($hint, '?')) {
+                $subTypeHints['null'] = true;
+                $hint = substr($hint, 1);
+            }
+
+            foreach (explode('|', $hint) as $part) {
+                $subTypeHints[$part] = true;
+            }
         }
 
-        if ($this->request->isAtLeastPHP('7.2')) {
-            $onlyObjects = true;
-            foreach ($this->subProperties as $subProp) {
-                if (
-                    !($subProp instanceof NestedObjectProperty)
-                    && !($subProp instanceof ReferenceProperty && $subProp->getRefType() instanceof ReferencedTypeClass)
-                ) {
-                    $onlyObjects = false;
-                    break;
+        if ($this->request->isAtLeastPHP('8.0')) {
+            if (isset($subTypeHints['null']) && count($subTypeHints) === 2) {
+                unset($subTypeHints['null']);
+                return array_key_first($subTypeHints);
+            }
+
+            if (count($subTypeHints) === 1) {
+                return array_key_first($subTypeHints);
+            }
+
+            if (count($subTypeHints) > 0) {
+                return join('|', array_keys($subTypeHints));
+            }
+        } else {
+            if (isset($subTypeHints['null']) && count($subTypeHints) === 2) {
+                $types = array_keys($subTypeHints);
+                $type  = $types[0] === 'null' ? $types[1] : $types[0];
+                return $type;
+            }
+
+            if (count($subTypeHints) === 1) {
+                $type = array_key_first($subTypeHints);
+                if ($type !== 'null') {
+                    return $type;
                 }
             }
-            if ($onlyObjects) {
-                return 'object';
+
+            if ($this->request->isAtLeastPHP('7.2')) {
+                $onlyObjects = true;
+                foreach ($this->subProperties as $subProp) {
+                    if (
+                        !($subProp instanceof NestedObjectProperty)
+                        && !($subProp instanceof ReferenceProperty && $subProp->getRefType() instanceof ReferencedTypeClass)
+                    ) {
+                        $onlyObjects = false;
+                        break;
+                    }
+                }
+                if ($onlyObjects) {
+                    return 'object';
+                }
             }
         }
 

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -59,12 +59,12 @@ class BarTest
     /**
      * @var FooTest|MoiKlass|FooTest_1|null
      */
-    private $exampleProp = null;
+    private ?object $exampleProp = null;
 
     /**
      * @param FooTest|MoiKlass|FooTest_1|null $exampleProp
      */
-    public function __construct($exampleProp = null)
+    public function __construct(?object $exampleProp = null)
     {
         $this->exampleProp = $exampleProp;
     }
@@ -72,7 +72,7 @@ class BarTest
     /**
      * @return FooTest|MoiKlass|FooTest_1|null
      */
-    public function getExampleProp()
+    public function getExampleProp(): ?object
     {
         return $this->exampleProp;
     }
@@ -80,7 +80,7 @@ class BarTest
     /**
      * @param FooTest|MoiKlass|FooTest_1 $exampleProp
      */
-    public function withExampleProp($exampleProp, bool $validate = true): self
+    public function withExampleProp(object $exampleProp, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -59,12 +59,12 @@ class Baz
     /**
      * @var Foo|Bar|null
      */
-    private $grox = null;
+    private ?object $grox = null;
 
     /**
      * @param Foo|Bar|null $grox
      */
-    public function __construct($grox = null)
+    public function __construct(?object $grox = null)
     {
         $this->grox = $grox;
     }
@@ -72,7 +72,7 @@ class Baz
     /**
      * @return Foo|Bar|null
      */
-    public function getGrox()
+    public function getGrox(): ?object
     {
         return $this->grox;
     }
@@ -80,7 +80,7 @@ class Baz
     /**
      * @param Foo|Bar $grox
      */
-    public function withGrox($grox, bool $validate = true): self
+    public function withGrox(object $grox, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
@@ -53,12 +53,12 @@ class MyObject
     /**
      * @var 'foo'|'bar'|'baz'|'quz'
      */
-    private $foo;
+    private string $foo;
 
     /**
      * @param 'foo'|'bar'|'baz'|'quz' $foo
      */
-    public function __construct($foo)
+    public function __construct(string $foo)
     {
         $this->foo = $foo;
     }
@@ -66,7 +66,7 @@ class MyObject
     /**
      * @return 'foo'|'bar'|'baz'|'quz'
      */
-    public function getFoo()
+    public function getFoo(): string
     {
         return $this->foo;
     }
@@ -74,7 +74,7 @@ class MyObject
     /**
      * @param 'foo'|'bar'|'baz'|'quz' $foo
      */
-    public function withFoo($foo, bool $validate = true): self
+    public function withFoo(string $foo, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
@@ -266,7 +266,7 @@ class MyClass
         $foo = $input->{'foo'};
         $bar = $input->{'bar'};
         $baz = $input->{'baz'};
-        $qux = ($input->{'qux'} !== null ? ((is_string($input->{'qux'})) ? $input->{'qux'} : (((is_string($input->{'qux'})) ? $input->{'qux'} : ((((($input->{'qux'}) === null) || (is_string($input->{'qux'}))) ? ($input->{'qux'} !== null ? $input->{'qux'} : null) : (((is_string($input->{'qux'})) ? $input->{'qux'} : (null)))))))) : null);
+        $qux = ($input->{'qux'} !== null ? ((is_string($input->{'qux'})) ? $input->{'qux'} : (((is_string($input->{'qux'})) ? $input->{'qux'} : (((is_string($input->{'qux'})) ? $input->{'qux'} : (((is_string($input->{'qux'})) ? $input->{'qux'} : (null)))))))) : null);
 
         $obj = new self($foo, $bar, $baz, $qux);
         return $obj;
@@ -289,10 +289,8 @@ class MyClass
         if ((is_string($this->baz)) || (is_string($this->baz))) {
             $output['baz'] = $this->baz;
         }
-        if ((is_string($this->qux)) || (is_string($this->qux)) || (is_string($this->qux))) {
+        if ((is_string($this->qux)) || (is_string($this->qux)) || (is_string($this->qux)) || (is_string($this->qux))) {
             $output['qux'] = $this->qux;
-        } else if (((($this->qux) === null) || (is_string($this->qux)))) {
-            $output['qux'] = ($this->qux !== null) ? ($this->qux) : null;
         }
 
         return $output;
@@ -315,10 +313,8 @@ class MyClass
         if ((is_string($this->baz)) || (is_string($this->baz))) {
         $output->{'baz'} = $this->baz;
         }
-        if ((is_string($this->qux)) || (is_string($this->qux)) || (is_string($this->qux))) {
+        if ((is_string($this->qux)) || (is_string($this->qux)) || (is_string($this->qux)) || (is_string($this->qux))) {
         $output->{'qux'} = $this->qux;
-        } else if (((($this->qux) === null) || (is_string($this->qux)))) {
-        $output->{'qux'} = ($this->qux !== null) ? ($this->qux) : null;
         }
 
         return $output;
@@ -353,6 +349,6 @@ class MyClass
         $this->foo = (is_string($this->foo)) ? ($this->foo) : ((is_string($this->foo)) ? ($this->foo) : ($this->foo));
         $this->bar = (is_string($this->bar)) ? ($this->bar) : ((is_string($this->bar)) ? ($this->bar) : ($this->bar));
         $this->baz = (is_string($this->baz)) ? ($this->baz) : ((is_string($this->baz)) ? ($this->baz) : ($this->baz));
-        $this->qux = (is_string($this->qux)) ? ($this->qux) : ((is_string($this->qux)) ? ($this->qux) : (((($this->qux) === null) || (is_string($this->qux))) ? (isset($this->qux) ? (clone $this->qux) : null) : ((is_string($this->qux)) ? ($this->qux) : ($this->qux))));
+        $this->qux = (is_string($this->qux)) ? ($this->qux) : ((is_string($this->qux)) ? ($this->qux) : ((is_string($this->qux)) ? ($this->qux) : ((is_string($this->qux)) ? ($this->qux) : ($this->qux))));
     }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -94,33 +94,15 @@ class MyClass
         ],
     ];
 
-    /**
-     * @var string
-     */
-    private $foo;
+    private string $foo;
 
-    /**
-     * @var string
-     */
-    private $bar;
+    private string $bar;
 
-    /**
-     * @var string
-     */
-    private $baz;
+    private string $baz;
 
-    /**
-     * @var string|null
-     */
-    private $qux;
+    private ?string $qux;
 
-    /**
-     * @param string $foo
-     * @param string $bar
-     * @param string $baz
-     * @param string|null $qux
-     */
-    public function __construct($foo, $bar, $baz, $qux)
+    public function __construct(string $foo, string $bar, string $baz, ?string $qux)
     {
         $this->foo = $foo;
         $this->bar = $bar;
@@ -128,18 +110,12 @@ class MyClass
         $this->qux = $qux;
     }
 
-    /**
-     * @return string
-     */
-    public function getFoo()
+    public function getFoo(): string
     {
         return $this->foo;
     }
 
-    /**
-     * @param string $foo
-     */
-    public function withFoo($foo, bool $validate = true): self
+    public function withFoo(string $foo, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -155,18 +131,12 @@ class MyClass
         return $clone;
     }
 
-    /**
-     * @return string
-     */
-    public function getBar()
+    public function getBar(): string
     {
         return $this->bar;
     }
 
-    /**
-     * @param string $bar
-     */
-    public function withBar($bar, bool $validate = true): self
+    public function withBar(string $bar, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -182,18 +152,12 @@ class MyClass
         return $clone;
     }
 
-    /**
-     * @return string
-     */
-    public function getBaz()
+    public function getBaz(): string
     {
         return $this->baz;
     }
 
-    /**
-     * @param string $baz
-     */
-    public function withBaz($baz, bool $validate = true): self
+    public function withBaz(string $baz, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();
@@ -209,18 +173,12 @@ class MyClass
         return $clone;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getQux()
+    public function getQux(): ?string
     {
         return $this->qux;
     }
 
-    /**
-     * @param string|null $qux
-     */
-    public function withQux($qux, bool $validate = true): self
+    public function withQux(?string $qux, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -218,7 +218,7 @@ class MyClass
         $foo = $input->{'foo'};
         $bar = $input->{'bar'};
         $baz = $input->{'baz'};
-        $qux = ($input->{'qux'} !== null ? ((is_string($input->{'qux'})) ? $input->{'qux'} : (((is_string($input->{'qux'})) ? $input->{'qux'} : ((((($input->{'qux'}) === null) || (is_string($input->{'qux'}))) ? ($input->{'qux'} !== null ? $input->{'qux'} : null) : (((is_string($input->{'qux'})) ? $input->{'qux'} : (null)))))))) : null);
+        $qux = ($input->{'qux'} !== null ? ((is_string($input->{'qux'})) ? $input->{'qux'} : (((is_string($input->{'qux'})) ? $input->{'qux'} : (((is_string($input->{'qux'})) ? $input->{'qux'} : (((is_string($input->{'qux'})) ? $input->{'qux'} : (null)))))))) : null);
 
         $obj = new self($foo, $bar, $baz, $qux);
         return $obj;
@@ -241,10 +241,8 @@ class MyClass
         if ((is_string($this->baz)) || (is_string($this->baz))) {
             $output['baz'] = $this->baz;
         }
-        if ((is_string($this->qux)) || (is_string($this->qux)) || (is_string($this->qux))) {
+        if ((is_string($this->qux)) || (is_string($this->qux)) || (is_string($this->qux)) || (is_string($this->qux))) {
             $output['qux'] = $this->qux;
-        } else if (((($this->qux) === null) || (is_string($this->qux)))) {
-            $output['qux'] = ($this->qux !== null) ? ($this->qux) : null;
         }
 
         return $output;
@@ -267,10 +265,8 @@ class MyClass
         if ((is_string($this->baz)) || (is_string($this->baz))) {
         $output->{'baz'} = $this->baz;
         }
-        if ((is_string($this->qux)) || (is_string($this->qux)) || (is_string($this->qux))) {
+        if ((is_string($this->qux)) || (is_string($this->qux)) || (is_string($this->qux)) || (is_string($this->qux))) {
         $output->{'qux'} = $this->qux;
-        } else if (((($this->qux) === null) || (is_string($this->qux)))) {
-        $output->{'qux'} = ($this->qux !== null) ? ($this->qux) : null;
         }
 
         return $output;
@@ -305,6 +301,6 @@ class MyClass
         $this->foo = (is_string($this->foo)) ? ($this->foo) : ((is_string($this->foo)) ? ($this->foo) : ($this->foo));
         $this->bar = (is_string($this->bar)) ? ($this->bar) : ((is_string($this->bar)) ? ($this->bar) : ($this->bar));
         $this->baz = (is_string($this->baz)) ? ($this->baz) : ((is_string($this->baz)) ? ($this->baz) : ($this->baz));
-        $this->qux = (is_string($this->qux)) ? ($this->qux) : ((is_string($this->qux)) ? ($this->qux) : (((($this->qux) === null) || (is_string($this->qux))) ? (isset($this->qux) ? (clone $this->qux) : null) : ((is_string($this->qux)) ? ($this->qux) : ($this->qux))));
+        $this->qux = (is_string($this->qux)) ? ($this->qux) : ((is_string($this->qux)) ? ($this->qux) : ((is_string($this->qux)) ? ($this->qux) : ((is_string($this->qux)) ? ($this->qux) : ($this->qux))));
     }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -223,7 +223,6 @@ class MyClass
         };
         $qux = ($input->{'qux'} !== null ? match (true) {
             is_string($input->{'qux'}) => $input->{'qux'},
-            (($input->{'qux'}) === null) || (is_string($input->{'qux'})) => ($input->{'qux'} !== null ? $input->{'qux'} : null),
             default => null,
         } : null);
 
@@ -250,7 +249,6 @@ class MyClass
         };
         $output['qux'] = match (true) {
             is_string($this->qux) => $this->qux,
-            (($this->qux) === null) || (is_string($this->qux)) => ($this->qux !== null) ? ($this->qux) : null,
         };
 
         return $output;
@@ -275,7 +273,6 @@ class MyClass
         };
         $output->{'qux'} = match (true) {
             is_string($this->qux) => $this->qux,
-            (($this->qux) === null) || (is_string($this->qux)) => ($this->qux !== null) ? ($this->qux) : null,
         };
 
         return $output;
@@ -318,7 +315,6 @@ class MyClass
         };
         $this->qux = match (true) {
             is_string($this->qux) => $this->qux,
-            (($this->qux) === null) || (is_string($this->qux)) => isset($this->qux) ? (clone $this->qux) : null,
         };
     }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -100,9 +100,9 @@ class MyClass
 
     private string $baz;
 
-    private string|null $qux;
+    private ?string $qux;
 
-    public function __construct(string $foo, string $bar, string $baz, string|null $qux)
+    public function __construct(string $foo, string $bar, string $baz, ?string $qux)
     {
         $this->foo = $foo;
         $this->bar = $bar;
@@ -173,12 +173,12 @@ class MyClass
         return $clone;
     }
 
-    public function getQux(): string|null
+    public function getQux(): ?string
     {
         return $this->qux;
     }
 
-    public function withQux(string|null $qux, bool $validate = true): self
+    public function withQux(?string $qux, bool $validate = true): self
     {
         if ($validate) {
             $validator = new \JsonSchema\Validator();

--- a/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
@@ -143,10 +143,7 @@ class MyClass
      */
     private $objAndStringUnion = null;
 
-    /**
-     * @var MyClassUnionOfOneObjAlternative1|null
-     */
-    private ?object $unionOfOneObj = null;
+    private ?MyClassUnionOfOneObj $unionOfOneObj = null;
 
     /**
      * @var null
@@ -158,10 +155,9 @@ class MyClass
      * @param SomeObj1|SomeObj2|null $refObjectsUnion
      * @param SomeObj1|MyClassRefAndNotRefObjectsUnionAlternative2|SomeObj2|MyClassRefAndNotRefObjectsUnionAlternative4|null $refAndNotRefObjectsUnion
      * @param MyClassObjAndStringUnionAlternative1|string|null $objAndStringUnion
-     * @param MyClassUnionOfOneObjAlternative1|null $unionOfOneObj
      * @param null $unionOfOneNull
      */
-    public function __construct(?object $objectsUnion = null, ?object $refObjectsUnion = null, ?object $refAndNotRefObjectsUnion = null, $objAndStringUnion = null, ?object $unionOfOneObj = null, $unionOfOneNull = null)
+    public function __construct(?object $objectsUnion = null, ?object $refObjectsUnion = null, ?object $refAndNotRefObjectsUnion = null, $objAndStringUnion = null, ?MyClassUnionOfOneObj $unionOfOneObj = null, $unionOfOneNull = null)
     {
         $this->objectsUnion = $objectsUnion;
         $this->refObjectsUnion = $refObjectsUnion;
@@ -311,27 +307,13 @@ class MyClass
         return $clone;
     }
 
-    /**
-     * @return MyClassUnionOfOneObjAlternative1|null
-     */
-    public function getUnionOfOneObj(): ?object
+    public function getUnionOfOneObj(): ?MyClassUnionOfOneObj
     {
         return $this->unionOfOneObj;
     }
 
-    /**
-     * @param MyClassUnionOfOneObjAlternative1 $unionOfOneObj
-     */
-    public function withUnionOfOneObj(object $unionOfOneObj, bool $validate = true): self
+    public function withUnionOfOneObj(MyClassUnionOfOneObj $unionOfOneObj): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($unionOfOneObj, self::$_schema['properties']['unionOfOneObj']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->unionOfOneObj = $unionOfOneObj;
 
@@ -409,10 +391,10 @@ class MyClass
         $refObjectsUnion = isset($input->{'refObjectsUnion'}) ? ((SomeObj2::validateInput($input->{'refObjectsUnion'}, true)) ? SomeObj2::fromInput($input->{'refObjectsUnion'}, $validate) : (((SomeObj1::validateInput($input->{'refObjectsUnion'}, true)) ? SomeObj1::fromInput($input->{'refObjectsUnion'}, $validate) : (null)))) : null;
         $refAndNotRefObjectsUnion = isset($input->{'refAndNotRefObjectsUnion'}) ? ((MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) ? MyClassRefAndNotRefObjectsUnionAlternative4::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate) : (((SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) ? SomeObj2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate) : (((MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) ? MyClassRefAndNotRefObjectsUnionAlternative2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate) : (((SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) ? SomeObj1::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate) : (null)))))))) : null;
         $objAndStringUnion = isset($input->{'objAndStringUnion'}) ? ((is_string($input->{'objAndStringUnion'})) ? $input->{'objAndStringUnion'} : (((MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true)) ? MyClassObjAndStringUnionAlternative1::fromInput($input->{'objAndStringUnion'}, $validate) : (null)))) : null;
-        $unionOfOneObj = isset($input->{'unionOfOneObj'}) ? ((MyClassUnionOfOneObjAlternative1::validateInput($input->{'unionOfOneObj'}, true)) ? MyClassUnionOfOneObjAlternative1::fromInput($input->{'unionOfOneObj'}, $validate) : (null)) : null;
+        $unionOfOneObj = isset($input->{'unionOfOneObj'}) ? MyClassUnionOfOneObj::fromInput($input->{'unionOfOneObj'}, $validate) : null;
         $unionOfOneNull = null;
         if (property_exists($input, 'unionOfOneNull')) {
-            $unionOfOneNull = ($input->{'unionOfOneNull'} !== null ? (((($input->{'unionOfOneNull'}) === null) || ($input->{'unionOfOneNull'} === null)) ? ($input->{'unionOfOneNull'} !== null ? $input->{'unionOfOneNull'} : null) : (null)) : null);
+            $unionOfOneNull = ($input->{'unionOfOneNull'} !== null ? $input->{'unionOfOneNull'} : null);
             $__providedOptionals['unionOfOneNull'] = true;
         }
 
@@ -461,12 +443,10 @@ class MyClass
             }
         }
         if (isset($this->unionOfOneObj)) {
-            if (($this->unionOfOneObj instanceof MyClassUnionOfOneObjAlternative1)) {
-                $output['unionOfOneObj'] = ($this->unionOfOneObj)->toArray();
-            }
+            $output['unionOfOneObj'] = ($this->unionOfOneObj)->toArray();
         }
         if (isset($this->unionOfOneNull) || array_key_exists('unionOfOneNull', $this->_providedOptionals)) {
-            $output['unionOfOneNull'] = ($this->unionOfOneNull !== null) ? (((($this->unionOfOneNull) === null) || ($this->unionOfOneNull === null)) ? (($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null) : (null)) : null;
+            $output['unionOfOneNull'] = ($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null;
         }
 
         return $output;
@@ -505,12 +485,10 @@ class MyClass
             }
         }
         if (isset($this->unionOfOneObj)) {
-            if (($this->unionOfOneObj instanceof MyClassUnionOfOneObjAlternative1)) {
             $output->{'unionOfOneObj'} = ($this->unionOfOneObj)->toStdClass();
-            }
         }
         if (isset($this->unionOfOneNull) || array_key_exists('unionOfOneNull', $this->_providedOptionals)) {
-            $output->{'unionOfOneNull'} = ($this->unionOfOneNull !== null) ? (((($this->unionOfOneNull) === null) || ($this->unionOfOneNull === null)) ? (($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null) : (null)) : null;
+            $output->{'unionOfOneNull'} = ($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null;
         }
 
         return $output;
@@ -555,10 +533,7 @@ class MyClass
             $this->objAndStringUnion = (is_string($this->objAndStringUnion)) ? ($this->objAndStringUnion) : (($this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1) ? (clone $this->objAndStringUnion) : ($this->objAndStringUnion));
         }
         if (isset($this->unionOfOneObj)) {
-            $this->unionOfOneObj = ($this->unionOfOneObj instanceof MyClassUnionOfOneObjAlternative1) ? (clone $this->unionOfOneObj) : ($this->unionOfOneObj);
-        }
-        if (isset($this->unionOfOneNull)) {
-            $this->unionOfOneNull = ((($this->unionOfOneNull) === null) || ($this->unionOfOneNull === null)) ? (isset($this->unionOfOneNull) ? (clone $this->unionOfOneNull) : null) : ($this->unionOfOneNull);
+            $this->unionOfOneObj = clone $this->unionOfOneObj;
         }
     }
 

--- a/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClassUnionOfOneObj.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClassUnionOfOneObj.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Ns\UnionObject_8_4;
+namespace Ns\UnionObject_7_4;
 
-class MyClassUnionOfOneObjAlternative1
+class MyClassUnionOfOneObj
 {
     /**
      * Schema used to validate input for creating instances of this class
@@ -68,11 +68,17 @@ class MyClassUnionOfOneObjAlternative1
      *
      * @param array|object $input Input data
      * @param bool $validate If `false`, validation against the schema will be skipped.
-     * @return MyClassUnionOfOneObjAlternative1 Created instance
+     * @return MyClassUnionOfOneObj Created instance
      * @throws \InvalidArgumentException
      */
-    public static function fromInput(array|object $input, bool $validate = true): MyClassUnionOfOneObjAlternative1
+    public static function fromInput($input, bool $validate = true): MyClassUnionOfOneObj
     {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
         $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
         if ($validate) {
             static::validateInput($input);
@@ -122,7 +128,7 @@ class MyClassUnionOfOneObjAlternative1
      * @return bool Validation result
      * @throws \InvalidArgumentException
      */
-    public static function validateInput(array|object $input, bool $return = false): bool
+    public static function validateInput($input, bool $return = false): bool
     {
         $validator = new \JsonSchema\Validator();
         $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;

--- a/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
@@ -131,7 +131,7 @@ class MyClass
 
     private MyClassObjAndStringUnionAlternative1|string|null $objAndStringUnion = null;
 
-    private ?MyClassUnionOfOneObjAlternative1 $unionOfOneObj = null;
+    private ?MyClassUnionOfOneObj $unionOfOneObj = null;
 
     /**
      * @var null
@@ -141,7 +141,7 @@ class MyClass
     /**
      * @param null $unionOfOneNull
      */
-    public function __construct(MyClassObjectsUnionAlternative1|MyClassObjectsUnionAlternative2|null $objectsUnion = null, SomeObj1|SomeObj2|null $refObjectsUnion = null, MyClassRefAndNotRefObjectsUnionAlternative2|MyClassRefAndNotRefObjectsUnionAlternative4|SomeObj1|SomeObj2|null $refAndNotRefObjectsUnion = null, MyClassObjAndStringUnionAlternative1|string|null $objAndStringUnion = null, ?MyClassUnionOfOneObjAlternative1 $unionOfOneObj = null, $unionOfOneNull = null)
+    public function __construct(MyClassObjectsUnionAlternative1|MyClassObjectsUnionAlternative2|null $objectsUnion = null, SomeObj1|SomeObj2|null $refObjectsUnion = null, MyClassRefAndNotRefObjectsUnionAlternative2|MyClassRefAndNotRefObjectsUnionAlternative4|SomeObj1|SomeObj2|null $refAndNotRefObjectsUnion = null, MyClassObjAndStringUnionAlternative1|string|null $objAndStringUnion = null, ?MyClassUnionOfOneObj $unionOfOneObj = null, $unionOfOneNull = null)
     {
         $this->objectsUnion = $objectsUnion;
         $this->refObjectsUnion = $refObjectsUnion;
@@ -235,12 +235,12 @@ class MyClass
         return $clone;
     }
 
-    public function getUnionOfOneObj(): ?MyClassUnionOfOneObjAlternative1
+    public function getUnionOfOneObj(): ?MyClassUnionOfOneObj
     {
         return $this->unionOfOneObj;
     }
 
-    public function withUnionOfOneObj(MyClassUnionOfOneObjAlternative1 $unionOfOneObj): self
+    public function withUnionOfOneObj(MyClassUnionOfOneObj $unionOfOneObj): self
     {
         $clone = clone $this;
         $clone->unionOfOneObj = $unionOfOneObj;
@@ -331,16 +331,10 @@ class MyClass
             is_string($input->{'objAndStringUnion'}) => $input->{'objAndStringUnion'},
             default => null,
         } : null;
-        $unionOfOneObj = isset($input->{'unionOfOneObj'}) ? match (true) {
-            MyClassUnionOfOneObjAlternative1::validateInput($input->{'unionOfOneObj'}, true) => MyClassUnionOfOneObjAlternative1::fromInput($input->{'unionOfOneObj'}, $validate),
-            default => null,
-        } : null;
+        $unionOfOneObj = isset($input->{'unionOfOneObj'}) ? MyClassUnionOfOneObj::fromInput($input->{'unionOfOneObj'}, $validate) : null;
         $unionOfOneNull = null;
         if (property_exists($input, 'unionOfOneNull')) {
-            $unionOfOneNull = ($input->{'unionOfOneNull'} !== null ? match (true) {
-            (($input->{'unionOfOneNull'}) === null) || ($input->{'unionOfOneNull'} === null) => ($input->{'unionOfOneNull'} !== null ? $input->{'unionOfOneNull'} : null),
-            default => null,
-        } : null);
+            $unionOfOneNull = ($input->{'unionOfOneNull'} !== null ? $input->{'unionOfOneNull'} : null);
             $__providedOptionals['unionOfOneNull'] = true;
         }
 
@@ -391,15 +385,10 @@ class MyClass
             };
         }
         if (isset($this->unionOfOneObj)) {
-            $output['unionOfOneObj'] = match (true) {
-                $this->unionOfOneObj instanceof MyClassUnionOfOneObjAlternative1 => ($this->unionOfOneObj)->toArray(),
-            };
+            $output['unionOfOneObj'] = ($this->unionOfOneObj)->toArray();
         }
         if (isset($this->unionOfOneNull) || array_key_exists('unionOfOneNull', $this->_providedOptionals)) {
-            $output['unionOfOneNull'] = ($this->unionOfOneNull !== null) ? (match (true) {
-                default => null,
-                (($this->unionOfOneNull) === null) || ($this->unionOfOneNull === null) => ($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null,
-            }) : null;
+            $output['unionOfOneNull'] = ($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null;
         }
 
         return $output;
@@ -440,15 +429,10 @@ class MyClass
             };
         }
         if (isset($this->unionOfOneObj)) {
-            $output->{'unionOfOneObj'} = match (true) {
-                $this->unionOfOneObj instanceof MyClassUnionOfOneObjAlternative1 => ($this->unionOfOneObj)->toStdClass(),
-            };
+            $output->{'unionOfOneObj'} = ($this->unionOfOneObj)->toStdClass();
         }
         if (isset($this->unionOfOneNull) || array_key_exists('unionOfOneNull', $this->_providedOptionals)) {
-            $output->{'unionOfOneNull'} = ($this->unionOfOneNull !== null) ? (match (true) {
-                default => null,
-                (($this->unionOfOneNull) === null) || ($this->unionOfOneNull === null) => ($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null,
-            }) : null;
+            $output->{'unionOfOneNull'} = ($this->unionOfOneNull !== null) ? ($this->unionOfOneNull) : null;
         }
 
         return $output;
@@ -507,14 +491,7 @@ class MyClass
             };
         }
         if (isset($this->unionOfOneObj)) {
-            $this->unionOfOneObj = match (true) {
-                $this->unionOfOneObj instanceof MyClassUnionOfOneObjAlternative1 => clone $this->unionOfOneObj,
-            };
-        }
-        if (isset($this->unionOfOneNull)) {
-            $this->unionOfOneNull = match (true) {
-                (($this->unionOfOneNull) === null) || ($this->unionOfOneNull === null) => isset($this->unionOfOneNull) ? (clone $this->unionOfOneNull) : null,
-            };
+            $this->unionOfOneObj = clone $this->unionOfOneObj;
         }
     }
 

--- a/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClassUnionOfOneObj.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClassUnionOfOneObj.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Ns\UnionObject_7_4;
+namespace Ns\UnionObject_8_4;
 
-class MyClassUnionOfOneObjAlternative1
+class MyClassUnionOfOneObj
 {
     /**
      * Schema used to validate input for creating instances of this class
@@ -68,17 +68,11 @@ class MyClassUnionOfOneObjAlternative1
      *
      * @param array|object $input Input data
      * @param bool $validate If `false`, validation against the schema will be skipped.
-     * @return MyClassUnionOfOneObjAlternative1 Created instance
+     * @return MyClassUnionOfOneObj Created instance
      * @throws \InvalidArgumentException
      */
-    public static function fromInput($input, bool $validate = true): MyClassUnionOfOneObjAlternative1
+    public static function fromInput(array|object $input, bool $validate = true): MyClassUnionOfOneObj
     {
-        if (!is_array($input) && !is_object($input)) {
-            throw new \InvalidArgumentException(
-                'Input to fromInput must be array or object, got ' . gettype($input)
-            );
-        }
-
         $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
         if ($validate) {
             static::validateInput($input);
@@ -128,7 +122,7 @@ class MyClassUnionOfOneObjAlternative1
      * @return bool Validation result
      * @throws \InvalidArgumentException
      */
-    public static function validateInput($input, bool $return = false): bool
+    public static function validateInput(array|object $input, bool $return = false): bool
     {
         $validator = new \JsonSchema\Validator();
         $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;


### PR DESCRIPTION
## Summary
- flatten anyOf/oneOf definitions with only one branch in `PropertyBuilder`
- collapse simple union type hints to a single nullable type
- update generator fixtures for new type output

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: 3 match.unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_68937deb3aa8832dbc246d636751963d