### PR TITLE
feat: introduce type hint normalization utility

### DIFF
--- a/src/Util/TypeHint.php
+++ b/src/Util/TypeHint.php
@@ -1,0 +1,371 @@
+<?php
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Util;
+
+use InvalidArgumentException;
+
+class TypeHint
+{
+    public const KIND_RETURN = 'return';
+    public const KIND_ARG = 'arg';
+    public const KIND_PROP = 'prop';
+
+    public const LEGACY_NULLABLE_OMIT_TYPE = 'omit-type';
+    public const LEGACY_NULLABLE_DROP_NULL = 'drop-null';
+
+    /** @var string[] */
+    public const SCALARS = ['int', 'float', 'string', 'bool'];
+
+    /** Built in types that are recognized case-insensitively */
+    private const BUILTIN_TYPES = [
+        'static', 'self', 'parent',
+        'callable', 'iterable', 'object', 'array',
+        'string', 'float', 'int', 'bool',
+        'true', 'false',
+        'null',
+        'mixed', 'void', 'never',
+    ];
+
+    /** Order for union types */
+    private const SORT_ORDER = [
+        'static' => 0,
+        'self' => 1,
+        'parent' => 2,
+        // 3 is reserved for class-like types
+        'callable' => 4,
+        'iterable' => 5,
+        'object' => 6,
+        'array' => 7,
+        'string' => 8,
+        'float' => 9,
+        'int' => 10,
+        'bool' => 11,
+        'true' => 12,
+        'false' => 13,
+        'null' => 14,
+    ];
+
+    /** Minimal PHP versions for built in types */
+    private const MIN_VERSION = [
+        'int' => ['arg' => '7.0', 'return' => '7.0', 'prop' => '7.4'],
+        'float' => ['arg' => '7.0', 'return' => '7.0', 'prop' => '7.4'],
+        'string' => ['arg' => '7.0', 'return' => '7.0', 'prop' => '7.4'],
+        'bool' => ['arg' => '7.0', 'return' => '7.0', 'prop' => '7.4'],
+        'true' => ['arg' => '8.2', 'return' => '8.2', 'prop' => '8.2'],
+        'false' => ['arg' => '8.2', 'return' => '8.2', 'prop' => '8.2'],
+        'array' => ['arg' => '5.0', 'return' => '7.0', 'prop' => '7.4'],
+        'callable' => ['arg' => '5.6', 'return' => '7.0', 'prop' => '7.4'],
+        'iterable' => ['arg' => '7.2', 'return' => '7.2', 'prop' => '7.4'],
+        'object' => ['arg' => '7.2', 'return' => '7.2', 'prop' => '7.4'],
+        'mixed' => ['arg' => '8.0', 'return' => '8.0', 'prop' => '8.0'],
+        'void' => ['return' => '7.4'],
+        'never' => ['return' => '8.1'],
+        'null' => ['arg' => '8.2', 'return' => '8.2', 'prop' => '8.2'],
+    ];
+
+    /**
+     * Normalize provided type declaration for the given PHP version and kind.
+     *
+     * @param array|string $input
+     * @param string $phpVersion
+     * @param string $kind One of KIND_*
+     * @param ?string $legacyFlag LEGACY_NULLABLE_* constants
+     */
+    public static function forPhpVer(array|string $input, string $phpVersion, string $kind, ?string $legacyFlag = null): ?string
+    {
+        if (version_compare($phpVersion, '5.6', '<')) {
+            throw new InvalidArgumentException('Unsupported PHP version');
+        }
+
+        $types = self::parseInput($input);
+        $types = self::normalizeTypes($types);
+
+        if ($kind === self::KIND_PROP && version_compare($phpVersion, '7.4', '<')) {
+            // typed properties are not supported, but validate input first
+            return null;
+        }
+
+        $types = self::removeRedundantTypes($types);
+
+        // map true/false to bool for older PHP versions
+        if (version_compare($phpVersion, '8.2', '<')) {
+            foreach ($types as &$t) {
+                $lt = strtolower($t);
+                if ($lt === 'true' || $lt === 'false') {
+                    $t = 'bool';
+                }
+            }
+            unset($t);
+            $types = self::normalizeTypes($types);
+            $types = self::removeRedundantTypes($types);
+        }
+
+        // handle special cases first
+        $lower = array_map('strtolower', $types);
+        if (in_array('never', $lower, true)) {
+            if (count($types) > 1) {
+                throw new InvalidArgumentException('never cannot be combined');
+            }
+            if ($kind !== self::KIND_RETURN) {
+                throw new InvalidArgumentException('never can be used only as return type');
+            }
+            if (version_compare($phpVersion, '8.1', '>=')) {
+                return 'never';
+            }
+            if (version_compare($phpVersion, '7.4', '>=')) {
+                return 'void';
+            }
+            return null;
+        }
+        if (in_array('void', $lower, true)) {
+            if (count($types) > 1) {
+                throw new InvalidArgumentException('void cannot be combined');
+            }
+            if ($kind !== self::KIND_RETURN) {
+                throw new InvalidArgumentException('void can be used only as return type');
+            }
+            if (version_compare($phpVersion, '7.4', '>=')) {
+                return 'void';
+            }
+            return null;
+        }
+        if (in_array('mixed', $lower, true)) {
+            if (!self::isSupported('mixed', $phpVersion, $kind)) {
+                return null;
+            }
+            return 'mixed';
+        }
+
+        // check each type for support
+        $types = array_values(array_filter($types, function (string $t) use ($phpVersion, $kind): bool {
+            $lt = strtolower($t);
+            if ($lt === 'null') {
+                return true; // handled later
+            }
+            if (self::isBuiltin($lt)) {
+                return self::isSupported($lt, $phpVersion, $kind);
+            }
+            // class-like names
+            if ($kind === self::KIND_RETURN && version_compare($phpVersion, '7.0', '<')) {
+                return false;
+            }
+            // KIND_ARG has no additional restrictions
+            return true;
+        }));
+
+        if ($types === []) {
+            return null;
+        }
+
+        $lower = array_map('strtolower', $types);
+        $hasNull = in_array('null', $lower, true);
+        $nonNull = array_values(array_filter($types, fn($t) => strtolower($t) !== 'null'));
+
+        if (count($nonNull) > 1 && version_compare($phpVersion, '8.0', '<')) {
+            $allClassLike = true;
+            foreach ($nonNull as $t) {
+                if (self::isBuiltin(strtolower($t))) {
+                    $allClassLike = false;
+                    break;
+                }
+            }
+            if ($allClassLike && version_compare($phpVersion, '7.2', '>=')) {
+                $nonNull = ['object'];
+                $types = $hasNull ? ['object', 'null'] : ['object'];
+                $lower = array_map('strtolower', $types);
+                $hasNull = in_array('null', $lower, true);
+            } else {
+                return null;
+            }
+        }
+
+        if ($nonNull === []) {
+            // only null
+            return version_compare($phpVersion, '8.2', '>=') ? 'null' : null;
+        }
+
+        if (count($nonNull) === 1) {
+            $type = $nonNull[0];
+            if (!$hasNull) {
+                return $type;
+            }
+
+            // nullable
+            if (version_compare($phpVersion, '7.1', '>=')) {
+                return '?' . $type;
+            }
+
+            // legacy handling
+            if ($legacyFlag === self::LEGACY_NULLABLE_OMIT_TYPE) {
+                return null;
+            }
+            if ($legacyFlag === self::LEGACY_NULLABLE_DROP_NULL) {
+                return $type;
+            }
+            throw new InvalidArgumentException('Nullable types are not supported');
+        }
+
+        // Union types (>1 non-null)
+        if (version_compare($phpVersion, '8.0', '<')) {
+            return null;
+        }
+
+        // ensure all non-null types supported
+        foreach ($nonNull as $t) {
+            $lt = strtolower($t);
+            if (self::isBuiltin($lt)) {
+                if (!self::isSupported($lt, $phpVersion, $kind)) {
+                    return null;
+                }
+            } else {
+                if ($kind === self::KIND_RETURN && version_compare($phpVersion, '7.0', '<')) {
+                    return null;
+                }
+            }
+        }
+
+        // sort union types
+        $sorted = self::sortTypes($types);
+        return implode('|', $sorted);
+    }
+
+    /** @param array|string $input */
+    private static function parseInput(array|string $input): array
+    {
+        if (is_string($input)) {
+            $input = [$input];
+        }
+        $types = [];
+        foreach ($input as $piece) {
+            if (!is_string($piece)) {
+                throw new InvalidArgumentException('Invalid type declaration');
+            }
+            $parts = explode('|', $piece);
+            foreach ($parts as $p) {
+                if ($p === '') {
+                    throw new InvalidArgumentException('Invalid type declaration');
+                }
+                if (preg_match('/\s/', $p)) {
+                    throw new InvalidArgumentException('Whitespace not allowed');
+                }
+                if ($p[0] === '?') {
+                    $p = substr($p, 1);
+                    if ($p === '' || preg_match('/\s/', $p)) {
+                        throw new InvalidArgumentException('Invalid nullable type');
+                    }
+                    $types[] = 'null';
+                }
+                if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $p)) {
+                    throw new InvalidArgumentException('Invalid type');
+                }
+                $types[] = $p;
+            }
+        }
+        return $types;
+    }
+
+    /** @param array<string> $types */
+    private static function normalizeTypes(array $types): array
+    {
+        $result = [];
+        $lowerMap = [];
+        foreach ($types as $t) {
+            $lower = strtolower($t);
+            $canonical = self::isBuiltin($lower) ? $lower : $t;
+            if (isset($lowerMap[$lower])) {
+                if (!self::isBuiltin($lower) && $lowerMap[$lower] !== $t) {
+                    throw new InvalidArgumentException('Duplicate types with different case');
+                }
+                continue;
+            }
+            $lowerMap[$lower] = $canonical;
+            $result[] = $canonical;
+        }
+        return $result;
+    }
+
+    /** @param array<string> $types */
+    private static function removeRedundantTypes(array $types): array
+    {
+        $lower = array_map('strtolower', $types);
+
+        if (in_array('mixed', $lower, true)) {
+            return ['mixed'];
+        }
+
+        if (in_array('object', $lower, true)) {
+            $types = array_values(array_filter($types, function (string $t): bool {
+                $lt = strtolower($t);
+                if ($lt === 'object') {
+                    return true;
+                }
+                return self::isBuiltin($lt);
+            }));
+            $lower = array_map('strtolower', $types);
+        }
+
+        if (in_array('iterable', $lower, true)) {
+            $types = array_values(array_filter($types, function (string $t): bool {
+                $lt = strtolower($t);
+                if ($lt === 'array' || $lt === 'traversable') {
+                    return false;
+                }
+                return true;
+            }));
+            $lower = array_map('strtolower', $types);
+        }
+
+        if (in_array('bool', $lower, true)) {
+            $types = array_values(array_filter($types, function (string $t): bool {
+                $lt = strtolower($t);
+                return $lt !== 'true' && $lt !== 'false';
+            }));
+            $lower = array_map('strtolower', $types);
+        } elseif (in_array('true', $lower, true) && in_array('false', $lower, true)) {
+            $types = array_values(array_filter($types, function (string $t): bool {
+                $lt = strtolower($t);
+                return $lt !== 'true' && $lt !== 'false';
+            }));
+            $types[] = 'bool';
+            $types = self::normalizeTypes($types);
+            $lower = array_map('strtolower', $types);
+        }
+
+        return $types;
+    }
+
+    private static function isBuiltin(string $lower): bool
+    {
+        return in_array($lower, self::BUILTIN_TYPES, true);
+    }
+
+    private static function isSupported(string $type, string $phpVersion, string $kind): bool
+    {
+        $min = self::MIN_VERSION[$type][$kind] ?? null;
+        if ($min === null) {
+            return true;
+        }
+        return version_compare($phpVersion, $min, '>=');
+    }
+
+    /** @param array<string> $types */
+    private static function sortTypes(array $types): array
+    {
+        usort($types, function (string $a, string $b): int {
+            $la = strtolower($a);
+            $lb = strtolower($b);
+            $ia = self::SORT_ORDER[$la] ?? 3; // class-like default
+            $ib = self::SORT_ORDER[$lb] ?? 3;
+            if ($ia === $ib) {
+                $cmp = strcasecmp($a, $b);
+                if ($cmp === 0) {
+                    return strcmp($a, $b);
+                }
+                return $cmp;
+            }
+            return $ia <=> $ib;
+        });
+        return $types;
+    }
+}

--- a/src/Util/TypeHint.php
+++ b/src/Util/TypeHint.php
@@ -11,57 +11,84 @@ class TypeHint
     public const KIND_ARG = 'arg';
     public const KIND_PROP = 'prop';
 
+    public const ALL_KINDS = [
+        self::KIND_RETURN,
+        self::KIND_ARG,
+        self::KIND_PROP,
+    ];
+
     public const LEGACY_NULLABLE_OMIT_TYPE = 'omit-type';
     public const LEGACY_NULLABLE_DROP_NULL = 'drop-null';
+
+    public const LEGACY_FLAGS = [
+        self::LEGACY_NULLABLE_OMIT_TYPE,
+        self::LEGACY_NULLABLE_DROP_NULL,
+    ];
 
     /** @var string[] */
     public const SCALARS = ['int', 'float', 'string', 'bool'];
 
     /** Built in types that are recognized case-insensitively */
     private const BUILTIN_TYPES = [
-        'static', 'self', 'parent',
-        'callable', 'iterable', 'object', 'array',
-        'string', 'float', 'int', 'bool',
-        'true', 'false',
+        'static',
+        'self',
+        'parent',
+
+        'callable',
+        'iterable',
+        'object',
+        'array',
+
+        'string',
+        'float',
+        'int',
+        'bool',
+
+        'true',
+        'false',
+
         'null',
-        'mixed', 'void', 'never',
+
+        'mixed',
+        'void',
+        'never',
     ];
 
     /** Order for union types */
     private const SORT_ORDER = [
-        'static' => 0,
-        'self' => 1,
-        'parent' => 2,
+        'static'    => 0,
+        'self'      => 1,
+        'parent'    => 2,
         // 3 is reserved for class-like types
-        'callable' => 4,
-        'iterable' => 5,
-        'object' => 6,
-        'array' => 7,
-        'string' => 8,
-        'float' => 9,
-        'int' => 10,
-        'bool' => 11,
-        'true' => 12,
-        'false' => 13,
-        'null' => 14,
+        'callable'  => 4,
+        'iterable'  => 5,
+        'object'    => 6,
+        'array'     => 7,
+        'string'    => 8,
+        'float'     => 9,
+        'int'       => 10,
+        'bool'      => 11,
+        'true'      => 12,
+        'false'     => 13,
+        'null'      => 14,
     ];
 
-    /** Minimal PHP versions for built in types */
+    /** Minimal PHP versions for built in types used STANDALONE (`false` has special handling) */
     private const MIN_VERSION = [
-        'int' => ['arg' => '7.0', 'return' => '7.0', 'prop' => '7.4'],
-        'float' => ['arg' => '7.0', 'return' => '7.0', 'prop' => '7.4'],
-        'string' => ['arg' => '7.0', 'return' => '7.0', 'prop' => '7.4'],
-        'bool' => ['arg' => '7.0', 'return' => '7.0', 'prop' => '7.4'],
-        'true' => ['arg' => '8.2', 'return' => '8.2', 'prop' => '8.2'],
-        'false' => ['arg' => '8.2', 'return' => '8.2', 'prop' => '8.2'],
-        'array' => ['arg' => '5.0', 'return' => '7.0', 'prop' => '7.4'],
-        'callable' => ['arg' => '5.6', 'return' => '7.0', 'prop' => '7.4'],
-        'iterable' => ['arg' => '7.2', 'return' => '7.2', 'prop' => '7.4'],
-        'object' => ['arg' => '7.2', 'return' => '7.2', 'prop' => '7.4'],
-        'mixed' => ['arg' => '8.0', 'return' => '8.0', 'prop' => '8.0'],
-        'void' => ['return' => '7.4'],
-        'never' => ['return' => '8.1'],
-        'null' => ['arg' => '8.2', 'return' => '8.2', 'prop' => '8.2'],
+        'int'       => [self::KIND_ARG => '7.0', self::KIND_RETURN => '7.0', self::KIND_PROP => '7.4'],
+        'float'     => [self::KIND_ARG => '7.0', self::KIND_RETURN => '7.0', self::KIND_PROP => '7.4'],
+        'string'    => [self::KIND_ARG => '7.0', self::KIND_RETURN => '7.0', self::KIND_PROP => '7.4'],
+        'bool'      => [self::KIND_ARG => '7.0', self::KIND_RETURN => '7.0', self::KIND_PROP => '7.4'],
+        'true'      => [self::KIND_ARG => '8.2', self::KIND_RETURN => '8.2', self::KIND_PROP => '8.2'],
+        'false'     => [self::KIND_ARG => '8.2', self::KIND_RETURN => '8.2', self::KIND_PROP => '8.2'],
+        'array'     => [self::KIND_ARG => '5.0', self::KIND_RETURN => '7.0', self::KIND_PROP => '7.4'],
+        'callable'  => [self::KIND_ARG => '5.6', self::KIND_RETURN => '7.0', self::KIND_PROP => '7.4'],
+        'iterable'  => [self::KIND_ARG => '7.2', self::KIND_RETURN => '7.2', self::KIND_PROP => '7.4'],
+        'object'    => [self::KIND_ARG => '7.2', self::KIND_RETURN => '7.2', self::KIND_PROP => '7.4'],
+        'mixed'     => [self::KIND_ARG => '8.0', self::KIND_RETURN => '8.0', self::KIND_PROP => '8.0'],
+        'void'      => [self::KIND_RETURN => '7.4'],
+        'never'     => [self::KIND_RETURN => '8.1'],
+        'null'      => [self::KIND_ARG => '8.2', self::KIND_RETURN => '8.2', self::KIND_PROP => '8.2'],
     ];
 
     /**
@@ -74,41 +101,34 @@ class TypeHint
      */
     public static function forPhpVer(array|string $input, string $phpVersion, string $kind, ?string $legacyFlag = null): ?string
     {
+        if (!in_array($kind, self::ALL_KINDS)) {
+            throw new InvalidArgumentException("Unsupported kind: {$kind}");
+        }
+        if ($legacyFlag !== null && !in_array($legacyFlag, self::LEGACY_FLAGS)) {
+            throw new InvalidArgumentException("Unknown legacy flag: {$legacyFlag}");
+        }
         if (version_compare($phpVersion, '5.6', '<')) {
-            throw new InvalidArgumentException('Unsupported PHP version');
+            throw new InvalidArgumentException("Unsupported PHP version: {$phpVersion}");
         }
 
         $types = self::parseInput($input);
-        $types = self::normalizeTypes($types);
 
-        if ($kind === self::KIND_PROP && version_compare($phpVersion, '7.4', '<')) {
-            // typed properties are not supported, but validate input first
-            return null;
-        }
-
+        $types = self::canonicalizeCaseAndDeduplicate($types);
         $types = self::removeRedundantTypes($types);
 
         // map true/false to bool for older PHP versions
-        if (version_compare($phpVersion, '8.2', '<')) {
-            foreach ($types as &$t) {
-                $lt = strtolower($t);
-                if ($lt === 'true' || $lt === 'false') {
-                    $t = 'bool';
-                }
-            }
-            unset($t);
-            $types = self::normalizeTypes($types);
-            $types = self::removeRedundantTypes($types);
+        $types = self::mapLiteralBools($types, $phpVersion);
+
+        if ($types === []) {
+            return null;
         }
 
-        // handle special cases first
-        $lower = array_map('strtolower', $types);
-        if (in_array('never', $lower, true)) {
+        if (in_array('never', $types, true)) {
             if (count($types) > 1) {
-                throw new InvalidArgumentException('never cannot be combined');
+                throw new InvalidArgumentException("'never' cannot be combined");
             }
             if ($kind !== self::KIND_RETURN) {
-                throw new InvalidArgumentException('never can be used only as return type');
+                throw new InvalidArgumentException("'never' can be used only as return type. Attempt to use as: {$kind} type");
             }
             if (version_compare($phpVersion, '8.1', '>=')) {
                 return 'never';
@@ -118,49 +138,35 @@ class TypeHint
             }
             return null;
         }
-        if (in_array('void', $lower, true)) {
+        if (in_array('void', $types, true)) {
             if (count($types) > 1) {
-                throw new InvalidArgumentException('void cannot be combined');
+                throw new InvalidArgumentException("'void' cannot be combined");
             }
             if ($kind !== self::KIND_RETURN) {
-                throw new InvalidArgumentException('void can be used only as return type');
+                throw new InvalidArgumentException("'void' can be used only as return type. Attempt to use as: {$kind} type");
             }
             if (version_compare($phpVersion, '7.4', '>=')) {
                 return 'void';
             }
             return null;
         }
-        if (in_array('mixed', $lower, true)) {
-            if (!self::isSupported('mixed', $phpVersion, $kind)) {
+        if (in_array('mixed', $types, true)) {
+            if (!self::isSupported('mixed', $types, $phpVersion, $kind)) {
                 return null;
             }
             return 'mixed';
         }
-
-        // check each type for support
-        $types = array_values(array_filter($types, function (string $t) use ($phpVersion, $kind): bool {
-            $lt = strtolower($t);
-            if ($lt === 'null') {
-                return true; // handled later
-            }
-            if (self::isBuiltin($lt)) {
-                return self::isSupported($lt, $phpVersion, $kind);
-            }
-            // class-like names
-            if ($kind === self::KIND_RETURN && version_compare($phpVersion, '7.0', '<')) {
-                return false;
-            }
-            // KIND_ARG has no additional restrictions
-            return true;
-        }));
-
-        if ($types === []) {
+        
+        // after basic input validation, return null if the PHP ver doesn't support types for the given kind
+        if ($kind === self::KIND_PROP && version_compare($phpVersion, '7.4', '<')) {
+            return null;
+        }
+        if ($kind === self::KIND_RETURN && version_compare($phpVersion, '7.0', '<')) {
             return null;
         }
 
-        $lower = array_map('strtolower', $types);
-        $hasNull = in_array('null', $lower, true);
-        $nonNull = array_values(array_filter($types, fn($t) => strtolower($t) !== 'null'));
+        $hasNull = in_array('null', $types, true);
+        $nonNull = self::removeNulls($types);
 
         if (count($nonNull) > 1 && version_compare($phpVersion, '8.0', '<')) {
             $allClassLike = true;
@@ -173,20 +179,23 @@ class TypeHint
             if ($allClassLike && version_compare($phpVersion, '7.2', '>=')) {
                 $nonNull = ['object'];
                 $types = $hasNull ? ['object', 'null'] : ['object'];
-                $lower = array_map('strtolower', $types);
-                $hasNull = in_array('null', $lower, true);
             } else {
                 return null;
             }
         }
 
-        if ($nonNull === []) {
-            // only null
+        if ($hasNull && $nonNull === []) {
+            // standalone null
             return version_compare($phpVersion, '8.2', '>=') ? 'null' : null;
         }
 
         if (count($nonNull) === 1) {
             $type = $nonNull[0];
+
+            if (!self::isSupported($type, $types, $phpVersion, $kind)) {
+                return null;
+            }
+
             if (!$hasNull) {
                 return $type;
             }
@@ -203,19 +212,14 @@ class TypeHint
             if ($legacyFlag === self::LEGACY_NULLABLE_DROP_NULL) {
                 return $type;
             }
-            throw new InvalidArgumentException('Nullable types are not supported');
-        }
-
-        // Union types (>1 non-null)
-        if (version_compare($phpVersion, '8.0', '<')) {
-            return null;
+            throw new InvalidArgumentException("PHP {$phpVersion} doesn't support nullable type hints, and \$legacyFlag is not provided.");
         }
 
         // ensure all non-null types supported
         foreach ($nonNull as $t) {
-            $lt = strtolower($t);
-            if (self::isBuiltin($lt)) {
-                if (!self::isSupported($lt, $phpVersion, $kind)) {
+            $lower = strtolower($t);
+            if (self::isBuiltin($lower)) {
+                if (!self::isSupported($lower, $types, $phpVersion, $kind)) {
                     return null;
                 }
             } else {
@@ -239,25 +243,26 @@ class TypeHint
         $types = [];
         foreach ($input as $piece) {
             if (!is_string($piece)) {
-                throw new InvalidArgumentException('Invalid type declaration');
+                throw new InvalidArgumentException('Invalid type of type to parse. Variable gettype: ' . gettype($piece));
             }
             $parts = explode('|', $piece);
             foreach ($parts as $p) {
                 if ($p === '') {
-                    throw new InvalidArgumentException('Invalid type declaration');
+                    throw new InvalidArgumentException('Type resolved to an empty string');
                 }
                 if (preg_match('/\s/', $p)) {
-                    throw new InvalidArgumentException('Whitespace not allowed');
+                    throw new InvalidArgumentException("Type contains whitespace: {$p}");
                 }
                 if ($p[0] === '?') {
+                    $saved = $p;
                     $p = substr($p, 1);
                     if ($p === '' || preg_match('/\s/', $p)) {
-                        throw new InvalidArgumentException('Invalid nullable type');
+                        throw new InvalidArgumentException("Invalid nullable type: {$saved}");
                     }
                     $types[] = 'null';
                 }
-                if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $p)) {
-                    throw new InvalidArgumentException('Invalid type');
+                if (!preg_match('/^(?:\\\)?[A-Za-z_][A-Za-z0-9_]*(?:\\\[A-Za-z_][A-Za-z0-9_])*$/', $p)) {
+                    throw new InvalidArgumentException("Illegal charachters found in type: {$p}");
                 }
                 $types[] = $p;
             }
@@ -266,22 +271,26 @@ class TypeHint
     }
 
     /** @param array<string> $types */
-    private static function normalizeTypes(array $types): array
+    private static function canonicalizeCaseAndDeduplicate(array $types): array
     {
         $result = [];
         $lowerMap = [];
+
         foreach ($types as $t) {
             $lower = strtolower($t);
             $canonical = self::isBuiltin($lower) ? $lower : $t;
+
             if (isset($lowerMap[$lower])) {
                 if (!self::isBuiltin($lower) && $lowerMap[$lower] !== $t) {
-                    throw new InvalidArgumentException('Duplicate types with different case');
+                    throw new InvalidArgumentException("Duplicate user-defined type with different case: {$t}");
                 }
                 continue;
             }
+
             $lowerMap[$lower] = $canonical;
             $result[] = $canonical;
         }
+
         return $result;
     }
 
@@ -328,10 +337,35 @@ class TypeHint
                 return $lt !== 'true' && $lt !== 'false';
             }));
             $types[] = 'bool';
-            $types = self::normalizeTypes($types);
+            $types = self::canonicalizeCaseAndDeduplicate($types);
             $lower = array_map('strtolower', $types);
         }
 
+        return $types;
+    }
+
+    /** 
+     * Expects already normalized array of types, when 'null' is lowercase
+     */
+    private static function removeNulls(array $types): array
+    {
+        return array_values(array_filter($types, fn($t) => $t !== 'null'));
+    }
+
+    private static function mapLiteralBools(array $types, string $phpVersion): array
+    {
+        $nonNull = self::removeNulls($types);
+
+        if (version_compare($phpVersion, '8.2', '<')) {
+            foreach ($types as &$t) {
+                $lt = strtolower($t);
+                if ($lt === 'true' || ($lt === 'false' && count($nonNull) === 1)) {
+                    $t = 'bool';
+                }
+            }
+            $types = self::canonicalizeCaseAndDeduplicate($types);
+            $types = self::removeRedundantTypes($types);
+        }
         return $types;
     }
 
@@ -340,31 +374,38 @@ class TypeHint
         return in_array($lower, self::BUILTIN_TYPES, true);
     }
 
-    private static function isSupported(string $type, string $phpVersion, string $kind): bool
+    private static function isSupported(string $type, array $types, string $phpVersion, string $kind): bool
     {
-        $min = self::MIN_VERSION[$type][$kind] ?? null;
-        if ($min === null) {
+        $nonNull = self::removeNulls($types);
+
+        if ($type === 'false' && count($nonNull) > 1 && version_compare($phpVersion, '8.0', '>=')) {
+            // false in unions supported since 8.0
             return true;
         }
-        return version_compare($phpVersion, $min, '>=');
+        
+        $minVer = self::MIN_VERSION[$type][$kind] ?? null;
+        if ($minVer === null) {
+            return true;
+        }
+        return version_compare($phpVersion, $minVer, '>=');
     }
 
     /** @param array<string> $types */
     private static function sortTypes(array $types): array
     {
         usort($types, function (string $a, string $b): int {
-            $la = strtolower($a);
-            $lb = strtolower($b);
-            $ia = self::SORT_ORDER[$la] ?? 3; // class-like default
-            $ib = self::SORT_ORDER[$lb] ?? 3;
-            if ($ia === $ib) {
+            $lowerA = strtolower($a);
+            $lowerB = strtolower($b);
+            $indexA = self::SORT_ORDER[$lowerA] ?? 3; // class-like default
+            $indexB = self::SORT_ORDER[$lowerB] ?? 3;
+            if ($indexA === $indexB) {
                 $cmp = strcasecmp($a, $b);
                 if ($cmp === 0) {
                     return strcmp($a, $b);
                 }
                 return $cmp;
             }
-            return $ia <=> $ib;
+            return $indexA <=> $indexB;
         });
         return $types;
     }

--- a/tests/Util/TypeHintUtilTest.php
+++ b/tests/Util/TypeHintUtilTest.php
@@ -97,7 +97,9 @@ class TypeHintUtilTest extends TestCase
             $missing_vers = array_diff(self::ALL_VERS, $providedVersions);
             foreach ($missing_vers as $missingVer) {
                 $prevVer = self::getPrevKnownVer($missingVer);
-                $prevVerData = array_find($versionCases, fn($verData) => $verData[0] === $prevVer);
+                // we do 'array_find' but since there can be multiple version-case entries for the same
+                // php ver (with different flags, for example), we use 'array_reverse' to get the last one
+                $prevVerData = array_find(array_reverse($versionCases), fn($verData) => $verData[0] === $prevVer);
 
                 if ($prevVer && $prevVerData) {
                     $versionCases[] = [
@@ -153,46 +155,53 @@ class TypeHintUtilTest extends TestCase
                         ...$baseKindCases,
                         ...$kindCases,
                     ];
-
+            
                     // now we have "kind cases" normalized for all the vesion cases
-                
 
                     foreach ($kindCases as $kind => $expectedResult) {
-                        $expectedResultStr = $expectedResult === self::EXPECT_EXCEPTION
-                            ? \InvalidArgumentException::class
-                            : ($expectedResult === null ? 'null' : var_export($expectedResult, true));
+                        $exceptionClass = null;
+
+                        if ($expectedResult === self::EXPECT_EXCEPTION) {
+                            $expectedResult = null;
+                            $exceptionClass = \InvalidArgumentException::class;
+                            $exceptionClass = $exceptionClass;
+                            $expectedResultStr = $exceptionClass;
+                        } else {
+                            $expectedResultStr = self::exportVar($expectedResult);
+                        }
                     
                         $caseData = [];
 
                         // create string respresentation of the input type to show in test case names or errors
-                        if (is_array($inputCase)) {
-                            $inputTypeString = "[" . implode(", ", array_map(fn($v)=>var_export($v, true), $inputCase)) . "]";
-                        } else {
-                            $inputTypeString = var_export($inputCase, true);
-                        }
+                        $inputTypeString = self::exportVar($inputCase);
 
                         $legacyFlagStr = '';
                         if ($legacyFlag) {
                             $legacyFlagStr = " with flag '$legacyFlag'";
                         }
 
-                        $caseData = [
-                            'input'      => $inputCase,
-                            'ver'        => $ver,
-                            'kind'       => $kind,
-                            'legacyflag' => $legacyFlag,
-                            'expected'   => $expectedResult,
-                        ];
-
                         $caseName = "{$inputTypeString} → {$expectedResultStr} for php {$ver} for '{$kind}'{$legacyFlagStr}";
 
-                        $data[$caseName] = $caseData;
+                        $caseNameLower = mb_strtolower($caseName); // or pretty-printing will split everything by uppercased chars
+                        if (array_key_exists($caseNameLower, $data)) {
+                            $caseNameLower = "$caseNameLower (2)"; // avoid overriding
+                        }
+
+                        $caseData = [
+                            'caseName'          => $caseName,
+                            'input'             => $inputCase,
+                            'ver'               => $ver,
+                            'kind'              => $kind,
+                            'legacyflag'        => $legacyFlag,
+                            'expected'          => $expectedResult,
+                            'exceptionClass'   => $exceptionClass,
+                        ];
+
+                        $data[$caseNameLower] = $caseData;
                     }
                 }
             }
         }
-
-        // echo "\n---\$data:\n";  print_r($data);  echo "\n---";
 
         return $data;
     }
@@ -209,9 +218,13 @@ class TypeHintUtilTest extends TestCase
         return self::ALL_VERS[$k - 1] ?? null;
     }
 
-    private static function sortVersionCases(array $versionCases): array
+    private static function sortVersionCases(array $versionCases, bool $descending = false): array
     {
-        usort($versionCases, static fn($a, $b) => version_compare($a[0], $b[0]));
+        $sortFn = $descending
+            ? static fn($verDataA, $verDataB) => version_compare($verDataB[0], $verDataA[0])
+            : static fn($verDataA, $verDataB) => version_compare($verDataA[0], $verDataB[0]);
+
+        usort($versionCases, $sortFn(...));
         return $versionCases;
     }
 
@@ -229,6 +242,14 @@ class TypeHintUtilTest extends TestCase
         }
 
         return $kindCases;
+    }
+
+    private static function exportVar(mixed $var): string
+    {
+        if (is_array($var)) {
+            return "[" . implode(", ", array_map(fn ($v) => self::exportVar($v), $var)) . "]";
+        } 
+        return $var === null ? 'null' : var_export($var, true);
     }
 
     /*---------------------------*
@@ -260,7 +281,7 @@ class TypeHintUtilTest extends TestCase
                     ['null', 'false'],
                 ], /* ———————————————————> */ '?false',
                 ['5.6', null],
-                ['7.0', self::EXPECT_EXCEPTION], // if no flag specified, expect throw
+                ['7.0', [self::EXPECT_EXCEPTION, kind::PROP => null]], // if no flag specified, must throw (except when kind is PROP)
                 ['7.0', null, 'flag' => TypeHint::LEGACY_NULLABLE_OMIT_TYPE],
                 ['7.0', ['bool', kind::PROP => null], 'flag' => TypeHint::LEGACY_NULLABLE_DROP_NULL],
                 ['7.1', ['?bool', kind::PROP => null]],
@@ -299,7 +320,7 @@ class TypeHintUtilTest extends TestCase
                     ['bool', 'false|null'],
                 ], /* ———————————————————> */ '?bool',
                 ['5.6', null],
-                ['7.0', self::EXPECT_EXCEPTION],
+                ['7.0', [self::EXPECT_EXCEPTION, kind::PROP => null]],
                 ['7.0', null, 'flag' => TypeHint::LEGACY_NULLABLE_OMIT_TYPE],
                 ['7.0', ['bool', kind::PROP => null], 'flag' => TypeHint::LEGACY_NULLABLE_DROP_NULL],
                 ['7.1', [kind::PROP => null]],
@@ -344,7 +365,7 @@ class TypeHintUtilTest extends TestCase
                     ["$type|" . ucfirst($type) . "|?" . strtoupper($type), "$type"], // ['int|Int|?INT', 'int']
                 ], /* ———————————————————> */ "?$type",
                 ['5.6', null],
-                ['7.0', self::EXPECT_EXCEPTION],
+                ['7.0', [self::EXPECT_EXCEPTION, kind::PROP => null]],
                 ['7.0', null, 'flag' => TypeHint::LEGACY_NULLABLE_OMIT_TYPE],
                 ['7.0', [$type, kind::PROP => null], 'flag' => TypeHint::LEGACY_NULLABLE_DROP_NULL],
                 ['7.1', [kind::PROP => null]],
@@ -368,9 +389,12 @@ class TypeHintUtilTest extends TestCase
                     ['?ARRAY', 'ARRAY'],
                     ['ARRAY|NULL', 'ARRAY'],
                 ], /* ———————————————————> */ '?array',
-                ['5.6', self::EXPECT_EXCEPTION],
+                ['5.6', [self::EXPECT_EXCEPTION, kind::PROP => null, kind::RETURN => null]],
                 ['5.6', null, 'flag' => TypeHint::LEGACY_NULLABLE_OMIT_TYPE],
-                ['5.6', ['array', kind::PROP => null], 'flag' => TypeHint::LEGACY_NULLABLE_DROP_NULL],
+                ['5.6', ['array', kind::PROP => null, kind::RETURN => null], 'flag' => TypeHint::LEGACY_NULLABLE_DROP_NULL],
+                ['7.0', [self::EXPECT_EXCEPTION, kind::PROP => null]],
+                ['7.0', null, 'flag' => TypeHint::LEGACY_NULLABLE_OMIT_TYPE],
+                ['7.0', ['array', kind::PROP => null], 'flag' => TypeHint::LEGACY_NULLABLE_DROP_NULL],
                 ['7.1', [kind::PROP => null]],
                 ['7.4'],
             ],
@@ -433,31 +457,6 @@ class TypeHintUtilTest extends TestCase
         ]);
     }
 
-    public static function invalidInput(): array
-    {
-        return self::convertToProviderArray([
-            [
-                [
-                    'A&B', '(A&B)', ['(A)', 'B'], '(A)|B', // we don't dupport intersections/DNF yet
-                    ['A', '|', 'B'],
-                    'My Class',
-                    '123Class',
-                    ['123', 'MyClass'],
-                    '? MyClass',
-                    '-', '+',
-                    '&', '(', ')',
-                    '?', ['?', 'array'],
-                    '|', ['|', 'array'],
-                    '||', ['||', 'array'],
-                    'A|', ['A|', 'array'],
-                    '\\', ['\\', 'array'],
-                    'string |array', ['string ', 'array'],
-                    'string?|array', ['string ', '?|array'],
-                ], /* ———————————————————> */ self::EXPECT_EXCEPTION,
-            ],
-        ]);
-    }
-
     public static function unions(): array
     {
         return self::convertToProviderArray([
@@ -498,9 +497,19 @@ class TypeHintUtilTest extends TestCase
             ],
             [
                 [
-                    'MyClass_2|null|MyClass_1',
-                    ['MyClass_2', '?MyClass_1'],
-                ], /* ———————————————————> */ 'MyClass_1|MyClass_2|null',
+                    '?\B|B|int|\C|string',
+                    ['?B', 'int', 'string', '\C', '\B'],
+                    ['\B', 'null|B', 'B|int|string|\C', '\B'],
+                    ['string|\B', 'null', '\C|int', '\B|B'],
+                ], /* ———————————————————> */ '\B|\C|B|string|int|null',
+                ['5.6', null],
+                ['8.0'],
+            ],
+            [
+                [
+                    'MyClass_2|null|MyClass_1|\Q',
+                    ['MyClass_2|\Q', '?MyClass_1'],
+                ], /* ———————————————————> */ '\Q|MyClass_1|MyClass_2|null',
                 ['5.6', null],
                 ['7.2', ['?object', kind::PROP => null]],
                 ['7.4', ['?object']],
@@ -508,8 +517,8 @@ class TypeHintUtilTest extends TestCase
             ],
             [
                 [
-                    'array|false|true|float|bool|int|MyObject|object|A|string|null|callable',
-                    ['array', 'false', 'true', 'float', 'bool', 'int', 'MyObject', 'object', 'string', 'null', 'callable'],
+                    'array|false|true|float|bool|int|MyObject|object|A|\B|string|null|callable',
+                    ['array', 'false', 'true', 'float', 'bool', 'int', 'MyObject', 'object', 'A', '\B', 'string', 'null', 'callable'],
                 ], /* ———————————————————> */ 'callable|object|array|string|float|int|bool|null',
                 ['5.6', null],
                 ['8.0'],
@@ -535,7 +544,7 @@ class TypeHintUtilTest extends TestCase
                     ['INT', 'STRING', 'string', 'int'],
                     ['INT|STRING', 'string|int'],
                     ['INT|int', 'string|STRING'],
-                ], /* ———————————————————> */ 'int|string',
+                ], /* ———————————————————> */ 'string|int',
                 ['5.6', null],
                 ['8.0'],
             ],
@@ -605,30 +614,33 @@ class TypeHintUtilTest extends TestCase
         ]);
     }
 
-    /**
-     * Helper that prints all generated case names when debugging the test suite.
-     *
-     * PHPUnit executes only public methods that start with `test`, so make this
-     * method private to avoid cluttering the output during normal runs.
-     */
-    private function test_TEMP_PRINT_CASE_NAMES(): void
+    public static function invalidInput(): array
     {
-        $all = [
-            ...self::booleans(),
-            ...self::scalars(),
-            ...self::nullableScalars(),
-            ...self::nullable(),
-            ...self::standaloneNull(),
-            ...self::neverType(),
-            ...self::voidType(),
-            ...self::invalidInput(),
-            ...self::unions(),
-            ...self::unionSorting(),
-            ...self::redundantAndDuplicate(),
-        ];
-        foreach (array_keys($all) as $caseName) {
-            echo $caseName, "\n";
-        }
+        return self::convertToProviderArray([
+            [
+                [
+                    'A&B', '(A&B)', ['(A)', 'B'], '(A)|B', // we don't dupport intersections/DNF yet
+                    ['A', '|', 'B'],
+                    'My Class',
+                    '123Class',
+                    ['123', 'MyClass'],
+                    '? MyClass',
+                    '-', '+',
+                    '&', '(', ')',
+                    '?', ['?', 'array'],
+                    '|', ['|', 'array'],
+                    '||', ['||', 'array'],
+                    'A|', ['A|', 'array'],
+                    '\\', ['\\', 'array'],
+                    '\|MyClass',
+                    'A\\\B',
+                    '\\\MyClass',
+                    'MyClass\\',
+                    'string |array', ['string ', 'array'],
+                    'string?|array', ['string ', '?|array'],
+                ], /* ———————————————————> */ self::EXPECT_EXCEPTION,
+            ],
+        ]);
     }
 
     /** 
@@ -641,26 +653,36 @@ class TypeHintUtilTest extends TestCase
     #[DataProvider('standaloneNull')]
     #[DataProvider('neverType')]
     #[DataProvider('voidType')]
-    #[DataProvider('invalidInput')]
     #[DataProvider('unions')]
     #[DataProvider('unionSorting')]
     #[DataProvider('redundantAndDuplicate')]
+    #[DataProvider('invalidInput')]
     public function testTypeHint(
+        string $caseName,
         array|string $input,
         string $ver,
         string $kind,
         ?string $legacyflag,
         ?string $expected,
+        ?string $exceptionClass,
     ): void
     {
-        if ($expected === self::EXPECT_EXCEPTION) {
-            $this->expectException(\InvalidArgumentException::class);
-            TypeHint::forPhpVer($input, $ver, $kind, $legacyflag);
+        $message = "Case: {$caseName}";
+
+        if ($exceptionClass) {
+            try {
+                $result = TypeHint::forPhpVer($input, $ver, $kind, $legacyflag);
+                $this->fail("{$message}\nExpected {$exceptionClass} exception, but got this: " . self::exportVar($result));
+            } catch (\InvalidArgumentException $e) {
+                $this->addToAssertionCount(1);
+            }
         } else {
-            assertThat(
-                TypeHint::forPhpVer($input, $ver, $kind),
-                equalTo($expected)
-            );
+            try {
+                $result = TypeHint::forPhpVer($input, $ver, $kind, $legacyflag);
+            } catch (\Throwable $e) {
+                throw new Exception("{$message}\nUtil threw unexpected " . $e::class . ": {$e->getMessage()}", 0, $e);
+            }
+            assertThat($result, equalTo($expected), $message);
         }
     }
 

--- a/tests/Util/TypeHintUtilTest.php
+++ b/tests/Util/TypeHintUtilTest.php
@@ -605,8 +605,13 @@ class TypeHintUtilTest extends TestCase
         ]);
     }
 
-    /** TO REMOVE. ONLY USED TO DEBUG THE TEST ITSELF */
-    public function test_TEMP_PRINT_CASE_NAMES(): void
+    /**
+     * Helper that prints all generated case names when debugging the test suite.
+     *
+     * PHPUnit executes only public methods that start with `test`, so make this
+     * method private to avoid cluttering the output during normal runs.
+     */
+    private function test_TEMP_PRINT_CASE_NAMES(): void
     {
         $all = [
             ...self::booleans(),
@@ -622,8 +627,7 @@ class TypeHintUtilTest extends TestCase
             ...self::redundantAndDuplicate(),
         ];
         foreach (array_keys($all) as $caseName) {
-            echo $caseName;
-            echo "\n";
+            echo $caseName, "\n";
         }
     }
 

--- a/tests/Util/TypeHintUtilTest.php
+++ b/tests/Util/TypeHintUtilTest.php
@@ -46,6 +46,7 @@ class TypeHintUtilTest extends TestCase
     private static function convertToProviderArray($cases)
     {
         $data = [];
+        $uniqueNames = [];
 
         foreach ($cases as $caseIdx => $case) {
             $caseNum = $caseIdx + 1;
@@ -181,6 +182,10 @@ class TypeHintUtilTest extends TestCase
                         }
 
                         $caseName = "{$inputTypeString} → {$expectedResultStr} for php {$ver} for '{$kind}'{$legacyFlagStr}";
+                        $uniqueName = $caseName;
+                        if (array_key_exists($uniqueName, $uniqueNames)) {
+                            $uniqueName = "$uniqueName (2)"; // avoid overriding
+                        }
 
                         $caseNameLower = mb_strtolower($caseName); // or pretty-printing will split everything by uppercased chars
                         if (array_key_exists($caseNameLower, $data)) {
@@ -189,6 +194,7 @@ class TypeHintUtilTest extends TestCase
 
                         $caseData = [
                             'caseName'          => $caseName,
+                            'uniqueName'        => $uniqueName,
                             'input'             => $inputCase,
                             'ver'               => $ver,
                             'kind'              => $kind,
@@ -253,12 +259,87 @@ class TypeHintUtilTest extends TestCase
     }
 
     /*---------------------------*
-    *       Data Providers       *
+    *        Core harness        *
     *----------------------------*/
-
-    public static function booleans(): array
+     
+    private function assertDataset(string $name, array $cases): void
     {
-        return self::convertToProviderArray([
+        $flatCases = self::convertToProviderArray($cases);
+
+        // Re-key the flat list into nested [ver][kind|flag][input] => ['ok' => string] or ['ex' => class]
+        [$expectedMap, $actualMap] = $this->buildMaps($flatCases);
+
+        // Stable ordering helps diffs
+        $this->ksortDeep($expectedMap);
+        $this->ksortDeep($actualMap);
+
+        $this->assertSame(count($flatCases), count($expectedMap), "Test is incorrect");
+        $this->assertSame(count($flatCases), count($actualMap), "Test is incorrect");
+
+        // keep assertion count meaningful: 1 per combination, also substract 3 auxiliary assertions,
+        // and perform it here (not before maps assertion) to keep count the same when map assertion fails
+        $this->addToAssertionCount(count($flatCases) - 3);
+
+        $this->assertSame(
+            $expectedMap,
+            $actualMap,
+            "Fail in '$name'."
+        );
+    }
+
+    /**
+     * @return array{0: array, 1: array}
+     */
+    private function buildMaps(array $flatCases): array
+    {
+        $expected = [];
+        $actual   = [];
+
+        foreach ($flatCases as $case) {
+            $uniqueName  = $case['uniqueName'];
+
+            // expected
+            if ($case['exceptionClass']) {
+                $expected[$uniqueName] = ['ex' => $case['exceptionClass']];
+            } else {
+                $expected[$uniqueName] = ['ok' => $case['expected']]; // expected is already a string or null
+            }
+
+            // actual
+            try {
+                $res = TypeHint::forPhpVer($case['input'], $case['ver'], $case['kind'], $case['legacyflag']);
+                $actual[$uniqueName] = ['ok' => $res];
+            } catch (\Throwable $e) {
+                $actual[$uniqueName] = ['ex' => $e::class];
+            }
+        }
+
+        return [$expected, $actual];
+    }
+
+    private function ksortDeep(array &$a): void
+    {
+        ksort($a);
+        foreach ($a as &$v) {
+            if (is_array($v)) {
+                $this->ksortDeep($v);
+            }
+        }
+    }
+
+    public function testThrowIfVersionIsOlderThan56(): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        TypeHint::forPhpVer('array', '5.4', kind::ARG);
+    }
+
+    /*------------------------*
+    *        Test sets        *
+    *-------------------------*/
+
+    public function testBooleans(): void
+    {
+        $this->assertDataset(__METHOD__, [
             [
                 // input cases
                 [
@@ -329,7 +410,7 @@ class TypeHintUtilTest extends TestCase
         ]);
     }
 
-    public static function scalars(): array
+    public function testScalarsOnly(): void
     {
         $cases = [];
         foreach (TypeHint::SCALARS as $type) {
@@ -346,10 +427,10 @@ class TypeHintUtilTest extends TestCase
                 ['7.4'],
             ];
         }
-        return self::convertToProviderArray($cases);
+        $this->assertDataset(__METHOD__, $cases);
     }
 
-    public static function nullableScalars(): array
+    public function testNullableScalars(): void
     {
         $cases = [];
         foreach (TypeHint::SCALARS as $type) {
@@ -372,12 +453,12 @@ class TypeHintUtilTest extends TestCase
                 ['7.4'],
             ];
         }
-        return self::convertToProviderArray($cases);
+        $this->assertDataset(__METHOD__, $cases);
     }
 
-    public static function nullable(): array
+    public function testNullablesOnly(): void
     {
-        return self::convertToProviderArray([
+        $this->assertDataset(__METHOD__, [
             [
                 [
                     'array|null',
@@ -401,9 +482,9 @@ class TypeHintUtilTest extends TestCase
         ]);
     }
 
-    public static function standaloneNull(): array
+    public function testStandaloneNull(): void
     {
-        return self::convertToProviderArray([
+        $this->assertDataset(__METHOD__, [
             [
                 [
                     'null', ['null'],
@@ -418,9 +499,9 @@ class TypeHintUtilTest extends TestCase
         ]);
     }
 
-    public static function neverType(): array
+    public function testNeverType(): void
     {
-        return self::convertToProviderArray([
+        $this->assertDataset(__METHOD__, [
             [
                 [
                     'never'
@@ -438,9 +519,9 @@ class TypeHintUtilTest extends TestCase
         ]);
     }
 
-    public static function voidType(): array
+    public function testVoidType(): void
     {
-        return self::convertToProviderArray([
+        $this->assertDataset(__METHOD__, [
             [
                 [
                     'void'
@@ -457,9 +538,9 @@ class TypeHintUtilTest extends TestCase
         ]);
     }
 
-    public static function unions(): array
+    public function testUnionsAll(): void
     {
-        return self::convertToProviderArray([
+        $this->assertDataset(__METHOD__, [
             [
                 [
                     'int|string', ['int', 'string'],
@@ -481,9 +562,9 @@ class TypeHintUtilTest extends TestCase
         ]);
     }
 
-    public static function unionSorting(): array
+    public function testUnionSorting(): void
     {
-        return self::convertToProviderArray([
+        $this->assertDataset(__METHOD__, [
             [
                 [
                     'B|A|null|int|string',
@@ -526,9 +607,9 @@ class TypeHintUtilTest extends TestCase
         ]);
     }
 
-    public static function redundantAndDuplicate(): array
+    public function testRedundantAndDuplicate(): void
     {
-        return self::convertToProviderArray([
+        $this->assertDataset(__METHOD__, [
             [
                 [
                     'mixed|A|B|callable|object|array|string|float|int|false|null',
@@ -614,9 +695,9 @@ class TypeHintUtilTest extends TestCase
         ]);
     }
 
-    public static function invalidInput(): array
+    public function testInvalidInput(): void
     {
-        return self::convertToProviderArray([
+        $this->assertDataset(__METHOD__, [
             [
                 [
                     'A&B', '(A&B)', ['(A)', 'B'], '(A)|B', // we don't dupport intersections/DNF yet
@@ -641,54 +722,5 @@ class TypeHintUtilTest extends TestCase
                 ], /* ———————————————————> */ self::EXPECT_EXCEPTION,
             ],
         ]);
-    }
-
-    /** 
-     * Main assertion method
-     */
-    #[DataProvider('booleans')]
-    #[DataProvider('scalars')]
-    #[DataProvider('nullableScalars')]
-    #[DataProvider('nullable')]
-    #[DataProvider('standaloneNull')]
-    #[DataProvider('neverType')]
-    #[DataProvider('voidType')]
-    #[DataProvider('unions')]
-    #[DataProvider('unionSorting')]
-    #[DataProvider('redundantAndDuplicate')]
-    #[DataProvider('invalidInput')]
-    public function testTypeHint(
-        string $caseName,
-        array|string $input,
-        string $ver,
-        string $kind,
-        ?string $legacyflag,
-        ?string $expected,
-        ?string $exceptionClass,
-    ): void
-    {
-        $message = "Case: {$caseName}";
-
-        if ($exceptionClass) {
-            try {
-                $result = TypeHint::forPhpVer($input, $ver, $kind, $legacyflag);
-                $this->fail("{$message}\nExpected {$exceptionClass} exception, but got this: " . self::exportVar($result));
-            } catch (\InvalidArgumentException $e) {
-                $this->addToAssertionCount(1);
-            }
-        } else {
-            try {
-                $result = TypeHint::forPhpVer($input, $ver, $kind, $legacyflag);
-            } catch (\Throwable $e) {
-                throw new Exception("{$message}\nUtil threw unexpected " . $e::class . ": {$e->getMessage()}", 0, $e);
-            }
-            assertThat($result, equalTo($expected), $message);
-        }
-    }
-
-    public function throwIfVersionIsOlderThan56(): void
-    {
-        self::expectException(InvalidArgumentException::class);
-        TypeHint::forPhpVer('array', '5.4', kind::ARG);
     }
 }


### PR DESCRIPTION
## Summary
- add `TypeHint` utility for normalizing PHP types across versions
- hide debugging helper in `TypeHintUtilTest`

## Testing
- `vendor/bin/phpstan --memory-limit=512M`
- `vendor/bin/phpunit --filter TypeHintUtil` *(fails: 191, errors: 164)*


------
https://chatgpt.com/codex/tasks/task_e_689d0af774dc832db625552533ca9ba4