### PR TITLE
Ensure setters revalidate against full schema when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Now it:
 - Improves type hints and PHPDoc type generation for complex types like unions, nested arrays, etc.
 - Adds a guard against passing anything other than an array/object to `fromInput`, building multi-line validation error messages.
 - Setter methods (`withX()`) now accept an optional `$validate` argument to be able skip validation, mirroring `fromInput()`.
+- Setter methods now invoke full object validation when property-level schema snippets are insufficient, such as when `$ref` or conditional keywords are involved.
 - Deterministic resolution of class property, accessor method and temporary variable names via a unified resolver, allowing case-sensitive properties and avoiding collisions with reserved names.
 - Option `mutableSetters` allows generating mutable `setX()` methods (optionally chainable).
 - Skips emitting empty `__construct` or `__clone` methods.

--- a/src/Generator/Class/Method/SetterFactory.php
+++ b/src/Generator/Class/Method/SetterFactory.php
@@ -23,6 +23,8 @@ class SetterFactory
     private bool $mutating;
     private bool $chainable;
 
+    private ?bool $fullSchemaValidation = null;
+
     public function __construct(
         private GeneratorRequest $request,
     ) {
@@ -52,12 +54,19 @@ class SetterFactory
         $propAnnotatedType = $paramProperty->typeAnnotation();
         $propTypeHint = $paramProperty->typeHint();
 
-        // Determine whether setter needs runtime validation.
-        $addValidation = $property->needsValidation();
+        // Determine whether setter needs runtime validation and whether
+        // validation must be performed against the full schema or just the
+        // property fragment.
+        $schemaRequiresFullValidation = $this->schemaRequiresFullValidation();
+        $propertyNeedsValidation = $property->needsValidation();
+        $propertyHasRef = $propertyNeedsValidation && $this->schemaHasRef($property->schema());
+
+        $addValidation = $propertyNeedsValidation || $schemaRequiresFullValidation;
+        $fullValidation = $schemaRequiresFullValidation || $propertyHasRef;
 
         $docBlock = $this->buildDocBlock($property, $varName, $propAnnotatedType, $propTypeHint, $addValidation);
         $parameters = $this->buildParams($varName, $propTypeHint, $addValidation);
-        $body = $this->generateBody($property, $propName, $varName, $addValidation);
+        $body = $this->generateBody($property, $propName, $varName, $addValidation, $fullValidation);
 
         $methodGen = new MethodGenerator(
             name: $methodName,
@@ -76,6 +85,37 @@ class SetterFactory
         }
 
         return $methodGen;
+    }
+
+    private function schemaRequiresFullValidation(): bool
+    {
+        if ($this->fullSchemaValidation !== null) {
+            return $this->fullSchemaValidation;
+        }
+
+        $schema = $this->request->getSchema();
+        foreach (['if', 'then', 'else', 'dependencies', 'dependentRequired', 'dependentSchemas'] as $k) {
+            if (array_key_exists($k, $schema)) {
+                return $this->fullSchemaValidation = true;
+            }
+        }
+
+        return $this->fullSchemaValidation = false;
+    }
+
+    private function schemaHasRef(array $schema): bool
+    {
+        if (array_key_exists('$ref', $schema)) {
+            return true;
+        }
+
+        foreach ($schema as $v) {
+            if (is_array($v) && $this->schemaHasRef($v)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function buildDocBlock(
@@ -134,12 +174,18 @@ class SetterFactory
         return $parameters;
     }
 
-    private function generateBody(PropertyInterface $property, string $propName, string $varName, bool $addValidation): string
+    private function generateBody(
+        PropertyInterface $property,
+        string $propName,
+        string $varName,
+        bool $addValidation,
+        bool $fullValidation,
+    ): string
     {
         $propKey = $property->keyStr();
 
         $validationBlock = '';
-        if ($addValidation) {
+        if ($addValidation && !$fullValidation) {
             $newValidatorExpr = $this->request->getOptions()->getNewValidatorExpr();
 
             $SCHEMA = PropertyNames::SCHEMA;
@@ -166,6 +212,10 @@ class SetterFactory
                 $body .= "\n\$this->{$OPTIONALS}[{$propKey}] = true;";
             }
 
+            if ($addValidation && $fullValidation) {
+                $body .= "\nif (\$validate) {\n    \$this->validate();\n}\n";
+            }
+
             if ($this->chainable) {
                 $body .= "\n\nreturn \$this;";
             }
@@ -178,6 +228,10 @@ class SetterFactory
 
             if ($property instanceof OptionalPropertyDecorator && $property->isOptionalNullable()) {
                 $body .= "\${$CLONE}->{$OPTIONALS}[{$propKey}] = true;\n";
+            }
+
+            if ($addValidation && $fullValidation) {
+                $body .= "\nif (\$validate) {\n    \${$CLONE}->validate();\n}\n";
             }
 
             $body .= "\nreturn \${$CLONE};";

--- a/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Record.php
@@ -61,16 +61,12 @@ class Record
      */
     public function withDataArray(array $dataArray, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArray, self::$_schema['properties']['dataArray']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArray = $dataArray;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-5.6/Foo.php
@@ -76,16 +76,12 @@ class Foo
      */
     public function withColor($color, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($color, self::$_schema['properties']['color']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->color = $color;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -105,16 +101,12 @@ class Foo
      */
     public function withSize($size, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($size, self::$_schema['properties']['size']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->size = $size;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-7.4/Foo.php
@@ -76,16 +76,12 @@ class Foo
      */
     public function withColor(string $color, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($color, self::$_schema['properties']['color']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->color = $color;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -103,16 +99,12 @@ class Foo
      */
     public function withSize(string $size, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($size, self::$_schema['properties']['size']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->size = $size;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-5.6/Foo.php
@@ -64,16 +64,12 @@ class Foo
      */
     public function withVal($val, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($val, self::$_schema['properties']['val']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->val = $val;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-7.4/Foo.php
@@ -64,16 +64,12 @@ class Foo
      */
     public function withVal($val, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($val, self::$_schema['properties']['val']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->val = $val;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-8.4/Foo.php
@@ -64,16 +64,12 @@ class Foo
      */
     public function withVal(int|string $val, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($val, self::$_schema['properties']['val']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->val = $val;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
@@ -155,16 +155,12 @@ class Foo
      */
     public function withFloatEnumRef($floatEnumRef, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($floatEnumRef, self::$_schema['properties']['floatEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->floatEnumRef = $floatEnumRef;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -235,16 +231,12 @@ class Foo
      */
     public function withBoolEnumRef($boolEnumRef, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($boolEnumRef, self::$_schema['properties']['boolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->boolEnumRef = $boolEnumRef;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -275,16 +267,12 @@ class Foo
      */
     public function withRequiredBoolEnumRef($requiredBoolEnumRef, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($requiredBoolEnumRef, self::$_schema['properties']['requiredBoolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->requiredBoolEnumRef = $requiredBoolEnumRef;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
@@ -150,16 +150,12 @@ class Foo
      */
     public function withFloatEnumRef($floatEnumRef, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($floatEnumRef, self::$_schema['properties']['floatEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->floatEnumRef = $floatEnumRef;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -220,16 +216,12 @@ class Foo
      */
     public function withBoolEnumRef(bool $boolEnumRef, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($boolEnumRef, self::$_schema['properties']['boolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->boolEnumRef = $boolEnumRef;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -255,16 +247,12 @@ class Foo
      */
     public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($requiredBoolEnumRef, self::$_schema['properties']['requiredBoolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->requiredBoolEnumRef = $requiredBoolEnumRef;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
@@ -150,16 +150,12 @@ class Foo
      */
     public function withFloatEnumRef(int|float $floatEnumRef, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($floatEnumRef, self::$_schema['properties']['floatEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->floatEnumRef = $floatEnumRef;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -220,16 +216,12 @@ class Foo
      */
     public function withBoolEnumRef(bool $boolEnumRef, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($boolEnumRef, self::$_schema['properties']['boolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->boolEnumRef = $boolEnumRef;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -255,16 +247,12 @@ class Foo
      */
     public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($requiredBoolEnumRef, self::$_schema['properties']['requiredBoolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->requiredBoolEnumRef = $requiredBoolEnumRef;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
@@ -82,16 +82,12 @@ class BarTest
      */
     public function withExampleProp($exampleProp, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($exampleProp, self::$_schema['properties']['exampleProp']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->exampleProp = $exampleProp;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -82,16 +82,12 @@ class BarTest
      */
     public function withExampleProp(object $exampleProp, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($exampleProp, self::$_schema['properties']['exampleProp']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->exampleProp = $exampleProp;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -522,16 +522,12 @@ class MyClass
      */
     public function withXyyz(ObjDef|string|array $xyyz, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($xyyz, self::$_schema['properties']['xyyz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->xyyz = $xyyz;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -557,16 +553,12 @@ class MyClass
      */
     public function withBuux(ObjDef|string|array $buux, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($buux, self::$_schema['properties']['buux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->buux = $buux;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -592,16 +584,12 @@ class MyClass
      */
     public function withBoic(ObjDef|string|array $boic, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($boic, self::$_schema['properties']['boic']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->boic = $boic;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
@@ -74,16 +74,12 @@ class MyClass
      */
     public function withFiles(array $files, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
@@ -70,16 +70,12 @@ class MyClass
      */
     public function withFiles(array $files, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
@@ -70,16 +70,12 @@ class MyClass
      */
     public function withFiles(array $files, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Record.php
@@ -137,16 +137,12 @@ class Record
      */
     public function withDataArray(array $dataArray, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArray, self::$_schema['properties']['dataArray']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArray = $dataArray;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -177,16 +173,12 @@ class Record
      */
     public function withDataArrayNested(array $dataArrayNested, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayNested, self::$_schema['properties']['dataArrayNested']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayNested = $dataArrayNested;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -217,16 +209,12 @@ class Record
      */
     public function withDataArrayAnyOf(array $dataArrayAnyOf, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayAnyOf, self::$_schema['properties']['dataArrayAnyOf']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayAnyOf = $dataArrayAnyOf;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -257,16 +245,12 @@ class Record
      */
     public function withDataArrayNestedAnyOf(array $dataArrayNestedAnyOf, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayNestedAnyOf, self::$_schema['properties']['dataArrayNestedAnyOf']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayNestedAnyOf = $dataArrayNestedAnyOf;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Record.php
@@ -137,16 +137,12 @@ class Record
      */
     public function withDataArray(array $dataArray, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArray, self::$_schema['properties']['dataArray']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArray = $dataArray;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -172,16 +168,12 @@ class Record
      */
     public function withDataArrayNested(array $dataArrayNested, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayNested, self::$_schema['properties']['dataArrayNested']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayNested = $dataArrayNested;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -207,16 +199,12 @@ class Record
      */
     public function withDataArrayAnyOf(array $dataArrayAnyOf, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayAnyOf, self::$_schema['properties']['dataArrayAnyOf']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayAnyOf = $dataArrayAnyOf;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -242,16 +230,12 @@ class Record
      */
     public function withDataArrayNestedAnyOf(array $dataArrayNestedAnyOf, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayNestedAnyOf, self::$_schema['properties']['dataArrayNestedAnyOf']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayNestedAnyOf = $dataArrayNestedAnyOf;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Record.php
@@ -137,16 +137,12 @@ class Record
      */
     public function withDataArray(array $dataArray, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArray, self::$_schema['properties']['dataArray']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArray = $dataArray;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -172,16 +168,12 @@ class Record
      */
     public function withDataArrayNested(array $dataArrayNested, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayNested, self::$_schema['properties']['dataArrayNested']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayNested = $dataArrayNested;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -207,16 +199,12 @@ class Record
      */
     public function withDataArrayAnyOf(array $dataArrayAnyOf, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayAnyOf, self::$_schema['properties']['dataArrayAnyOf']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayAnyOf = $dataArrayAnyOf;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -242,16 +230,12 @@ class Record
      */
     public function withDataArrayNestedAnyOf(array $dataArrayNestedAnyOf, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayNestedAnyOf, self::$_schema['properties']['dataArrayNestedAnyOf']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayNestedAnyOf = $dataArrayNestedAnyOf;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
@@ -82,16 +82,12 @@ class Baz
      */
     public function withGrox($grox, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($grox, self::$_schema['properties']['grox']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->grox = $grox;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -95,16 +95,12 @@ class Qux
      */
     public function withGrox($grox, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($grox, self::$_schema['properties']['grox']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->grox = $grox;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -82,16 +82,12 @@ class Baz
      */
     public function withGrox(object $grox, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($grox, self::$_schema['properties']['grox']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->grox = $grox;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -95,16 +95,12 @@ class Qux
      */
     public function withGrox($grox, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($grox, self::$_schema['properties']['grox']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->grox = $grox;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
@@ -95,16 +95,12 @@ class Qux
      */
     public function withGrox(Bar|Foo|string|array $grox, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($grox, self::$_schema['properties']['grox']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->grox = $grox;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/RefList/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-5.6/MyClass.php
@@ -51,16 +51,12 @@ class MyClass
      */
     public function withFoo(array $foo, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/RefList/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-7.4/MyClass.php
@@ -51,16 +51,12 @@ class MyClass
      */
     public function withFoo(array $foo, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/RefList/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-8.4/MyClass.php
@@ -51,16 +51,12 @@ class MyClass
      */
     public function withFoo(array $foo, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/ReferenceArrayProperty/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ReferenceArrayProperty/Output-5.6/MyClass.php
@@ -79,16 +79,12 @@ class MyClass
      */
     public function withFoo(array $foo, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/ReferenceArrayProperty/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ReferenceArrayProperty/Output-8.4/MyClass.php
@@ -79,16 +79,12 @@ class MyClass
      */
     public function withFoo(array $foo, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
@@ -76,16 +76,12 @@ class MyObject
      */
     public function withFoo($foo, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
@@ -76,16 +76,12 @@ class MyObject
      */
     public function withFoo(string $foo, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/IfThenElse.php
+++ b/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/IfThenElse.php
@@ -86,10 +86,14 @@ class IfThenElse
         return $this->kind;
     }
 
-    public function withKind(?string $kind): self
+    public function withKind(?string $kind, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->kind = $kind;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -105,10 +109,14 @@ class IfThenElse
     /**
      * @param mixed $value
      */
-    public function withValue($value): self
+    public function withValue($value, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->value = $value;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
+++ b/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
@@ -84,16 +84,12 @@ class RefValidation
      */
     public function withFoo(int $foo, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -123,16 +119,12 @@ class RefValidation
      */
     public function withBar(int|string $bar, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidationBaz.php
+++ b/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidationBaz.php
@@ -55,16 +55,12 @@ class RefValidationBaz
      */
     public function withNestedFoo(int $nestedFoo, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($nestedFoo, self::$_schema['properties']['nestedFoo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->nestedFoo = $nestedFoo;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
@@ -170,16 +170,12 @@ class MyClass
      */
     public function withBar($bar, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -199,16 +195,12 @@ class MyClass
      */
     public function withBaz($baz, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($baz, self::$_schema['properties']['baz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->baz = $baz;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -228,16 +220,12 @@ class MyClass
      */
     public function withQux($qux, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($qux, self::$_schema['properties']['qux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->qux = $qux;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -138,16 +138,12 @@ class MyClass
 
     public function withBar(string $bar, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -159,16 +155,12 @@ class MyClass
 
     public function withBaz(string $baz, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($baz, self::$_schema['properties']['baz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->baz = $baz;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -180,16 +172,12 @@ class MyClass
 
     public function withQux(?string $qux, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($qux, self::$_schema['properties']['qux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->qux = $qux;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -138,16 +138,12 @@ class MyClass
 
     public function withBar(string $bar, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -159,16 +155,12 @@ class MyClass
 
     public function withBaz(string $baz, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($baz, self::$_schema['properties']['baz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->baz = $baz;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -180,16 +172,12 @@ class MyClass
 
     public function withQux(?string $qux, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($qux, self::$_schema['properties']['qux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->qux = $qux;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
@@ -215,16 +215,12 @@ class MyClass
      */
     public function withRefObjectsUnion(object $refObjectsUnion, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($refObjectsUnion, self::$_schema['properties']['refObjectsUnion']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->refObjectsUnion = $refObjectsUnion;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -250,16 +246,12 @@ class MyClass
      */
     public function withRefAndNotRefObjectsUnion(object $refAndNotRefObjectsUnion, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($refAndNotRefObjectsUnion, self::$_schema['properties']['refAndNotRefObjectsUnion']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->refAndNotRefObjectsUnion = $refAndNotRefObjectsUnion;
+
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }


### PR DESCRIPTION
## Summary
- Detect `$ref` usage and cross-property conditionals when generating setters
- Revalidate the whole object instead of a property fragment when necessary
- Regenerate fixtures and document the change

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68952b0fbf28832d9b661222da6b97c4