### PR TITLE
Use full schema validation in setters with references or cross-property rules

### DIFF
--- a/src/Generator/Class/Method/SetterFactory.php
+++ b/src/Generator/Class/Method/SetterFactory.php
@@ -22,6 +22,11 @@ class SetterFactory
 
     private bool $mutating;
     private bool $chainable;
+    /**
+     * Whether the whole object must be revalidated on each setter call
+     * due to cross-property constraints in the schema.
+     */
+    private bool $alwaysRevalidate;
 
     public function __construct(
         private GeneratorRequest $request,
@@ -29,6 +34,7 @@ class SetterFactory
         $mutableConfig = $this->request->getMutableSetters();
         $this->mutating = $mutableConfig !== null;
         $this->chainable = $mutableConfig === 'chainable' || $this->mutating === false;
+        $this->alwaysRevalidate = $this->schemaRequiresFullValidation($request->getSchema());
     }
 
     public function generateSetter(PropertyInterface $property): ?MethodGenerator
@@ -52,12 +58,18 @@ class SetterFactory
         $propAnnotatedType = $paramProperty->typeAnnotation();
         $propTypeHint = $paramProperty->typeHint();
 
-        // Determine whether setter needs runtime validation.
-        $addValidation = $property->needsValidation();
+        // Determine whether setter needs runtime validation.  Validation is required
+        // when the property itself has constraints that are not enforced by PHP's
+        // type system or when the class schema contains cross-property constraints
+        // (like `if`/`then`/`else`) that may be invalidated by changing any property.
+        $needsValidation = $property->needsValidation();
+        $propRequiresFullValidation = $needsValidation && $this->schemaContainsRef($property->schema());
+        $fullRevalidation = $this->alwaysRevalidate || $propRequiresFullValidation;
+        $addValidation = $needsValidation || $this->alwaysRevalidate;
 
         $docBlock = $this->buildDocBlock($property, $varName, $propAnnotatedType, $propTypeHint, $addValidation);
         $parameters = $this->buildParams($varName, $propTypeHint, $addValidation);
-        $body = $this->generateBody($property, $propName, $varName, $addValidation);
+        $body = $this->generateBody($property, $propName, $varName, $addValidation, $fullRevalidation);
 
         $methodGen = new MethodGenerator(
             name: $methodName,
@@ -134,9 +146,58 @@ class SetterFactory
         return $parameters;
     }
 
-    private function generateBody(PropertyInterface $property, string $propName, string $varName, bool $addValidation): string
-    {
+    private function generateBody(
+        PropertyInterface $property,
+        string $propName,
+        string $varName,
+        bool $addValidation,
+        bool $fullRevalidation
+    ): string {
         $propKey = $property->keyStr();
+
+        $OPTIONALS = PropertyNames::OPTIONALS;
+
+        if ($fullRevalidation) {
+            if ($this->mutating) {
+                $CLONE = self::CLONE_VAR_NAME;
+                $body = "if (\$validate) {\n";
+                $body .= "    \${$CLONE} = clone \$this;\n";
+                $body .= "    \${$CLONE}->$propName = \$$varName;\n";
+                if ($property instanceof OptionalPropertyDecorator && $property->isOptionalNullable()) {
+                    $body .= "    \${$CLONE}->{$OPTIONALS}[{$propKey}] = true;\n";
+                }
+                $body .= "    \${$CLONE}->validate();\n";
+                $body .= "    \$this->{$propName} = \${$CLONE}->$propName;\n";
+                if ($property instanceof OptionalPropertyDecorator && $property->isOptionalNullable()) {
+                    $body .= "    \$this->{$OPTIONALS}[{$propKey}] = true;\n";
+                }
+                $body .= "} else {\n";
+                $body .= "    \$this->{$propName} = \$$varName;\n";
+                if ($property instanceof OptionalPropertyDecorator && $property->isOptionalNullable()) {
+                    $body .= "    \$this->{$OPTIONALS}[{$propKey}] = true;\n";
+                }
+                $body .= "}\n";
+
+                if ($this->chainable) {
+                    $body .= "\nreturn \$this;";
+                }
+
+                return $body;
+            }
+
+            $CLONE = self::CLONE_VAR_NAME;
+            $body = "\${$CLONE} = clone \$this;\n";
+            $body .= "\${$CLONE}->$propName = \$$varName;\n";
+            if ($property instanceof OptionalPropertyDecorator && $property->isOptionalNullable()) {
+                $body .= "\${$CLONE}->{$OPTIONALS}[{$propKey}] = true;\n";
+            }
+            if ($addValidation) {
+                $body .= "if (\$validate) {\n    \${$CLONE}->validate();\n}\n";
+            }
+            $body .= "\nreturn \${$CLONE};";
+
+            return $body;
+        }
 
         $validationBlock = '';
         if ($addValidation) {
@@ -154,8 +215,6 @@ class SetterFactory
                 }\n\n
                 PHP;
         }
-
-        $OPTIONALS = PropertyNames::OPTIONALS;
 
         if ($this->mutating) {
             $body =
@@ -184,5 +243,32 @@ class SetterFactory
         }
 
         return $body;
+    }
+
+    private function schemaContainsRef(array $schema): bool
+    {
+        if (isset($schema['$ref'])) {
+            return true;
+        }
+
+        foreach ($schema as $value) {
+            if (is_array($value) && $this->schemaContainsRef($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function schemaRequiresFullValidation(array $schema): bool
+    {
+        $keywords = ['if', 'then', 'else', 'allOf', 'anyOf', 'oneOf', 'not', 'dependencies', 'dependentRequired', 'dependentSchemas'];
+        foreach ($keywords as $kw) {
+            if (array_key_exists($kw, $schema)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Generator/Fixtures/AllOf/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AllOf/Output-8.4/MyClass.php
@@ -73,10 +73,13 @@ class MyClass
     /**
      * Descr for 'street_address'
      */
-    public function withStreetAddress(string $streetAddress): self
+    public function withStreetAddress(string $streetAddress, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->streetAddress = $streetAddress;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -92,10 +95,13 @@ class MyClass
     /**
      * Descr for 'house_number'
      */
-    public function withHouseNumber(string $houseNumber): self
+    public function withHouseNumber(string $houseNumber, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->houseNumber = $houseNumber;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -119,10 +125,13 @@ class MyClass
     /**
      * Descr for 'type'
      */
-    public function withType(MyClassType $type): self
+    public function withType(MyClassType $type, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->type = $type;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -146,10 +155,13 @@ class MyClass
     /**
      * Descr for 'city'
      */
-    public function withCity(string $city): self
+    public function withCity(string $city, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->city = $city;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -173,10 +185,13 @@ class MyClass
     /**
      * Descr for 'state'
      */
-    public function withState(string $state): self
+    public function withState(string $state, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->state = $state;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/AllOfRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output-5.6/MyClass.php
@@ -71,16 +71,11 @@ class MyClass
      */
     public function withCity($city, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($city, self::$_schema['properties']['city']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->city = $city;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -100,16 +95,11 @@ class MyClass
      */
     public function withStreet($street, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($street, self::$_schema['properties']['street']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->street = $street;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -129,16 +119,11 @@ class MyClass
      */
     public function withCountry($country, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($country, self::$_schema['properties']['country']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->country = $country;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/AllOfRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output-7.4/MyClass.php
@@ -51,16 +51,11 @@ class MyClass
 
     public function withCity(string $city, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($city, self::$_schema['properties']['city']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->city = $city;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -70,10 +65,13 @@ class MyClass
         return $this->street;
     }
 
-    public function withStreet(string $street): self
+    public function withStreet(string $street, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->street = $street;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -83,10 +81,13 @@ class MyClass
         return $this->country;
     }
 
-    public function withCountry(string $country): self
+    public function withCountry(string $country, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->country = $country;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/AllOfRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AllOfRef/Output-8.4/MyClass.php
@@ -51,16 +51,11 @@ class MyClass
 
     public function withCity(string $city, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($city, self::$_schema['properties']['city']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->city = $city;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -70,10 +65,13 @@ class MyClass
         return $this->street;
     }
 
-    public function withStreet(string $street): self
+    public function withStreet(string $street, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->street = $street;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -83,10 +81,13 @@ class MyClass
         return $this->country;
     }
 
-    public function withCountry(string $country): self
+    public function withCountry(string $country, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->country = $country;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/ArrayProperty/Output-8.4/Record.php
@@ -61,16 +61,11 @@ class Record
      */
     public function withDataArray(array $dataArray, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArray, self::$_schema['properties']['dataArray']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArray = $dataArray;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-5.6/Foo.php
@@ -76,16 +76,11 @@ class Foo
      */
     public function withColor($color, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($color, self::$_schema['properties']['color']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->color = $color;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -105,16 +100,11 @@ class Foo
      */
     public function withSize($size, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($size, self::$_schema['properties']['size']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->size = $size;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/DefinitionsEnum/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsEnum/Output-7.4/Foo.php
@@ -76,16 +76,11 @@ class Foo
      */
     public function withColor(string $color, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($color, self::$_schema['properties']['color']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->color = $color;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -103,16 +98,11 @@ class Foo
      */
     public function withSize(string $size, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($size, self::$_schema['properties']['size']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->size = $size;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-5.6/Foo.php
@@ -64,16 +64,11 @@ class Foo
      */
     public function withVal($val, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($val, self::$_schema['properties']['val']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->val = $val;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-7.4/Foo.php
@@ -64,16 +64,11 @@ class Foo
      */
     public function withVal($val, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($val, self::$_schema['properties']['val']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->val = $val;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/DefinitionsMixedEnum/Output-8.4/Foo.php
@@ -64,16 +64,11 @@ class Foo
      */
     public function withVal(int|string $val, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($val, self::$_schema['properties']['val']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->val = $val;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-5.6/Foo.php
@@ -155,16 +155,11 @@ class Foo
      */
     public function withFloatEnumRef($floatEnumRef, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($floatEnumRef, self::$_schema['properties']['floatEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->floatEnumRef = $floatEnumRef;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -235,16 +230,11 @@ class Foo
      */
     public function withBoolEnumRef($boolEnumRef, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($boolEnumRef, self::$_schema['properties']['boolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->boolEnumRef = $boolEnumRef;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -275,16 +265,11 @@ class Foo
      */
     public function withRequiredBoolEnumRef($requiredBoolEnumRef, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($requiredBoolEnumRef, self::$_schema['properties']['requiredBoolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->requiredBoolEnumRef = $requiredBoolEnumRef;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-7.4/Foo.php
@@ -150,16 +150,11 @@ class Foo
      */
     public function withFloatEnumRef($floatEnumRef, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($floatEnumRef, self::$_schema['properties']['floatEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->floatEnumRef = $floatEnumRef;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -220,16 +215,11 @@ class Foo
      */
     public function withBoolEnumRef(bool $boolEnumRef, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($boolEnumRef, self::$_schema['properties']['boolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->boolEnumRef = $boolEnumRef;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -255,16 +245,11 @@ class Foo
      */
     public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($requiredBoolEnumRef, self::$_schema['properties']['requiredBoolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->requiredBoolEnumRef = $requiredBoolEnumRef;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/EnumUnsupported/Output-8.4/Foo.php
@@ -150,16 +150,11 @@ class Foo
      */
     public function withFloatEnumRef(int|float $floatEnumRef, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($floatEnumRef, self::$_schema['properties']['floatEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->floatEnumRef = $floatEnumRef;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -220,16 +215,11 @@ class Foo
      */
     public function withBoolEnumRef(bool $boolEnumRef, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($boolEnumRef, self::$_schema['properties']['boolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->boolEnumRef = $boolEnumRef;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -255,16 +245,11 @@ class Foo
      */
     public function withRequiredBoolEnumRef(bool $requiredBoolEnumRef, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($requiredBoolEnumRef, self::$_schema['properties']['requiredBoolEnumRef']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->requiredBoolEnumRef = $requiredBoolEnumRef;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
@@ -82,16 +82,11 @@ class BarTest
      */
     public function withExampleProp($exampleProp, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($exampleProp, self::$_schema['properties']['exampleProp']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->exampleProp = $exampleProp;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -82,16 +82,11 @@ class BarTest
      */
     public function withExampleProp(object $exampleProp, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($exampleProp, self::$_schema['properties']['exampleProp']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->exampleProp = $exampleProp;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -522,16 +522,11 @@ class MyClass
      */
     public function withXyyz(ObjDef|string|array $xyyz, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($xyyz, self::$_schema['properties']['xyyz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->xyyz = $xyyz;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -557,16 +552,11 @@ class MyClass
      */
     public function withBuux(ObjDef|string|array $buux, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($buux, self::$_schema['properties']['buux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->buux = $buux;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -592,16 +582,11 @@ class MyClass
      */
     public function withBoic(ObjDef|string|array $boic, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($boic, self::$_schema['properties']['boic']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->boic = $boic;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
@@ -74,16 +74,11 @@ class MyClass
      */
     public function withFiles(array $files, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
@@ -70,16 +70,11 @@ class MyClass
      */
     public function withFiles(array $files, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
@@ -70,16 +70,11 @@ class MyClass
      */
     public function withFiles(array $files, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-5.6/Record.php
@@ -137,16 +137,11 @@ class Record
      */
     public function withDataArray(array $dataArray, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArray, self::$_schema['properties']['dataArray']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArray = $dataArray;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -177,16 +172,11 @@ class Record
      */
     public function withDataArrayNested(array $dataArrayNested, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayNested, self::$_schema['properties']['dataArrayNested']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayNested = $dataArrayNested;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -217,16 +207,11 @@ class Record
      */
     public function withDataArrayAnyOf(array $dataArrayAnyOf, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayAnyOf, self::$_schema['properties']['dataArrayAnyOf']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayAnyOf = $dataArrayAnyOf;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -257,16 +242,11 @@ class Record
      */
     public function withDataArrayNestedAnyOf(array $dataArrayNestedAnyOf, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayNestedAnyOf, self::$_schema['properties']['dataArrayNestedAnyOf']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayNestedAnyOf = $dataArrayNestedAnyOf;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-7.4/Record.php
@@ -137,16 +137,11 @@ class Record
      */
     public function withDataArray(array $dataArray, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArray, self::$_schema['properties']['dataArray']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArray = $dataArray;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -172,16 +167,11 @@ class Record
      */
     public function withDataArrayNested(array $dataArrayNested, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayNested, self::$_schema['properties']['dataArrayNested']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayNested = $dataArrayNested;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -207,16 +197,11 @@ class Record
      */
     public function withDataArrayAnyOf(array $dataArrayAnyOf, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayAnyOf, self::$_schema['properties']['dataArrayAnyOf']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayAnyOf = $dataArrayAnyOf;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -242,16 +227,11 @@ class Record
      */
     public function withDataArrayNestedAnyOf(array $dataArrayNestedAnyOf, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayNestedAnyOf, self::$_schema['properties']['dataArrayNestedAnyOf']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayNestedAnyOf = $dataArrayNestedAnyOf;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/NestedTypedArrayProperty/Output-8.4/Record.php
@@ -137,16 +137,11 @@ class Record
      */
     public function withDataArray(array $dataArray, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArray, self::$_schema['properties']['dataArray']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArray = $dataArray;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -172,16 +167,11 @@ class Record
      */
     public function withDataArrayNested(array $dataArrayNested, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayNested, self::$_schema['properties']['dataArrayNested']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayNested = $dataArrayNested;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -207,16 +197,11 @@ class Record
      */
     public function withDataArrayAnyOf(array $dataArrayAnyOf, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayAnyOf, self::$_schema['properties']['dataArrayAnyOf']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayAnyOf = $dataArrayAnyOf;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -242,16 +227,11 @@ class Record
      */
     public function withDataArrayNestedAnyOf(array $dataArrayNestedAnyOf, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($dataArrayNestedAnyOf, self::$_schema['properties']['dataArrayNestedAnyOf']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->dataArrayNestedAnyOf = $dataArrayNestedAnyOf;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
@@ -82,16 +82,11 @@ class Baz
      */
     public function withGrox($grox, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($grox, self::$_schema['properties']['grox']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->grox = $grox;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -95,16 +95,11 @@ class Qux
      */
     public function withGrox($grox, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($grox, self::$_schema['properties']['grox']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->grox = $grox;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -82,16 +82,11 @@ class Baz
      */
     public function withGrox(object $grox, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($grox, self::$_schema['properties']['grox']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->grox = $grox;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -95,16 +95,11 @@ class Qux
      */
     public function withGrox($grox, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($grox, self::$_schema['properties']['grox']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->grox = $grox;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
@@ -95,16 +95,11 @@ class Qux
      */
     public function withGrox(Bar|Foo|string|array $grox, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($grox, self::$_schema['properties']['grox']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->grox = $grox;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/RefList/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-5.6/MyClass.php
@@ -51,16 +51,11 @@ class MyClass
      */
     public function withFoo(array $foo, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/RefList/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-7.4/MyClass.php
@@ -51,16 +51,11 @@ class MyClass
      */
     public function withFoo(array $foo, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/RefList/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/RefList/Output-8.4/MyClass.php
@@ -51,16 +51,11 @@ class MyClass
      */
     public function withFoo(array $foo, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/ReferenceArrayProperty/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ReferenceArrayProperty/Output-5.6/MyClass.php
@@ -79,16 +79,11 @@ class MyClass
      */
     public function withFoo(array $foo, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/ReferenceArrayProperty/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ReferenceArrayProperty/Output-8.4/MyClass.php
@@ -79,16 +79,11 @@ class MyClass
      */
     public function withFoo(array $foo, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
@@ -76,16 +76,11 @@ class MyObject
      */
     public function withFoo($foo, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
@@ -76,16 +76,11 @@ class MyObject
      */
     public function withFoo(string $foo, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/IfThenElse.php
+++ b/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/IfThenElse.php
@@ -86,10 +86,13 @@ class IfThenElse
         return $this->kind;
     }
 
-    public function withKind(?string $kind): self
+    public function withKind(?string $kind, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->kind = $kind;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -105,10 +108,13 @@ class IfThenElse
     /**
      * @param mixed $value
      */
-    public function withValue($value): self
+    public function withValue($value, bool $validate = true): self
     {
         $clone = clone $this;
         $clone->value = $value;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
+++ b/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
@@ -84,16 +84,11 @@ class RefValidation
      */
     public function withFoo(int $foo, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($foo, self::$_schema['properties']['foo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->foo = $foo;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -123,16 +118,11 @@ class RefValidation
      */
     public function withBar(int|string $bar, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidationBaz.php
+++ b/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidationBaz.php
@@ -55,16 +55,11 @@ class RefValidationBaz
      */
     public function withNestedFoo(int $nestedFoo, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($nestedFoo, self::$_schema['properties']['nestedFoo']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->nestedFoo = $nestedFoo;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
@@ -170,16 +170,11 @@ class MyClass
      */
     public function withBar($bar, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -199,16 +194,11 @@ class MyClass
      */
     public function withBaz($baz, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($baz, self::$_schema['properties']['baz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->baz = $baz;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -228,16 +218,11 @@ class MyClass
      */
     public function withQux($qux, $validate = true)
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($qux, self::$_schema['properties']['qux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->qux = $qux;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -138,16 +138,11 @@ class MyClass
 
     public function withBar(string $bar, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -159,16 +154,11 @@ class MyClass
 
     public function withBaz(string $baz, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($baz, self::$_schema['properties']['baz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->baz = $baz;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -180,16 +170,11 @@ class MyClass
 
     public function withQux(?string $qux, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($qux, self::$_schema['properties']['qux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->qux = $qux;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -138,16 +138,11 @@ class MyClass
 
     public function withBar(string $bar, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($bar, self::$_schema['properties']['bar']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->bar = $bar;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -159,16 +154,11 @@ class MyClass
 
     public function withBaz(string $baz, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($baz, self::$_schema['properties']['baz']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->baz = $baz;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -180,16 +170,11 @@ class MyClass
 
     public function withQux(?string $qux, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($qux, self::$_schema['properties']['qux']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->qux = $qux;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }

--- a/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
@@ -215,16 +215,11 @@ class MyClass
      */
     public function withRefObjectsUnion(object $refObjectsUnion, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($refObjectsUnion, self::$_schema['properties']['refObjectsUnion']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->refObjectsUnion = $refObjectsUnion;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }
@@ -250,16 +245,11 @@ class MyClass
      */
     public function withRefAndNotRefObjectsUnion(object $refAndNotRefObjectsUnion, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($refAndNotRefObjectsUnion, self::$_schema['properties']['refAndNotRefObjectsUnion']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->refAndNotRefObjectsUnion = $refAndNotRefObjectsUnion;
+        if ($validate) {
+            $clone->validate();
+        }
 
         return $clone;
     }


### PR DESCRIPTION
## Summary
- call `validate()` on the whole object when setters involve `$ref` or schema-wide conditions
- regenerate fixture outputs to reflect full validation in setters

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68952b0fbf28832d9b661222da6b97c4