### PR TITLE
Support typed additionalProperties in object schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Now it:
 - Improves type hints and PHPDoc type generation for complex types like unions, nested arrays, etc.
 - Adds a guard against passing anything other than an array/object to `fromInput`, building multi-line validation error messages.
 - Setter methods (`withX()`) now accept an optional `$validate` argument to be able skip validation, mirroring `fromInput()`.
+- Generates classes for schemas that combine explicit `properties` with typed `additionalProperties`.
 - Deterministic resolution of class property, accessor method and temporary variable names via a unified resolver, allowing case-sensitive properties and avoiding collisions with reserved names.
 - Option `mutableSetters` allows generating mutable `setX()` methods (optionally chainable).
 - Skips emitting empty `__construct` or `__clone` methods.

--- a/src/Generator/Class/Method/AdditionalProperties/AdditionalPropGetterFactory.php
+++ b/src/Generator/Class/Method/AdditionalProperties/AdditionalPropGetterFactory.php
@@ -49,7 +49,7 @@ class AdditionalPropGetterFactory
         $tags = [
             new ParamTag(
                 variableName: ArgumentNames::AS_ARRAY,
-                types: 'bool',
+                types: ['bool'],
                 description: 'Whether return an associative array instead of `stdClass` object.',
             ),
         ];

--- a/src/Generator/Class/Method/AdditionalProperties/AdditionalPropsMethodsFactory.php
+++ b/src/Generator/Class/Method/AdditionalProperties/AdditionalPropsMethodsFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator\Class\Method\AdditionalProperties;
 
 use Helmich\Schema2Class\Generator\GeneratorRequest;
+use Laminas\Code\Generator\MethodGenerator;
 
 class AdditionalPropsMethodsFactory
 {

--- a/src/Generator/Definition/DefinitionsCollector.php
+++ b/src/Generator/Definition/DefinitionsCollector.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator\Definition;
 
 use Generator as PhpGenerator;
+use Helmich\Schema2Class\Generator\Enum\SchemaToEnum;
 use Helmich\Schema2Class\Generator\GeneratorRequest;
+use Helmich\Schema2Class\Generator\Property\Type\Composite\IntersectProperty;
+use Helmich\Schema2Class\Generator\Property\Type\Object\NestedObjectProperty;
 
 /**
  * Class is used to traverse a schema and collect {@see Definition} objects
@@ -23,9 +26,16 @@ class DefinitionsCollector
     public function __construct(private readonly GeneratorRequest $generatorRequest)
     {
         if (($cls = $this->generatorRequest->getTargetClass()) !== null) {
-            $ns = trim($this->generatorRequest->getTargetNamespace(), '\\');
-            $fqn = $ns !== '' ? $ns . '\\' . $cls : $cls;
-            $this->usedClassNames[] = $fqn;
+            $schema = $this->generatorRequest->getSchema();
+            $generatesClass = IntersectProperty::canHandleSchema($schema)
+                || NestedObjectProperty::canHandleSchema($schema)
+                || (isset($schema['enum']) && SchemaToEnum::canGenerateEnum($schema, $this->generatorRequest));
+
+            if ($generatesClass) {
+                $ns = trim($this->generatorRequest->getTargetNamespace(), '\\');
+                $fqn = $ns !== '' ? $ns . '\\' . $cls : $cls;
+                $this->usedClassNames[] = $fqn;
+            }
         }
     }
 

--- a/src/Generator/Property/PropertyBuilder.php
+++ b/src/Generator/Property/PropertyBuilder.php
@@ -83,8 +83,6 @@ class PropertyBuilder
         $definition = self::sanitizeEnum($definition);
         $definition = self::collapseSingleTypeArray($definition);
         
-        self::assertNoPropertiesWithAdditional($definition);
-        
         if ($property = self::tryInlineReference($req, $name, $definition, $isRequired)) {
             return $property;
         }
@@ -354,23 +352,6 @@ class PropertyBuilder
         }
 
         return $property->allowsNull() ? new NullablePropertyDecorator($name, $property, $req) : $property;
-    }
-
-    private static function assertNoPropertiesWithAdditional(array $definition): void
-    {
-        $hasAdditionalProperties =
-            isset($definition["additionalProperties"])
-            && is_array($definition["additionalProperties"])
-            && count($definition["additionalProperties"]) > 0;
-
-        $hasProperties =
-            isset($definition["properties"])
-            && is_array($definition["properties"])
-            && count($definition["properties"]) > 0;
-
-        if ($hasProperties && $hasAdditionalProperties) {
-            throw new GeneratorException("using 'properties' and 'additionalProperties' in the same schema is currently not supported.");
-        }
     }
 
     /**

--- a/src/Generator/Property/Type/Object/NestedObjectProperty.php
+++ b/src/Generator/Property/Type/Object/NestedObjectProperty.php
@@ -26,11 +26,7 @@ class NestedObjectProperty extends AbstractProperty
             && is_array($schema["properties"])
             && count($schema["properties"]) > 0;
 
-        $hasAdditionalProperties = isset($schema["additionalProperties"])
-            && is_array($schema["additionalProperties"])
-            && count($schema["additionalProperties"]) > 0;
-
-        return $isObject && $hasProperties && !$hasAdditionalProperties;
+        return $isObject && $hasProperties;
     }
 
     /**

--- a/tests/Generator/Fixtures/AdditionalProperties/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProperties/Output-5.6/MyClass.php
@@ -1,0 +1,364 @@
+<?php
+
+namespace Ns\AdditionalProperties_5_6;
+
+class MyClass
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static $_schema = [
+        'type' => 'object',
+        'properties' => [
+            'number' => [
+                'type' => 'number',
+            ],
+            'street_name' => [
+                'type' => 'string',
+            ],
+            'street_type' => [
+                'enum' => [
+                    'Street',
+                    'Avenue',
+                    'Boulevard',
+                ],
+            ],
+        ],
+        'additionalProperties' => [
+            'type' => 'string',
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     *
+     * @var array
+     */
+    private static $_namesMap = [
+        'number' => 'number',
+        'street_name' => 'streetName',
+        'street_type' => 'streetType',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     *
+     * @var \stdClass
+     */
+    private $_additionalProperties;
+
+    /**
+     * @var int|float|null
+     */
+    private $number = null;
+
+    /**
+     * @var string|null
+     */
+    private $streetName = null;
+
+    /**
+     * @var 'Street'|'Avenue'|'Boulevard'|null
+     */
+    private $streetType = null;
+
+    /**
+     * @param int|float|null $number
+     * @param string|null $streetName
+     * @param 'Street'|'Avenue'|'Boulevard'|null $streetType
+     */
+    public function __construct($number = null, $streetName = null, $streetType = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->number = $number;
+        $this->streetName = $streetName;
+        $this->streetType = $streetType;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties($asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     * @param bool $validate Whether to revalidate the resulting object.
+     * @return self
+     */
+    public function withAdditionalProperties($additionalProperties, $validate = true)
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        if ($validate) {
+            $clone->validate();
+        }
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     *
+     * @param bool $validate Whether to revalidate the resulting object.
+     * @return self
+     */
+    public function withoutAdditionalProperties($validate = true)
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        if ($validate) {
+            $clone->validate();
+        }
+        return $clone;
+    }
+
+    /**
+     * @return int|float|null
+     */
+    public function getNumber()
+    {
+        return isset($this->number) ? $this->number : null;
+    }
+
+    /**
+     * @param int|float $number
+     * @param bool $validate
+     * @return self
+     */
+    public function withNumber($number, $validate = true)
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($number, self::$_schema['properties']['number']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->number = $number;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutNumber()
+    {
+        $clone = clone $this;
+        unset($clone->number);
+
+        return $clone;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getStreetName()
+    {
+        return isset($this->streetName) ? $this->streetName : null;
+    }
+
+    /**
+     * @param string $streetName
+     * @param bool $validate
+     * @return self
+     */
+    public function withStreetName($streetName, $validate = true)
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($streetName, self::$_schema['properties']['street_name']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->streetName = $streetName;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutStreetName()
+    {
+        $clone = clone $this;
+        unset($clone->streetName);
+
+        return $clone;
+    }
+
+    /**
+     * @return 'Street'|'Avenue'|'Boulevard'|null
+     */
+    public function getStreetType()
+    {
+        return isset($this->streetType) ? $this->streetType : null;
+    }
+
+    /**
+     * @param 'Street'|'Avenue'|'Boulevard' $streetType
+     * @param bool $validate
+     * @return self
+     */
+    public function withStreetType($streetType, $validate = true)
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($streetType, self::$_schema['properties']['street_type']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->streetType = $streetType;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutStreetType()
+    {
+        $clone = clone $this;
+        unset($clone->streetType);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClass Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, $validate = true)
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $number = isset($input->{'number'}) ? $input->{'number'} : null;
+        $streetName = isset($input->{'street_name'}) ? $input->{'street_name'} : null;
+        $streetType = isset($input->{'street_type'}) ? $input->{'street_type'} : null;
+
+        $obj = new self($number, $streetName, $streetType);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray()
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->number)) {
+            $output['number'] = $this->number;
+        }
+        if (isset($this->streetName)) {
+            $output['street_name'] = $this->streetName;
+        }
+        if (isset($this->streetType)) {
+            $output['street_type'] = $this->streetType;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->number)) {
+            $output->{'number'} = $this->number;
+        }
+        if (isset($this->streetName)) {
+            $output->{'street_name'} = $this->streetName;
+        }
+        if (isset($this->streetType)) {
+            $output->{'street_type'} = $this->streetType;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate($return = false)
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, $return = false)
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function($e) {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/AdditionalProperties/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProperties/Output-7.4/MyClass.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\AdditionalProperties_7_4;
+
+class MyClass
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'type' => 'object',
+        'properties' => [
+            'number' => [
+                'type' => 'number',
+            ],
+            'street_name' => [
+                'type' => 'string',
+            ],
+            'street_type' => [
+                'enum' => [
+                    'Street',
+                    'Avenue',
+                    'Boulevard',
+                ],
+            ],
+        ],
+        'additionalProperties' => [
+            'type' => 'string',
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'number' => 'number',
+        'street_name' => 'streetName',
+        'street_type' => 'streetType',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    /**
+     * @var int|float|null
+     */
+    private $number = null;
+
+    private ?string $streetName = null;
+
+    /**
+     * @var 'Street'|'Avenue'|'Boulevard'|null
+     */
+    private ?string $streetType = null;
+
+    /**
+     * @param int|float|null $number
+     * @param 'Street'|'Avenue'|'Boulevard'|null $streetType
+     */
+    public function __construct($number = null, ?string $streetName = null, ?string $streetType = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->number = $number;
+        $this->streetName = $streetName;
+        $this->streetType = $streetType;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties(bool $asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     * @param bool $validate Whether to revalidate the resulting object.
+     */
+    public function withAdditionalProperties($additionalProperties, bool $validate = true): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        if ($validate) {
+            $clone->validate();
+        }
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     *
+     * @param bool $validate Whether to revalidate the resulting object.
+     */
+    public function withoutAdditionalProperties(bool $validate = true): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        if ($validate) {
+            $clone->validate();
+        }
+        return $clone;
+    }
+
+    /**
+     * @return int|float|null
+     */
+    public function getNumber()
+    {
+        return $this->number ?? null;
+    }
+
+    /**
+     * @param int|float $number
+     */
+    public function withNumber($number, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($number, self::$_schema['properties']['number']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->number = $number;
+
+        return $clone;
+    }
+
+    public function withoutNumber(): self
+    {
+        $clone = clone $this;
+        unset($clone->number);
+
+        return $clone;
+    }
+
+    public function getStreetName(): ?string
+    {
+        return $this->streetName ?? null;
+    }
+
+    public function withStreetName(string $streetName): self
+    {
+        $clone = clone $this;
+        $clone->streetName = $streetName;
+
+        return $clone;
+    }
+
+    public function withoutStreetName(): self
+    {
+        $clone = clone $this;
+        unset($clone->streetName);
+
+        return $clone;
+    }
+
+    /**
+     * @return 'Street'|'Avenue'|'Boulevard'|null
+     */
+    public function getStreetType(): ?string
+    {
+        return $this->streetType ?? null;
+    }
+
+    /**
+     * @param 'Street'|'Avenue'|'Boulevard' $streetType
+     */
+    public function withStreetType(string $streetType, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($streetType, self::$_schema['properties']['street_type']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->streetType = $streetType;
+
+        return $clone;
+    }
+
+    public function withoutStreetType(): self
+    {
+        $clone = clone $this;
+        unset($clone->streetType);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClass Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, bool $validate = true): MyClass
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $number = isset($input->{'number'}) ? $input->{'number'} : null;
+        $streetName = isset($input->{'street_name'}) ? $input->{'street_name'} : null;
+        $streetType = isset($input->{'street_type'}) ? $input->{'street_type'} : null;
+
+        $obj = new self($number, $streetName, $streetType);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->number)) {
+            $output['number'] = $this->number;
+        }
+        if (isset($this->streetName)) {
+            $output['street_name'] = $this->streetName;
+        }
+        if (isset($this->streetType)) {
+            $output['street_type'] = $this->streetType;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->number)) {
+            $output->{'number'} = $this->number;
+        }
+        if (isset($this->streetName)) {
+            $output->{'street_name'} = $this->streetName;
+        }
+        if (isset($this->streetType)) {
+            $output->{'street_type'} = $this->streetType;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/AdditionalProperties/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalProperties/Output-8.4/MyClass.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\AdditionalProperties_8_4;
+
+class MyClass
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'type' => 'object',
+        'properties' => [
+            'number' => [
+                'type' => 'number',
+            ],
+            'street_name' => [
+                'type' => 'string',
+            ],
+            'street_type' => [
+                'enum' => [
+                    'Street',
+                    'Avenue',
+                    'Boulevard',
+                ],
+            ],
+        ],
+        'additionalProperties' => [
+            'type' => 'string',
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'number' => 'number',
+        'street_name' => 'streetName',
+        'street_type' => 'streetType',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private int|float|null $number = null;
+
+    private ?string $streetName = null;
+
+    private ?MyClassStreetType $streetType = null;
+
+    public function __construct(int|float|null $number = null, ?string $streetName = null, ?MyClassStreetType $streetType = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->number = $number;
+        $this->streetName = $streetName;
+        $this->streetType = $streetType;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     */
+    public function getAdditionalProperties(bool $asArray = true): \stdClass|array
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     * @param bool $validate Whether to revalidate the resulting object.
+     */
+    public function withAdditionalProperties(\stdClass|array $additionalProperties, bool $validate = true): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        if ($validate) {
+            $clone->validate();
+        }
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     *
+     * @param bool $validate Whether to revalidate the resulting object.
+     */
+    public function withoutAdditionalProperties(bool $validate = true): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        if ($validate) {
+            $clone->validate();
+        }
+        return $clone;
+    }
+
+    public function getNumber(): int|float|null
+    {
+        return $this->number ?? null;
+    }
+
+    public function withNumber(int|float $number): self
+    {
+        $clone = clone $this;
+        $clone->number = $number;
+
+        return $clone;
+    }
+
+    public function withoutNumber(): self
+    {
+        $clone = clone $this;
+        unset($clone->number);
+
+        return $clone;
+    }
+
+    public function getStreetName(): ?string
+    {
+        return $this->streetName ?? null;
+    }
+
+    public function withStreetName(string $streetName): self
+    {
+        $clone = clone $this;
+        $clone->streetName = $streetName;
+
+        return $clone;
+    }
+
+    public function withoutStreetName(): self
+    {
+        $clone = clone $this;
+        unset($clone->streetName);
+
+        return $clone;
+    }
+
+    public function getStreetType(): ?MyClassStreetType
+    {
+        return $this->streetType ?? null;
+    }
+
+    public function withStreetType(MyClassStreetType $streetType): self
+    {
+        $clone = clone $this;
+        $clone->streetType = $streetType;
+
+        return $clone;
+    }
+
+    public function withoutStreetType(): self
+    {
+        $clone = clone $this;
+        unset($clone->streetType);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClass Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput(array|object $input, bool $validate = true): MyClass
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $number = isset($input->{'number'}) ? $input->{'number'} : null;
+        $streetName = isset($input->{'street_name'}) ? $input->{'street_name'} : null;
+        $streetType = isset($input->{'street_type'}) ? MyClassStreetType::from($input->{'street_type'}) : null;
+
+        $obj = new self($number, $streetName, $streetType);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->number)) {
+            $output['number'] = $this->number;
+        }
+        if (isset($this->streetName)) {
+            $output['street_name'] = $this->streetName;
+        }
+        if (isset($this->streetType)) {
+            $output['street_type'] = ($this->streetType)->value;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->number)) {
+            $output->{'number'} = $this->number;
+        }
+        if (isset($this->streetName)) {
+            $output->{'street_name'} = $this->streetName;
+        }
+        if (isset($this->streetType)) {
+            $output->{'street_type'} = ($this->streetType)->value;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/AdditionalProperties/Output-8.4/MyClassStreetType.php
+++ b/tests/Generator/Fixtures/AdditionalProperties/Output-8.4/MyClassStreetType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\AdditionalProperties_8_4;
+
+enum MyClassStreetType: string {
+    case AVENUE = 'Avenue';
+    case BOULEVARD = 'Boulevard';
+    case STREET = 'Street';
+}

--- a/tests/Generator/Fixtures/AdditionalPropertiesRoot/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRoot/Output-5.6/MyClass.php
@@ -1,0 +1,364 @@
+<?php
+
+namespace Ns\AdditionalPropertiesRoot_5_6;
+
+class MyClass
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static $_schema = [
+        'type' => 'object',
+        'properties' => [
+            'number' => [
+                'type' => 'number',
+            ],
+            'street_name' => [
+                'type' => 'string',
+            ],
+            'street_type' => [
+                'enum' => [
+                    'Street',
+                    'Avenue',
+                    'Boulevard',
+                ],
+            ],
+        ],
+        'additionalProperties' => [
+            'type' => 'string',
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     *
+     * @var array
+     */
+    private static $_namesMap = [
+        'number' => 'number',
+        'street_name' => 'streetName',
+        'street_type' => 'streetType',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     *
+     * @var \stdClass
+     */
+    private $_additionalProperties;
+
+    /**
+     * @var int|float|null
+     */
+    private $number = null;
+
+    /**
+     * @var string|null
+     */
+    private $streetName = null;
+
+    /**
+     * @var 'Street'|'Avenue'|'Boulevard'|null
+     */
+    private $streetType = null;
+
+    /**
+     * @param int|float|null $number
+     * @param string|null $streetName
+     * @param 'Street'|'Avenue'|'Boulevard'|null $streetType
+     */
+    public function __construct($number = null, $streetName = null, $streetType = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->number = $number;
+        $this->streetName = $streetName;
+        $this->streetType = $streetType;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties($asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     * @param bool $validate Whether to revalidate the resulting object.
+     * @return self
+     */
+    public function withAdditionalProperties($additionalProperties, $validate = true)
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        if ($validate) {
+            $clone->validate();
+        }
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     *
+     * @param bool $validate Whether to revalidate the resulting object.
+     * @return self
+     */
+    public function withoutAdditionalProperties($validate = true)
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        if ($validate) {
+            $clone->validate();
+        }
+        return $clone;
+    }
+
+    /**
+     * @return int|float|null
+     */
+    public function getNumber()
+    {
+        return isset($this->number) ? $this->number : null;
+    }
+
+    /**
+     * @param int|float $number
+     * @param bool $validate
+     * @return self
+     */
+    public function withNumber($number, $validate = true)
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($number, self::$_schema['properties']['number']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->number = $number;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutNumber()
+    {
+        $clone = clone $this;
+        unset($clone->number);
+
+        return $clone;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getStreetName()
+    {
+        return isset($this->streetName) ? $this->streetName : null;
+    }
+
+    /**
+     * @param string $streetName
+     * @param bool $validate
+     * @return self
+     */
+    public function withStreetName($streetName, $validate = true)
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($streetName, self::$_schema['properties']['street_name']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->streetName = $streetName;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutStreetName()
+    {
+        $clone = clone $this;
+        unset($clone->streetName);
+
+        return $clone;
+    }
+
+    /**
+     * @return 'Street'|'Avenue'|'Boulevard'|null
+     */
+    public function getStreetType()
+    {
+        return isset($this->streetType) ? $this->streetType : null;
+    }
+
+    /**
+     * @param 'Street'|'Avenue'|'Boulevard' $streetType
+     * @param bool $validate
+     * @return self
+     */
+    public function withStreetType($streetType, $validate = true)
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($streetType, self::$_schema['properties']['street_type']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->streetType = $streetType;
+
+        return $clone;
+    }
+
+    /**
+     * @return self
+     */
+    public function withoutStreetType()
+    {
+        $clone = clone $this;
+        unset($clone->streetType);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClass Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, $validate = true)
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $number = isset($input->{'number'}) ? $input->{'number'} : null;
+        $streetName = isset($input->{'street_name'}) ? $input->{'street_name'} : null;
+        $streetType = isset($input->{'street_type'}) ? $input->{'street_type'} : null;
+
+        $obj = new self($number, $streetName, $streetType);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray()
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->number)) {
+            $output['number'] = $this->number;
+        }
+        if (isset($this->streetName)) {
+            $output['street_name'] = $this->streetName;
+        }
+        if (isset($this->streetType)) {
+            $output['street_type'] = $this->streetType;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass()
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->number)) {
+            $output->{'number'} = $this->number;
+        }
+        if (isset($this->streetName)) {
+            $output->{'street_name'} = $this->streetName;
+        }
+        if (isset($this->streetType)) {
+            $output->{'street_type'} = $this->streetType;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate($return = false)
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, $return = false)
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function($e) {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/AdditionalPropertiesRoot/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRoot/Output-7.4/MyClass.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\AdditionalPropertiesRoot_7_4;
+
+class MyClass
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'type' => 'object',
+        'properties' => [
+            'number' => [
+                'type' => 'number',
+            ],
+            'street_name' => [
+                'type' => 'string',
+            ],
+            'street_type' => [
+                'enum' => [
+                    'Street',
+                    'Avenue',
+                    'Boulevard',
+                ],
+            ],
+        ],
+        'additionalProperties' => [
+            'type' => 'string',
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'number' => 'number',
+        'street_name' => 'streetName',
+        'street_type' => 'streetType',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    /**
+     * @var int|float|null
+     */
+    private $number = null;
+
+    private ?string $streetName = null;
+
+    /**
+     * @var 'Street'|'Avenue'|'Boulevard'|null
+     */
+    private ?string $streetType = null;
+
+    /**
+     * @param int|float|null $number
+     * @param 'Street'|'Avenue'|'Boulevard'|null $streetType
+     */
+    public function __construct($number = null, ?string $streetName = null, ?string $streetType = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->number = $number;
+        $this->streetName = $streetName;
+        $this->streetType = $streetType;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties(bool $asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     * @param bool $validate Whether to revalidate the resulting object.
+     */
+    public function withAdditionalProperties($additionalProperties, bool $validate = true): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        if ($validate) {
+            $clone->validate();
+        }
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     *
+     * @param bool $validate Whether to revalidate the resulting object.
+     */
+    public function withoutAdditionalProperties(bool $validate = true): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        if ($validate) {
+            $clone->validate();
+        }
+        return $clone;
+    }
+
+    /**
+     * @return int|float|null
+     */
+    public function getNumber()
+    {
+        return $this->number ?? null;
+    }
+
+    /**
+     * @param int|float $number
+     */
+    public function withNumber($number, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($number, self::$_schema['properties']['number']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->number = $number;
+
+        return $clone;
+    }
+
+    public function withoutNumber(): self
+    {
+        $clone = clone $this;
+        unset($clone->number);
+
+        return $clone;
+    }
+
+    public function getStreetName(): ?string
+    {
+        return $this->streetName ?? null;
+    }
+
+    public function withStreetName(string $streetName): self
+    {
+        $clone = clone $this;
+        $clone->streetName = $streetName;
+
+        return $clone;
+    }
+
+    public function withoutStreetName(): self
+    {
+        $clone = clone $this;
+        unset($clone->streetName);
+
+        return $clone;
+    }
+
+    /**
+     * @return 'Street'|'Avenue'|'Boulevard'|null
+     */
+    public function getStreetType(): ?string
+    {
+        return $this->streetType ?? null;
+    }
+
+    /**
+     * @param 'Street'|'Avenue'|'Boulevard' $streetType
+     */
+    public function withStreetType(string $streetType, bool $validate = true): self
+    {
+        if ($validate) {
+            $validator = new \JsonSchema\Validator();
+            $validator->validate($streetType, self::$_schema['properties']['street_type']);
+            if (!$validator->isValid()) {
+                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+            }
+        }
+
+        $clone = clone $this;
+        $clone->streetType = $streetType;
+
+        return $clone;
+    }
+
+    public function withoutStreetType(): self
+    {
+        $clone = clone $this;
+        unset($clone->streetType);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClass Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, bool $validate = true): MyClass
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $number = isset($input->{'number'}) ? $input->{'number'} : null;
+        $streetName = isset($input->{'street_name'}) ? $input->{'street_name'} : null;
+        $streetType = isset($input->{'street_type'}) ? $input->{'street_type'} : null;
+
+        $obj = new self($number, $streetName, $streetType);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->number)) {
+            $output['number'] = $this->number;
+        }
+        if (isset($this->streetName)) {
+            $output['street_name'] = $this->streetName;
+        }
+        if (isset($this->streetType)) {
+            $output['street_type'] = $this->streetType;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->number)) {
+            $output->{'number'} = $this->number;
+        }
+        if (isset($this->streetName)) {
+            $output->{'street_name'} = $this->streetName;
+        }
+        if (isset($this->streetType)) {
+            $output->{'street_type'} = $this->streetType;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/AdditionalPropertiesRoot/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRoot/Output-8.4/MyClass.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\AdditionalPropertiesRoot_8_4;
+
+class MyClass
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'type' => 'object',
+        'properties' => [
+            'number' => [
+                'type' => 'number',
+            ],
+            'street_name' => [
+                'type' => 'string',
+            ],
+            'street_type' => [
+                'enum' => [
+                    'Street',
+                    'Avenue',
+                    'Boulevard',
+                ],
+            ],
+        ],
+        'additionalProperties' => [
+            'type' => 'string',
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'number' => 'number',
+        'street_name' => 'streetName',
+        'street_type' => 'streetType',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private int|float|null $number = null;
+
+    private ?string $streetName = null;
+
+    private ?MyClassStreetType $streetType = null;
+
+    public function __construct(int|float|null $number = null, ?string $streetName = null, ?MyClassStreetType $streetType = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->number = $number;
+        $this->streetName = $streetName;
+        $this->streetType = $streetType;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     */
+    public function getAdditionalProperties(bool $asArray = true): \stdClass|array
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     * @param bool $validate Whether to revalidate the resulting object.
+     */
+    public function withAdditionalProperties(\stdClass|array $additionalProperties, bool $validate = true): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        if ($validate) {
+            $clone->validate();
+        }
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     *
+     * @param bool $validate Whether to revalidate the resulting object.
+     */
+    public function withoutAdditionalProperties(bool $validate = true): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        if ($validate) {
+            $clone->validate();
+        }
+        return $clone;
+    }
+
+    public function getNumber(): int|float|null
+    {
+        return $this->number ?? null;
+    }
+
+    public function withNumber(int|float $number): self
+    {
+        $clone = clone $this;
+        $clone->number = $number;
+
+        return $clone;
+    }
+
+    public function withoutNumber(): self
+    {
+        $clone = clone $this;
+        unset($clone->number);
+
+        return $clone;
+    }
+
+    public function getStreetName(): ?string
+    {
+        return $this->streetName ?? null;
+    }
+
+    public function withStreetName(string $streetName): self
+    {
+        $clone = clone $this;
+        $clone->streetName = $streetName;
+
+        return $clone;
+    }
+
+    public function withoutStreetName(): self
+    {
+        $clone = clone $this;
+        unset($clone->streetName);
+
+        return $clone;
+    }
+
+    public function getStreetType(): ?MyClassStreetType
+    {
+        return $this->streetType ?? null;
+    }
+
+    public function withStreetType(MyClassStreetType $streetType): self
+    {
+        $clone = clone $this;
+        $clone->streetType = $streetType;
+
+        return $clone;
+    }
+
+    public function withoutStreetType(): self
+    {
+        $clone = clone $this;
+        unset($clone->streetType);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClass Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput(array|object $input, bool $validate = true): MyClass
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $number = isset($input->{'number'}) ? $input->{'number'} : null;
+        $streetName = isset($input->{'street_name'}) ? $input->{'street_name'} : null;
+        $streetType = isset($input->{'street_type'}) ? MyClassStreetType::from($input->{'street_type'}) : null;
+
+        $obj = new self($number, $streetName, $streetType);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->number)) {
+            $output['number'] = $this->number;
+        }
+        if (isset($this->streetName)) {
+            $output['street_name'] = $this->streetName;
+        }
+        if (isset($this->streetType)) {
+            $output['street_type'] = ($this->streetType)->value;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->number)) {
+            $output->{'number'} = $this->number;
+        }
+        if (isset($this->streetName)) {
+            $output->{'street_name'} = $this->streetName;
+        }
+        if (isset($this->streetType)) {
+            $output->{'street_type'} = ($this->streetType)->value;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/AdditionalPropertiesRoot/Output-8.4/MyClassStreetType.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRoot/Output-8.4/MyClassStreetType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\AdditionalPropertiesRoot_8_4;
+
+enum MyClassStreetType: string {
+    case AVENUE = 'Avenue';
+    case BOULEVARD = 'Boulevard';
+    case STREET = 'Street';
+}

--- a/tests/Generator/SchemaDefinitionsCollectorTest.php
+++ b/tests/Generator/SchemaDefinitionsCollectorTest.php
@@ -79,4 +79,25 @@ final class SchemaDefinitionsCollectorTest extends TestCase
         $this->assertSame('Address', $definitions['#/definitions/address']->className);
         $this->assertSame('Name', $definitions['#/definitions/address/$defs/name']->className);
     }
+
+    public function testRootEnumReservesClassName(): void
+    {
+        $schema = [
+            'type' => 'string',
+            'enum' => ['foo', 'bar'],
+            'definitions' => [
+                'TargetClass' => ['type' => 'string'],
+            ],
+        ];
+
+        $collector = new DefinitionsCollector(new GeneratorRequest(
+            schema: $schema,
+            spec: new ValidatedSpecificationFilesItem('Ns', 'TargetClass', 'dir'),
+            opts: new SpecificationOptions(),
+        ));
+        $definitions = iterator_to_array($collector->collect($schema));
+
+        $this->assertArrayHasKey('#/definitions/TargetClass', $definitions);
+        $this->assertSame('Ns\\TargetClass_1', $definitions['#/definitions/TargetClass']->classFQN);
+    }
 }


### PR DESCRIPTION
## Summary
- allow NestedObjectProperty to handle schemas that define both properties and additionalProperties
- avoid reserving unused root class names when no root class is generated
- add snapshot fixtures for typed additionalProperties and fix related phpstan warnings
- ensure enum-producing schemas reserve the root class name

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: Match expression does not handle remaining value: true [x3])*

------
https://chatgpt.com/codex/tasks/task_e_68977a986dec832dabdb29f1a8a0e3aa