### PR TITLE
Generate item classes for array alternatives in unions

### DIFF
--- a/src/Generator/Expression/ArrowFunctionGenerator.php
+++ b/src/Generator/Expression/ArrowFunctionGenerator.php
@@ -9,12 +9,12 @@ use Helmich\Schema2Class\Util\TypeHint;
 
 class ArrowFunctionGenerator
 {
-    /** 
-     * @param string|array<string,string>[] $parameters  Array of callback params expressions, for example:
+    /**
+     * @param string|array<int, string>|array<string, string|null> $parameters  Array of callback params expressions, for example:
      * ```
      * ['$k', '$v', '...$rest']
      * ```
-     * or 
+     * or
      * ```
      * [
      *  '$k' => 'string',
@@ -22,8 +22,8 @@ class ArrowFunctionGenerator
      *  '...$rest' => null,
      * ]
      * ```
-     * If array key is integer, its value used as param, and no type hint added.  
-     * If array key is NOT integer, it is used as param, and value used as type hint. Use `null` to exclude type hint in that case.  
+     * If array key is integer, its value used as param, and no type hint added.
+     * If array key is NOT integer, it is used as param, and value used as type hint. Use `null` to exclude type hint in that case.
      */
     public static function make(
         string|array $parameters,

--- a/src/Generator/Expression/OrGenerator.php
+++ b/src/Generator/Expression/OrGenerator.php
@@ -7,7 +7,7 @@ use Helmich\Schema2Class\Util\StringUtils;
 
 class OrGenerator
 {
-    /** 
+    /**
      * @param array<int,string> $conditions operands/conditions
      * @param bool $parens Whether to wrap the resulting expression with parenthesis
      */
@@ -17,12 +17,9 @@ class OrGenerator
             throw new \InvalidArgumentException("Attempt to generate OR expression without conditions");
         }
         foreach ($conditions as $k => $cond) {
-            $n = $k + 1;
-            $type = gettype($cond);
-            if (empty($cond)) {
-                throw new \InvalidArgumentException("Condition #{$n} is empty: {$cond} ($type)");
-            } elseif (!is_string($cond)) {
-                throw new \InvalidArgumentException("Condition #{$n} is not string: {$cond} ($type)");
+            if ($cond === '') {
+                $n = $k + 1;
+                throw new \InvalidArgumentException("Condition #{$n} is empty");
             }
         }
 

--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -278,22 +278,8 @@ class UnionProperty extends AbstractProperty
      */
     public function generateSubTypes(WriterInterface $writer, OutputInterface $output): void
     {
-        $def = $this->schema;
-
-        foreach ($def["oneOf"] as $i => $subDef) {
-            $propertyTypeName = $this->subTypeName($i);
-
-            $isObject = (isset($subDef["type"]) && $subDef["type"] === "object") || isset($subDef["properties"]);
-            $isEnum   = isset($subDef["enum"]);
-
-            if ($isObject || $isEnum) {
-                $req = $this->request
-                    ->withSchema($subDef)
-                    ->withClass($propertyTypeName);
-
-                $generator = $this->request->getSchemaToClassFactory()->build($writer, $output);
-                $generator->schemaToClass($this->propagateRootDefinitions($req));
-            }
+        foreach ($this->subProperties as $prop) {
+            $prop->generateSubTypes($writer, $output);
         }
     }
 
@@ -518,11 +504,6 @@ class UnionProperty extends AbstractProperty
         }
 
         return parent::allowsNull();
-    }
-
-    private function subTypeName(int $idx = 0): string
-    {
-        return $this->request->getTargetClass() . $this->nameForClass . "Alternative" . ($idx + 1);
     }
 
     public function needsValidation(): bool

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassArrayOfObjAndStringUnionAlternative1Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassArrayOfObjAndStringUnionAlternative1Item.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_7_4;
+
+class MyClassArrayOfObjAndStringUnionAlternative1Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'name' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'name' => 'name',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $name = null;
+
+    public function __construct(?string $name = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->name = $name;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties(bool $asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties($additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    public function withoutName(): self
+    {
+        $clone = clone $this;
+        unset($clone->name);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassArrayOfObjAndStringUnionAlternative1Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, bool $validate = true): MyClassArrayOfObjAndStringUnionAlternative1Item
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+
+        $obj = new self($name);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->name)) {
+            $output->{'name'} = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassArrayOfObjectsUnionAlternative1Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassArrayOfObjectsUnionAlternative1Item.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_7_4;
+
+class MyClassArrayOfObjectsUnionAlternative1Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'name' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'name' => 'name',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $name = null;
+
+    public function __construct(?string $name = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->name = $name;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties(bool $asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties($additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    public function withoutName(): self
+    {
+        $clone = clone $this;
+        unset($clone->name);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassArrayOfObjectsUnionAlternative1Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, bool $validate = true): MyClassArrayOfObjectsUnionAlternative1Item
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+
+        $obj = new self($name);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->name)) {
+            $output->{'name'} = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassArrayOfObjectsUnionAlternative2Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassArrayOfObjectsUnionAlternative2Item.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_7_4;
+
+class MyClassArrayOfObjectsUnionAlternative2Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'accountNumber' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'accountNumber' => 'accountNumber',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $accountNumber = null;
+
+    public function __construct(?string $accountNumber = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->accountNumber = $accountNumber;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties(bool $asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties($additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getAccountNumber(): ?string
+    {
+        return $this->accountNumber ?? null;
+    }
+
+    public function withAccountNumber(string $accountNumber): self
+    {
+        $clone = clone $this;
+        $clone->accountNumber = $accountNumber;
+
+        return $clone;
+    }
+
+    public function withoutAccountNumber(): self
+    {
+        $clone = clone $this;
+        unset($clone->accountNumber);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassArrayOfObjectsUnionAlternative2Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, bool $validate = true): MyClassArrayOfObjectsUnionAlternative2Item
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $accountNumber = isset($input->{'accountNumber'}) ? $input->{'accountNumber'} : null;
+
+        $obj = new self($accountNumber);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->accountNumber)) {
+            $output['accountNumber'] = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->accountNumber)) {
+            $output->{'accountNumber'} = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_7_4;
+
+class MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'name' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'name' => 'name',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $name = null;
+
+    public function __construct(?string $name = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->name = $name;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties(bool $asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties($additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    public function withoutName(): self
+    {
+        $clone = clone $this;
+        unset($clone->name);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, bool $validate = true): MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+
+        $obj = new self($name);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->name)) {
+            $output->{'name'} = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_7_4;
+
+class MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'name' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'name' => 'name',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $name = null;
+
+    public function __construct(?string $name = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->name = $name;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties(bool $asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties($additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    public function withoutName(): self
+    {
+        $clone = clone $this;
+        unset($clone->name);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, bool $validate = true): MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+
+        $obj = new self($name);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->name)) {
+            $output->{'name'} = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_7_4;
+
+class MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'accountNumber' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'accountNumber' => 'accountNumber',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $accountNumber = null;
+
+    public function __construct(?string $accountNumber = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->accountNumber = $accountNumber;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties(bool $asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties($additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getAccountNumber(): ?string
+    {
+        return $this->accountNumber ?? null;
+    }
+
+    public function withAccountNumber(string $accountNumber): self
+    {
+        $clone = clone $this;
+        $clone->accountNumber = $accountNumber;
+
+        return $clone;
+    }
+
+    public function withoutAccountNumber(): self
+    {
+        $clone = clone $this;
+        unset($clone->accountNumber);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, bool $validate = true): MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $accountNumber = isset($input->{'accountNumber'}) ? $input->{'accountNumber'} : null;
+
+        $obj = new self($accountNumber);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->accountNumber)) {
+            $output['accountNumber'] = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->accountNumber)) {
+            $output->{'accountNumber'} = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_7_4;
+
+class MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'accountNumber' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'accountNumber' => 'accountNumber',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $accountNumber = null;
+
+    public function __construct(?string $accountNumber = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->accountNumber = $accountNumber;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties(bool $asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties($additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getAccountNumber(): ?string
+    {
+        return $this->accountNumber ?? null;
+    }
+
+    public function withAccountNumber(string $accountNumber): self
+    {
+        $clone = clone $this;
+        $clone->accountNumber = $accountNumber;
+
+        return $clone;
+    }
+
+    public function withoutAccountNumber(): self
+    {
+        $clone = clone $this;
+        unset($clone->accountNumber);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, bool $validate = true): MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $accountNumber = isset($input->{'accountNumber'}) ? $input->{'accountNumber'} : null;
+
+        $obj = new self($accountNumber);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->accountNumber)) {
+            $output['accountNumber'] = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->accountNumber)) {
+            $output->{'accountNumber'} = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassRefArrayOfObjectsUnionAlternative1Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassRefArrayOfObjectsUnionAlternative1Item.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_7_4;
+
+class MyClassRefArrayOfObjectsUnionAlternative1Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'name' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'name' => 'name',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $name = null;
+
+    public function __construct(?string $name = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->name = $name;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties(bool $asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties($additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    public function withoutName(): self
+    {
+        $clone = clone $this;
+        unset($clone->name);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassRefArrayOfObjectsUnionAlternative1Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, bool $validate = true): MyClassRefArrayOfObjectsUnionAlternative1Item
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+
+        $obj = new self($name);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->name)) {
+            $output->{'name'} = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassRefArrayOfObjectsUnionAlternative2Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClassRefArrayOfObjectsUnionAlternative2Item.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_7_4;
+
+class MyClassRefArrayOfObjectsUnionAlternative2Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'accountNumber' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'accountNumber' => 'accountNumber',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $accountNumber = null;
+
+    public function __construct(?string $accountNumber = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->accountNumber = $accountNumber;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     * @return array|\stdClass
+     */
+    public function getAdditionalProperties(bool $asArray = true)
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties($additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getAccountNumber(): ?string
+    {
+        return $this->accountNumber ?? null;
+    }
+
+    public function withAccountNumber(string $accountNumber): self
+    {
+        $clone = clone $this;
+        $clone->accountNumber = $accountNumber;
+
+        return $clone;
+    }
+
+    public function withoutAccountNumber(): self
+    {
+        $clone = clone $this;
+        unset($clone->accountNumber);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassRefArrayOfObjectsUnionAlternative2Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput($input, bool $validate = true): MyClassRefArrayOfObjectsUnionAlternative2Item
+    {
+        if (!is_array($input) && !is_object($input)) {
+            throw new \InvalidArgumentException(
+                'Input to fromInput must be array or object, got ' . gettype($input)
+            );
+        }
+
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $accountNumber = isset($input->{'accountNumber'}) ? $input->{'accountNumber'} : null;
+
+        $obj = new self($accountNumber);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->accountNumber)) {
+            $output['accountNumber'] = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->accountNumber)) {
+            $output->{'accountNumber'} = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput($input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassArrayOfObjAndStringUnionAlternative1Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassArrayOfObjAndStringUnionAlternative1Item.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_8_4;
+
+class MyClassArrayOfObjAndStringUnionAlternative1Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'name' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'name' => 'name',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $name = null;
+
+    public function __construct(?string $name = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->name = $name;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     */
+    public function getAdditionalProperties(bool $asArray = true): \stdClass|array
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties(\stdClass|array $additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    public function withoutName(): self
+    {
+        $clone = clone $this;
+        unset($clone->name);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassArrayOfObjAndStringUnionAlternative1Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput(array|object $input, bool $validate = true): MyClassArrayOfObjAndStringUnionAlternative1Item
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+
+        $obj = new self($name);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->name)) {
+            $output->{'name'} = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassArrayOfObjectsUnionAlternative1Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassArrayOfObjectsUnionAlternative1Item.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_8_4;
+
+class MyClassArrayOfObjectsUnionAlternative1Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'name' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'name' => 'name',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $name = null;
+
+    public function __construct(?string $name = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->name = $name;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     */
+    public function getAdditionalProperties(bool $asArray = true): \stdClass|array
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties(\stdClass|array $additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    public function withoutName(): self
+    {
+        $clone = clone $this;
+        unset($clone->name);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassArrayOfObjectsUnionAlternative1Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput(array|object $input, bool $validate = true): MyClassArrayOfObjectsUnionAlternative1Item
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+
+        $obj = new self($name);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->name)) {
+            $output->{'name'} = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassArrayOfObjectsUnionAlternative2Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassArrayOfObjectsUnionAlternative2Item.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_8_4;
+
+class MyClassArrayOfObjectsUnionAlternative2Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'accountNumber' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'accountNumber' => 'accountNumber',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $accountNumber = null;
+
+    public function __construct(?string $accountNumber = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->accountNumber = $accountNumber;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     */
+    public function getAdditionalProperties(bool $asArray = true): \stdClass|array
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties(\stdClass|array $additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getAccountNumber(): ?string
+    {
+        return $this->accountNumber ?? null;
+    }
+
+    public function withAccountNumber(string $accountNumber): self
+    {
+        $clone = clone $this;
+        $clone->accountNumber = $accountNumber;
+
+        return $clone;
+    }
+
+    public function withoutAccountNumber(): self
+    {
+        $clone = clone $this;
+        unset($clone->accountNumber);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassArrayOfObjectsUnionAlternative2Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput(array|object $input, bool $validate = true): MyClassArrayOfObjectsUnionAlternative2Item
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $accountNumber = isset($input->{'accountNumber'}) ? $input->{'accountNumber'} : null;
+
+        $obj = new self($accountNumber);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->accountNumber)) {
+            $output['accountNumber'] = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->accountNumber)) {
+            $output->{'accountNumber'} = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_8_4;
+
+class MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'name' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'name' => 'name',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $name = null;
+
+    public function __construct(?string $name = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->name = $name;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     */
+    public function getAdditionalProperties(bool $asArray = true): \stdClass|array
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties(\stdClass|array $additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    public function withoutName(): self
+    {
+        $clone = clone $this;
+        unset($clone->name);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput(array|object $input, bool $validate = true): MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+
+        $obj = new self($name);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->name)) {
+            $output->{'name'} = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_8_4;
+
+class MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'name' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'name' => 'name',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $name = null;
+
+    public function __construct(?string $name = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->name = $name;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     */
+    public function getAdditionalProperties(bool $asArray = true): \stdClass|array
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties(\stdClass|array $additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    public function withoutName(): self
+    {
+        $clone = clone $this;
+        unset($clone->name);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput(array|object $input, bool $validate = true): MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+
+        $obj = new self($name);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->name)) {
+            $output->{'name'} = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_8_4;
+
+class MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'accountNumber' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'accountNumber' => 'accountNumber',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $accountNumber = null;
+
+    public function __construct(?string $accountNumber = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->accountNumber = $accountNumber;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     */
+    public function getAdditionalProperties(bool $asArray = true): \stdClass|array
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties(\stdClass|array $additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getAccountNumber(): ?string
+    {
+        return $this->accountNumber ?? null;
+    }
+
+    public function withAccountNumber(string $accountNumber): self
+    {
+        $clone = clone $this;
+        $clone->accountNumber = $accountNumber;
+
+        return $clone;
+    }
+
+    public function withoutAccountNumber(): self
+    {
+        $clone = clone $this;
+        unset($clone->accountNumber);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput(array|object $input, bool $validate = true): MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $accountNumber = isset($input->{'accountNumber'}) ? $input->{'accountNumber'} : null;
+
+        $obj = new self($accountNumber);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->accountNumber)) {
+            $output['accountNumber'] = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->accountNumber)) {
+            $output->{'accountNumber'} = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_8_4;
+
+class MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'accountNumber' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'accountNumber' => 'accountNumber',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $accountNumber = null;
+
+    public function __construct(?string $accountNumber = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->accountNumber = $accountNumber;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     */
+    public function getAdditionalProperties(bool $asArray = true): \stdClass|array
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties(\stdClass|array $additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getAccountNumber(): ?string
+    {
+        return $this->accountNumber ?? null;
+    }
+
+    public function withAccountNumber(string $accountNumber): self
+    {
+        $clone = clone $this;
+        $clone->accountNumber = $accountNumber;
+
+        return $clone;
+    }
+
+    public function withoutAccountNumber(): self
+    {
+        $clone = clone $this;
+        unset($clone->accountNumber);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput(array|object $input, bool $validate = true): MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $accountNumber = isset($input->{'accountNumber'}) ? $input->{'accountNumber'} : null;
+
+        $obj = new self($accountNumber);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->accountNumber)) {
+            $output['accountNumber'] = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->accountNumber)) {
+            $output->{'accountNumber'} = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassRefArrayOfObjectsUnionAlternative1Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassRefArrayOfObjectsUnionAlternative1Item.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_8_4;
+
+class MyClassRefArrayOfObjectsUnionAlternative1Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'name' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'name' => 'name',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $name = null;
+
+    public function __construct(?string $name = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->name = $name;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     */
+    public function getAdditionalProperties(bool $asArray = true): \stdClass|array
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties(\stdClass|array $additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    public function withoutName(): self
+    {
+        $clone = clone $this;
+        unset($clone->name);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassRefArrayOfObjectsUnionAlternative1Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput(array|object $input, bool $validate = true): MyClassRefArrayOfObjectsUnionAlternative1Item
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $name = isset($input->{'name'}) ? $input->{'name'} : null;
+
+        $obj = new self($name);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->name)) {
+            $output['name'] = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->name)) {
+            $output->{'name'} = $this->name;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassRefArrayOfObjectsUnionAlternative2Item.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClassRefArrayOfObjectsUnionAlternative2Item.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\UnionArrayObject_8_4;
+
+class MyClassRefArrayOfObjectsUnionAlternative2Item
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     */
+    private static array $_schema = [
+        'properties' => [
+            'accountNumber' => [
+                'type' => 'string',
+            ],
+        ],
+        'definitions' => [
+            'ArrayOfObjects1' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'ArrayOfObjects2' => [
+                'type' => 'array',
+                'items' => [
+                    'properties' => [
+                        'accountNumber' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * Mapping of schema property names to this class's property names.
+     */
+    private static array $_namesMap = [
+        'accountNumber' => 'accountNumber',
+    ];
+
+    /**
+     * Map of name/value pairs for properties not specified in the schema.
+     */
+    private \stdClass $_additionalProperties;
+
+    private ?string $accountNumber = null;
+
+    public function __construct(?string $accountNumber = null)
+    {
+        $this->_additionalProperties = new \stdClass();
+
+        $this->accountNumber = $accountNumber;
+    }
+
+    /**
+     * Object (`stdClass`) or array with name/value pairs for properties not specified in the schema.
+     *
+     * @param bool $asArray Whether return an associative array instead of `stdClass` object.
+     */
+    public function getAdditionalProperties(bool $asArray = true): \stdClass|array
+    {
+        return $asArray
+            ? json_decode(json_encode($this->_additionalProperties), true)
+            : $this->_additionalProperties;
+    }
+
+    /**
+     * Allows adding properties not specified in the schema.
+     *
+     * @param \stdClass|array $additionalProperties Map of property name/value pairs to add.
+     */
+    public function withAdditionalProperties(\stdClass|array $additionalProperties): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = is_array($additionalProperties)
+            ? \JsonSchema\Validator::arrayToObjectRecursive($additionalProperties)
+            : $additionalProperties;
+
+        return $clone;
+    }
+
+    /**
+     * Removes all extra properties not specified in the schema.
+     */
+    public function withoutAdditionalProperties(): self
+    {
+        $clone = clone $this;
+        $clone->_additionalProperties = new \stdClass();
+        return $clone;
+    }
+
+    public function getAccountNumber(): ?string
+    {
+        return $this->accountNumber ?? null;
+    }
+
+    public function withAccountNumber(string $accountNumber): self
+    {
+        $clone = clone $this;
+        $clone->accountNumber = $accountNumber;
+
+        return $clone;
+    }
+
+    public function withoutAccountNumber(): self
+    {
+        $clone = clone $this;
+        unset($clone->accountNumber);
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array or object
+     *
+     * @param array|object $input Input data
+     * @param bool $validate If `false`, validation against the schema will be skipped.
+     * @return MyClassRefArrayOfObjectsUnionAlternative2Item Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function fromInput(array|object $input, bool $validate = true): MyClassRefArrayOfObjectsUnionAlternative2Item
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $accountNumber = isset($input->{'accountNumber'}) ? $input->{'accountNumber'} : null;
+
+        $obj = new self($accountNumber);
+
+        $_additionalProperties = array_diff_key(get_object_vars($input), self::$_namesMap);
+        if (!empty($_additionalProperties)) {
+            $obj->_additionalProperties = (object) $_additionalProperties;
+        }
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object to array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toArray(): array
+    {
+        $output = json_decode(json_encode($this->_additionalProperties), true);
+
+        if (isset($this->accountNumber)) {
+            $output['accountNumber'] = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Converts this object to a stdClass that can be JSON-serialized
+     *
+     * @return \stdClass Converted object
+     */
+    public function toStdClass(): \stdClass
+    {
+        $output = $this->_additionalProperties;
+
+        if (isset($this->accountNumber)) {
+            $output->{'accountNumber'} = $this->accountNumber;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false): bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, self::$_schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
+            throw new \InvalidArgumentException(join(".\n", $errors));
+        }
+
+        return $validator->isValid();
+    }
+}


### PR DESCRIPTION
## Summary
- properly generate subtypes for union branches with arrays of objects
- align arrow function parameter docs with accepted shapes
- regenerate union array object fixtures

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit tests/Generator/ClassGenerationTest.php --filter UnionArrayObject`
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` (fails: Match expression does not handle remaining value: true)

------
https://chatgpt.com/codex/tasks/task_e_689f9a62ec4c832d8998c6b97e2d0c27