### PR TITLE
Refactor union array handling to avoid duplicate is_array checks

### DIFF
--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -107,13 +107,16 @@ class UnionProperty extends AbstractProperty
     
             // If this arm is an "array" type, prefix its test with is_array(...)
             if (
-                $subProp instanceof ReferenceArrayProperty
-                || $subProp instanceof ObjectArrayProperty
-                || $subProp instanceof PrimitiveArrayProperty
+                (
+                    $subProp instanceof ReferenceArrayProperty
+                    || $subProp instanceof ObjectArrayProperty
+                    || $subProp instanceof PrimitiveArrayProperty
+                )
+                && !str_contains($discriminator, "is_array({$accessor})")
             ) {
                 $discriminator = "(is_array({$accessor}) && {$discriminator})";
             }
-    
+
             if (! isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => [], "fallback" => false];
             }
@@ -133,7 +136,8 @@ class UnionProperty extends AbstractProperty
             }
 
             $keyword = count($branches) ? "elseif" : "if";
-            $parenthesizedCondition = OrGenerator::make($info["discriminators"]);
+            $conds = array_values(array_unique($info["discriminators"]));
+            $parenthesizedCondition = OrGenerator::make($conds);
 
             $branches[] = 
                 <<<PHP
@@ -220,7 +224,8 @@ class UnionProperty extends AbstractProperty
 
         $branches = [];
         foreach ($conversions as $assignment => $conversion) {
-            $parenthesizedCondition = OrGenerator::make($conversion["discriminators"]);
+            $conds = array_values(array_unique($conversion["discriminators"]));
+            $parenthesizedCondition = OrGenerator::make($conds);
             $keyword = count($branches) ? "elseif" : "if";
             $branches[] =
                 <<<PHP
@@ -260,7 +265,8 @@ class UnionProperty extends AbstractProperty
 
         $branches = [];
         foreach ($conversions as $assignment => $conversion) {
-            $parenthesizedCondition = OrGenerator::make($conversion["discriminators"]);
+            $conds = array_values(array_unique($conversion["discriminators"]));
+            $parenthesizedCondition = OrGenerator::make($conds);
             $keyword = count($branches) ? "elseif" : "if";
             $branches[] =
                 <<<PHP
@@ -377,6 +383,8 @@ class UnionProperty extends AbstractProperty
             $subAssertions[] = $prop->typeAssertionExpr($expr);
         }
 
+        $subAssertions = array_values(array_unique($subAssertions));
+
         return OrGenerator::make($subAssertions);
     }
 
@@ -387,6 +395,8 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $prop) {
             $subAssertions[] = $prop->inputAssertionExpr($expr);
         }
+
+        $subAssertions = array_values(array_unique($subAssertions));
 
         return OrGenerator::make($subAssertions);
     }
@@ -401,18 +411,29 @@ class UnionProperty extends AbstractProperty
                 $map    = $subProperty->inputMappingExpr($expr);
                 $match->addArm($assert, $map);
             }
-            
+
             $match->addArm("default", "null");
 
             return $match->generate();
         }
 
-        $out = "null";
+        $conversions = [];
 
         foreach ($this->subProperties as $subProperty) {
             $assert = $subProperty->inputAssertionExpr($expr);
             $map    = $subProperty->inputMappingExpr($expr);
-            $out    = TernaryGenerator::make($assert, $map, $out);
+
+            if (!isset($conversions[$map])) {
+                $conversions[$map] = [];
+            }
+            $conversions[$map][] = $assert;
+        }
+
+        $out = "null";
+        foreach ($conversions as $map => $asserts) {
+            $conds = array_values(array_unique($asserts));
+            $condition = OrGenerator::make($conds);
+            $out = TernaryGenerator::make($condition, $map, $out);
         }
 
         return $out;
@@ -484,12 +505,31 @@ class UnionProperty extends AbstractProperty
             return $match->generate();
         }
 
-        $out = $expr;
+        $conversions = [];
 
         foreach ($this->subProperties as $subProperty) {
             $assert = $subProperty->typeAssertionExpr($expr);
             $map    = $subProperty->cloneExpr($expr);
-            $out    = TernaryGenerator::make($assert, $map, $out);
+
+            if ($map === $expr) {
+                continue;
+            }
+
+            if (!isset($conversions[$map])) {
+                $conversions[$map] = [];
+            }
+            $conversions[$map][] = $assert;
+        }
+
+        if ($conversions === []) {
+            return $expr;
+        }
+
+        $out = $expr;
+        foreach ($conversions as $map => $asserts) {
+            $conds = array_values(array_unique($asserts));
+            $condition = OrGenerator::make($conds);
+            $out = TernaryGenerator::make($condition, $map, $out);
         }
 
         return $out;

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
@@ -186,9 +186,9 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'})
-            ? (is_int($input->{'foo'})
+            ? ((is_int($input->{'foo'}))
                 ? (int)$input->{'foo'}
-                : (is_string($input->{'foo'}) ? $input->{'foo'} : null)
+                : ((is_string($input->{'foo'})) ? $input->{'foo'} : null)
             )
             : null;
 
@@ -292,12 +292,5 @@ class MyClass
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = (is_int($this->foo) ? $this->foo : (is_string($this->foo) ? $this->foo : $this->foo));
-        }
     }
 }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
@@ -182,11 +182,11 @@ class BarTest
         }
 
         $exampleProp = isset($input->{'exampleProp'})
-            ? (FooTest_1::validateInput($input->{'exampleProp'}, true)
+            ? ((FooTest_1::validateInput($input->{'exampleProp'}, true))
                 ? FooTest_1::fromInput($input->{'exampleProp'}, $validate)
-                : (MoiKlass::validateInput($input->{'exampleProp'}, true)
+                : ((MoiKlass::validateInput($input->{'exampleProp'}, true))
                     ? MoiKlass::fromInput($input->{'exampleProp'}, $validate)
-                    : (FooTest::validateInput($input->{'exampleProp'}, true)
+                    : ((FooTest::validateInput($input->{'exampleProp'}, true))
                         ? FooTest::fromInput($input->{'exampleProp'}, $validate)
                         : null
                     )
@@ -280,18 +280,5 @@ class BarTest
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->exampleProp)) {
-            $this->exampleProp = ($this->exampleProp instanceof FooTest_1
-                ? $this->exampleProp
-                : ($this->exampleProp instanceof MoiKlass
-                    ? $this->exampleProp
-                    : ($this->exampleProp instanceof FooTest ? $this->exampleProp : $this->exampleProp)
-                )
-            );
-        }
     }
 }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -170,11 +170,11 @@ class BarTest
         }
 
         $exampleProp = isset($input->{'exampleProp'})
-            ? (FooTest_1::validateInput($input->{'exampleProp'}, true)
+            ? ((FooTest_1::validateInput($input->{'exampleProp'}, true))
                 ? FooTest_1::fromInput($input->{'exampleProp'}, $validate)
-                : (MoiKlass::validateInput($input->{'exampleProp'}, true)
+                : ((MoiKlass::validateInput($input->{'exampleProp'}, true))
                     ? MoiKlass::fromInput($input->{'exampleProp'}, $validate)
-                    : (FooTest::validateInput($input->{'exampleProp'}, true)
+                    : ((FooTest::validateInput($input->{'exampleProp'}, true))
                         ? FooTest::fromInput($input->{'exampleProp'}, $validate)
                         : null
                     )
@@ -269,18 +269,5 @@ class BarTest
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->exampleProp)) {
-            $this->exampleProp = ($this->exampleProp instanceof FooTest_1
-                ? $this->exampleProp
-                : ($this->exampleProp instanceof MoiKlass
-                    ? $this->exampleProp
-                    : ($this->exampleProp instanceof FooTest ? $this->exampleProp : $this->exampleProp)
-                )
-            );
-        }
     }
 }

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -2357,11 +2357,11 @@ class MyClass
             : null;
         $_providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? (is_string($input->{'ensureArgs1'})
+            ? ((is_string($input->{'ensureArgs1'}))
                 ? $input->{'ensureArgs1'}
-                : (MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)
+                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : (MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)
+                    : ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
                         ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
                         : null
                     )
@@ -2671,15 +2671,11 @@ class MyClass
             $this->testObj = clone $this->testObj;
         }
         if (isset($this->ensureArgs1)) {
-            $this->ensureArgs1 = (is_string($this->ensureArgs1)
-                ? $this->ensureArgs1
-                : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
-                    ? clone $this->ensureArgs1
-                    : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
-                        ? clone $this->ensureArgs1
-                        : $this->ensureArgs1
-                    )
-                )
+            $this->ensureArgs1 = (($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
+            )
+                ? clone $this->ensureArgs1
+                : $this->ensureArgs1
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -1383,11 +1383,11 @@ class MyClass
             : null;
         $_providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? (is_string($input->{'ensureArgs1'})
+            ? ((is_string($input->{'ensureArgs1'}))
                 ? $input->{'ensureArgs1'}
-                : (MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)
+                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : (MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)
+                    : ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
                         ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
                         : null
                     )
@@ -1695,15 +1695,11 @@ class MyClass
             $this->testObj = clone $this->testObj;
         }
         if (isset($this->ensureArgs1)) {
-            $this->ensureArgs1 = (is_string($this->ensureArgs1)
-                ? $this->ensureArgs1
-                : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
-                    ? clone $this->ensureArgs1
-                    : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
-                        ? clone $this->ensureArgs1
-                        : $this->ensureArgs1
-                    )
-                )
+            $this->ensureArgs1 = (($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
+            )
+                ? clone $this->ensureArgs1
+                : $this->ensureArgs1
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -2357,11 +2357,11 @@ class MyClass
             : null;
         $__providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? (is_string($input->{'ensureArgs1'})
+            ? ((is_string($input->{'ensureArgs1'}))
                 ? $input->{'ensureArgs1'}
-                : (MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)
+                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : (MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)
+                    : ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
                         ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
                         : null
                     )
@@ -2671,15 +2671,11 @@ class MyClass
             $this->testObj = clone $this->testObj;
         }
         if (isset($this->ensureArgs1)) {
-            $this->ensureArgs1 = (is_string($this->ensureArgs1)
-                ? $this->ensureArgs1
-                : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
-                    ? clone $this->ensureArgs1
-                    : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
-                        ? clone $this->ensureArgs1
-                        : $this->ensureArgs1
-                    )
-                )
+            $this->ensureArgs1 = (($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
+            )
+                ? clone $this->ensureArgs1
+                : $this->ensureArgs1
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -1383,11 +1383,11 @@ class MyClass
             : null;
         $__providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? (is_string($input->{'ensureArgs1'})
+            ? ((is_string($input->{'ensureArgs1'}))
                 ? $input->{'ensureArgs1'}
-                : (MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)
+                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : (MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)
+                    : ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
                         ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
                         : null
                     )
@@ -1695,15 +1695,11 @@ class MyClass
             $this->testObj = clone $this->testObj;
         }
         if (isset($this->ensureArgs1)) {
-            $this->ensureArgs1 = (is_string($this->ensureArgs1)
-                ? $this->ensureArgs1
-                : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
-                    ? clone $this->ensureArgs1
-                    : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
-                        ? clone $this->ensureArgs1
-                        : $this->ensureArgs1
-                    )
-                )
+            $this->ensureArgs1 = (($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
+            )
+                ? clone $this->ensureArgs1
+                : $this->ensureArgs1
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
@@ -182,9 +182,9 @@ class Baz
         }
 
         $grox = isset($input->{'grox'})
-            ? (Bar::validateInput($input->{'grox'}, true)
+            ? ((Bar::validateInput($input->{'grox'}, true))
                 ? Bar::fromInput($input->{'grox'}, $validate)
-                : (Foo::validateInput($input->{'grox'}, true)
+                : ((Foo::validateInput($input->{'grox'}, true))
                     ? Foo::fromInput($input->{'grox'}, $validate)
                     : null
                 )
@@ -271,15 +271,5 @@ class Baz
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->grox)) {
-            $this->grox = ($this->grox instanceof Bar
-                ? $this->grox
-                : ($this->grox instanceof Foo ? $this->grox : $this->grox)
-            );
-        }
     }
 }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -195,18 +195,15 @@ class Qux
         }
 
         $grox = isset($input->{'grox'})
-            ? ((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true))
-                ? (Bar::validateInput($input->{'grox'}, true)
+            ? (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
+                ? ((Bar::validateInput($input->{'grox'}, true))
                     ? Bar::fromInput($input->{'grox'}, $validate)
-                    : (Foo::validateInput($input->{'grox'}, true)
+                    : ((Foo::validateInput($input->{'grox'}, true))
                         ? Foo::fromInput($input->{'grox'}, $validate)
                         : null
                     )
                 )
-                : (is_array($input->{'grox'})
-                    ? $input->{'grox'}
-                    : (is_string($input->{'grox'}) ? $input->{'grox'} : null)
-                )
+                : ((is_string($input->{'grox'}) || is_array($input->{'grox'})) ? $input->{'grox'} : null)
             )
             : null;
 
@@ -300,21 +297,5 @@ class Qux
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->grox)) {
-            $this->grox = (($this->grox instanceof Foo || $this->grox instanceof Bar)
-                ? ($this->grox instanceof Bar
-                    ? $this->grox
-                    : ($this->grox instanceof Foo ? $this->grox : $this->grox)
-                )
-                : (is_array($this->grox)
-                    ? $this->grox
-                    : (is_string($this->grox) ? $this->grox : $this->grox)
-                )
-            );
-        }
     }
 }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -170,9 +170,9 @@ class Baz
         }
 
         $grox = isset($input->{'grox'})
-            ? (Bar::validateInput($input->{'grox'}, true)
+            ? ((Bar::validateInput($input->{'grox'}, true))
                 ? Bar::fromInput($input->{'grox'}, $validate)
-                : (Foo::validateInput($input->{'grox'}, true)
+                : ((Foo::validateInput($input->{'grox'}, true))
                     ? Foo::fromInput($input->{'grox'}, $validate)
                     : null
                 )
@@ -260,15 +260,5 @@ class Baz
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->grox)) {
-            $this->grox = ($this->grox instanceof Bar
-                ? $this->grox
-                : ($this->grox instanceof Foo ? $this->grox : $this->grox)
-            );
-        }
     }
 }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -183,18 +183,15 @@ class Qux
         }
 
         $grox = isset($input->{'grox'})
-            ? ((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true))
-                ? (Bar::validateInput($input->{'grox'}, true)
+            ? (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
+                ? ((Bar::validateInput($input->{'grox'}, true))
                     ? Bar::fromInput($input->{'grox'}, $validate)
-                    : (Foo::validateInput($input->{'grox'}, true)
+                    : ((Foo::validateInput($input->{'grox'}, true))
                         ? Foo::fromInput($input->{'grox'}, $validate)
                         : null
                     )
                 )
-                : (is_array($input->{'grox'})
-                    ? $input->{'grox'}
-                    : (is_string($input->{'grox'}) ? $input->{'grox'} : null)
-                )
+                : ((is_string($input->{'grox'}) || is_array($input->{'grox'})) ? $input->{'grox'} : null)
             )
             : null;
 
@@ -289,21 +286,5 @@ class Qux
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->grox)) {
-            $this->grox = (($this->grox instanceof Foo || $this->grox instanceof Bar)
-                ? ($this->grox instanceof Bar
-                    ? $this->grox
-                    : ($this->grox instanceof Foo ? $this->grox : $this->grox)
-                )
-                : (is_array($this->grox)
-                    ? $this->grox
-                    : (is_string($this->grox) ? $this->grox : $this->grox)
-                )
-            );
-        }
     }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -201,9 +201,9 @@ class MyClass
 
         $foo = $input->{'foo'};
         $bar = isset($input->{'bar'})
-            ? (is_array($input->{'bar'}) || is_object($input->{'bar'})
+            ? ((is_string($input->{'bar'}) || is_array($input->{'bar'}) || is_object($input->{'bar'}))
                 ? $input->{'bar'}
-                : (is_string($input->{'bar'}) ? $input->{'bar'} : null)
+                : null
             )
             : null;
 
@@ -301,19 +301,5 @@ class MyClass
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        $this->foo = (is_array($this->foo) || is_object($this->foo)
-            ? $this->foo
-            : (is_string($this->foo) ? $this->foo : $this->foo)
-        );
-        if (isset($this->bar)) {
-            $this->bar = (is_array($this->bar) || is_object($this->bar)
-                ? $this->bar
-                : (is_string($this->bar) ? $this->bar : $this->bar)
-            );
-        }
     }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -187,9 +187,9 @@ class MyClass
 
         $foo = $input->{'foo'};
         $bar = isset($input->{'bar'})
-            ? (is_array($input->{'bar'}) || is_object($input->{'bar'})
+            ? ((is_string($input->{'bar'}) || is_array($input->{'bar'}) || is_object($input->{'bar'}))
                 ? $input->{'bar'}
-                : (is_string($input->{'bar'}) ? $input->{'bar'} : null)
+                : null
             )
             : null;
 
@@ -288,19 +288,5 @@ class MyClass
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        $this->foo = (is_array($this->foo) || is_object($this->foo)
-            ? $this->foo
-            : (is_string($this->foo) ? $this->foo : $this->foo)
-        );
-        if (isset($this->bar)) {
-            $this->bar = (is_array($this->bar) || is_object($this->bar)
-                ? $this->bar
-                : (is_string($this->bar) ? $this->bar : $this->bar)
-            );
-        }
     }
 }

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-5.6/MyClass.php
@@ -243,9 +243,6 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = ($this->foo instanceof MyClassFooAlternative2
-            ? clone $this->foo
-            : (is_string($this->foo) ? $this->foo : $this->foo)
-        );
+        $this->foo = (($this->foo instanceof MyClassFooAlternative2) ? clone $this->foo : $this->foo);
     }
 }

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClass.php
@@ -235,9 +235,6 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = ($this->foo instanceof MyClassFooAlternative2
-            ? clone $this->foo
-            : (is_string($this->foo) ? $this->foo : $this->foo)
-        );
+        $this->foo = (($this->foo instanceof MyClassFooAlternative2) ? clone $this->foo : $this->foo);
     }
 }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-5.6/Record.php
@@ -355,18 +355,18 @@ class Record
             : null;
         $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'})
             ? array_map(function($i) use ($validate) {
-                return (Fio::validateInput($i, true)
+                return ((Fio::validateInput($i, true))
                     ? Fio::fromInput($i, $validate)
-                    : (Phone::validateInput($i, true) ? Phone::fromInput($i, $validate) : null)
+                    : ((Phone::validateInput($i, true)) ? Phone::fromInput($i, $validate) : null)
                 );
             }, $input->{'dataArrayAnyOf'})
             : null;
         $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'})
             ? array_map(function($i) use ($validate) {
                 return array_map(function($i) use ($validate) {
-                    return (Fio::validateInput($i, true)
+                    return ((Fio::validateInput($i, true))
                         ? Fio::fromInput($i, $validate)
-                        : (Phone::validateInput($i, true) ? Phone::fromInput($i, $validate) : null)
+                        : ((Phone::validateInput($i, true)) ? Phone::fromInput($i, $validate) : null)
                     );
                 }, $i);
             }, $input->{'dataArrayNestedAnyOf'})
@@ -511,15 +511,17 @@ class Record
             );
         }
         if (isset($this->dataArrayAnyOf)) {
-            $this->dataArrayAnyOf = array_map(function($i) {
-                return ($i instanceof Fio ? $i : ($i instanceof Phone ? $i : $i));
-            }, $this->dataArrayAnyOf);
+            $this->dataArrayAnyOf = array_map(
+                function($i) { return $i; },
+                $this->dataArrayAnyOf
+            );
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $this->dataArrayNestedAnyOf = array_map(function($i) {
-                return array_map(function($i) {
-                    return ($i instanceof Fio ? $i : ($i instanceof Phone ? $i : $i));
-                }, $i);
+                return array_map(
+                    function($i) { return $i; },
+                    $i
+                );
             }, $this->dataArrayNestedAnyOf);
         }
     }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-7.4/Record.php
@@ -324,16 +324,16 @@ class Record
             )
             : null;
         $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'})
-            ? array_map(fn ($i) => (Fio::validateInput($i, true)
+            ? array_map(fn ($i) => ((Fio::validateInput($i, true))
                 ? Fio::fromInput($i, $validate)
-                : (Phone::validateInput($i, true) ? Phone::fromInput($i, $validate) : null)
+                : ((Phone::validateInput($i, true)) ? Phone::fromInput($i, $validate) : null)
             ), $input->{'dataArrayAnyOf'})
             : null;
         $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'})
             ? array_map(
-                fn ($i) => array_map(fn ($i) => (Fio::validateInput($i, true)
+                fn ($i) => array_map(fn ($i) => ((Fio::validateInput($i, true))
                     ? Fio::fromInput($i, $validate)
-                    : (Phone::validateInput($i, true) ? Phone::fromInput($i, $validate) : null)
+                    : ((Phone::validateInput($i, true)) ? Phone::fromInput($i, $validate) : null)
                 ), $i),
                 $input->{'dataArrayNestedAnyOf'},
             )
@@ -460,16 +460,10 @@ class Record
             $this->dataArrayNested = array_map(fn ($i) => $i, $this->dataArrayNested);
         }
         if (isset($this->dataArrayAnyOf)) {
-            $this->dataArrayAnyOf = array_map(
-                fn ($i) => ($i instanceof Fio ? $i : ($i instanceof Phone ? $i : $i)),
-                $this->dataArrayAnyOf,
-            );
+            $this->dataArrayAnyOf = array_map(fn ($i) => $i, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
-            $this->dataArrayNestedAnyOf = array_map(
-                fn ($i) => array_map(fn ($i) => ($i instanceof Fio ? $i : ($i instanceof Phone ? $i : $i)), $i),
-                $this->dataArrayNestedAnyOf,
-            );
+            $this->dataArrayNestedAnyOf = array_map(fn ($i) => array_map(fn ($i) => $i, $i), $this->dataArrayNestedAnyOf);
         }
     }
 }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
@@ -177,12 +177,4 @@ class MyObject
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = (in_array($this->foo, ['baz', 'quz'], true)
-            ? $this->foo
-            : (in_array($this->foo, ['foo', 'bar'], true) ? $this->foo : $this->foo)
-        );
-    }
 }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
@@ -176,12 +176,4 @@ class MyObject
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = (in_array($this->foo, ['baz', 'quz'], true)
-            ? $this->foo
-            : (in_array($this->foo, ['foo', 'bar'], true) ? $this->foo : $this->foo)
-        );
-    }
 }

--- a/tests/Generator/Fixtures/SettersValidation/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-5.6/Foo.php
@@ -346,9 +346,9 @@ class Foo
 
         $_providedOptionals = [];
         $a = isset($input->{'a'})
-            ? (is_array($input->{'a'})
+            ? ((in_array($input->{'a'}, ['a', 'b'], true) || is_array($input->{'a'}))
                 ? $input->{'a'}
-                : (in_array($input->{'a'}, ['a', 'b'], true) ? $input->{'a'} : null)
+                : null
             )
             : null;
         $b = isset($input->{'b'}) ? $input->{'b'} : null;
@@ -458,16 +458,6 @@ class Foo
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->a)) {
-            $this->a = (is_array($this->a)
-                ? $this->a
-                : (in_array($this->a, ['a', 'b'], true) ? $this->a : $this->a)
-            );
-        }
     }
 
     /**

--- a/tests/Generator/Fixtures/SettersValidation/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-7.4/Foo.php
@@ -307,9 +307,9 @@ class Foo
 
         $_providedOptionals = [];
         $a = isset($input->{'a'})
-            ? (is_array($input->{'a'})
+            ? ((in_array($input->{'a'}, ['a', 'b'], true) || is_array($input->{'a'}))
                 ? $input->{'a'}
-                : (in_array($input->{'a'}, ['a', 'b'], true) ? $input->{'a'} : null)
+                : null
             )
             : null;
         $b = isset($input->{'b'}) ? $input->{'b'} : null;
@@ -420,16 +420,6 @@ class Foo
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->a)) {
-            $this->a = (is_array($this->a)
-                ? $this->a
-                : (in_array($this->a, ['a', 'b'], true) ? $this->a : $this->a)
-            );
-        }
     }
 
     /**

--- a/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
@@ -155,12 +155,12 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'})
-            ? ((is_int($input->{'foo'}) || is_float($input->{'foo'}))
+            ? (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
                 ? (str_contains((string)$input->{'foo'}, '.')
                     ? (float)$input->{'foo'}
                     : (int)$input->{'foo'}
                 )
-                : (is_string($input->{'foo'}) ? $input->{'foo'} : null)
+                : ((is_string($input->{'foo'})) ? $input->{'foo'} : null)
             )
             : null;
 
@@ -244,15 +244,5 @@ class MyClass
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = ((is_int($this->foo) || is_float($this->foo))
-                ? $this->foo
-                : (is_string($this->foo) ? $this->foo : $this->foo)
-            );
-        }
     }
 }

--- a/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
@@ -143,12 +143,12 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'})
-            ? ((is_int($input->{'foo'}) || is_float($input->{'foo'}))
+            ? (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
                 ? (str_contains((string)$input->{'foo'}, '.')
                     ? (float)$input->{'foo'}
                     : (int)$input->{'foo'}
                 )
-                : (is_string($input->{'foo'}) ? $input->{'foo'} : null)
+                : ((is_string($input->{'foo'})) ? $input->{'foo'} : null)
             )
             : null;
 
@@ -233,15 +233,5 @@ class MyClass
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = ((is_int($this->foo) || is_float($this->foo))
-                ? $this->foo
-                : (is_string($this->foo) ? $this->foo : $this->foo)
-            );
-        }
     }
 }

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
@@ -413,20 +413,22 @@ class MyClass
         }
 
         $arrayOfObjectsUnion = isset($input->{'arrayOfObjectsUnion'})
-            ? ((is_array($input->{'arrayOfObjectsUnion'})
+            ? (((is_array($input->{'arrayOfObjectsUnion'})
                 && count($input->{'arrayOfObjectsUnion'}) === count(array_filter(
                     $input->{'arrayOfObjectsUnion'},
                     fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => MyClassArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
                 )))
+            )
                 ? array_map(
                     fn ($i): MyClassArrayOfObjectsUnionAlternative2Item => MyClassArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                     $input->{'arrayOfObjectsUnion'},
                 )
-                : ((is_array($input->{'arrayOfObjectsUnion'})
+                : (((is_array($input->{'arrayOfObjectsUnion'})
                     && count($input->{'arrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'arrayOfObjectsUnion'},
                         fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => MyClassArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
                     )))
+                )
                     ? array_map(
                         fn ($i): MyClassArrayOfObjectsUnionAlternative1Item => MyClassArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
                         $input->{'arrayOfObjectsUnion'},
@@ -436,20 +438,22 @@ class MyClass
             )
             : null;
         $refArrayOfObjectsUnion = isset($input->{'refArrayOfObjectsUnion'})
-            ? ((is_array($input->{'refArrayOfObjectsUnion'})
+            ? (((is_array($input->{'refArrayOfObjectsUnion'})
                 && count($input->{'refArrayOfObjectsUnion'}) === count(array_filter(
                     $input->{'refArrayOfObjectsUnion'},
                     fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => MyClassRefArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
                 )))
+            )
                 ? array_map(
                     fn ($i): MyClassRefArrayOfObjectsUnionAlternative2Item => MyClassRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                     $input->{'refArrayOfObjectsUnion'},
                 )
-                : ((is_array($input->{'refArrayOfObjectsUnion'})
+                : (((is_array($input->{'refArrayOfObjectsUnion'})
                     && count($input->{'refArrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'refArrayOfObjectsUnion'},
                         fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => MyClassRefArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
                     )))
+                )
                     ? array_map(
                         fn ($i): MyClassRefArrayOfObjectsUnionAlternative1Item => MyClassRefArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
                         $input->{'refArrayOfObjectsUnion'},
@@ -459,38 +463,42 @@ class MyClass
             )
             : null;
         $refAndNotRefArrayOfObjectsUnion = isset($input->{'refAndNotRefArrayOfObjectsUnion'})
-            ? ((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+            ? (((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                 && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                     $input->{'refAndNotRefArrayOfObjectsUnion'},
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::validateInput($item, true),
                 )))
+            )
                 ? array_map(
                     fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::fromInput($i, $validate),
                     $input->{'refAndNotRefArrayOfObjectsUnion'},
                 )
-                : ((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                : (((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                     && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item::validateInput($item, true),
                     )))
+                )
                     ? array_map(
                         fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item::fromInput($i, $validate),
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                     )
-                    : ((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                    : (((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                         && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                             $input->{'refAndNotRefArrayOfObjectsUnion'},
                             fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
                         )))
+                    )
                         ? array_map(
                             fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                             $input->{'refAndNotRefArrayOfObjectsUnion'},
                         )
-                        : ((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                        : (((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                             && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                                 $input->{'refAndNotRefArrayOfObjectsUnion'},
                                 fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
                             )))
+                        )
                             ? array_map(
                                 fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
                                 $input->{'refAndNotRefArrayOfObjectsUnion'},
@@ -502,13 +510,14 @@ class MyClass
             )
             : null;
         $arrayOfObjAndStringUnion = isset($input->{'arrayOfObjAndStringUnion'})
-            ? (is_string($input->{'arrayOfObjAndStringUnion'})
+            ? ((is_string($input->{'arrayOfObjAndStringUnion'}))
                 ? $input->{'arrayOfObjAndStringUnion'}
-                : ((is_array($input->{'arrayOfObjAndStringUnion'})
+                : (((is_array($input->{'arrayOfObjAndStringUnion'})
                     && count($input->{'arrayOfObjAndStringUnion'}) === count(array_filter(
                         $input->{'arrayOfObjAndStringUnion'},
                         fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => MyClassArrayOfObjAndStringUnionAlternative1Item::validateInput($item, true),
                     )))
+                )
                     ? array_map(
                         fn ($i): MyClassArrayOfObjAndStringUnionAlternative1Item => MyClassArrayOfObjAndStringUnionAlternative1Item::fromInput($i, $validate),
                         $input->{'arrayOfObjAndStringUnion'},
@@ -826,20 +835,22 @@ class MyClass
     public function __clone()
     {
         if (isset($this->arrayOfObjectsUnion)) {
-            $this->arrayOfObjectsUnion = ((is_array($this->arrayOfObjectsUnion)
+            $this->arrayOfObjectsUnion = (((is_array($this->arrayOfObjectsUnion)
                 && count($this->arrayOfObjectsUnion) === count(array_filter(
                     $this->arrayOfObjectsUnion,
                     fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative2Item,
                 )))
+            )
                 ? array_map(
                     fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => clone $i,
                     $this->arrayOfObjectsUnion,
                 )
-                : ((is_array($this->arrayOfObjectsUnion)
+                : (((is_array($this->arrayOfObjectsUnion)
                     && count($this->arrayOfObjectsUnion) === count(array_filter(
                         $this->arrayOfObjectsUnion,
                         fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative1Item,
                     )))
+                )
                     ? array_map(
                         fn (MyClassArrayOfObjectsUnionAlternative1Item $i) => clone $i,
                         $this->arrayOfObjectsUnion,
@@ -849,20 +860,22 @@ class MyClass
             );
         }
         if (isset($this->refArrayOfObjectsUnion)) {
-            $this->refArrayOfObjectsUnion = ((is_array($this->refArrayOfObjectsUnion)
+            $this->refArrayOfObjectsUnion = (((is_array($this->refArrayOfObjectsUnion)
                 && count($this->refArrayOfObjectsUnion) === count(array_filter(
                     $this->refArrayOfObjectsUnion,
                     fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative2Item,
                 )))
+            )
                 ? array_map(
                     fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => clone $i,
                     $this->refArrayOfObjectsUnion,
                 )
-                : ((is_array($this->refArrayOfObjectsUnion)
+                : (((is_array($this->refArrayOfObjectsUnion)
                     && count($this->refArrayOfObjectsUnion) === count(array_filter(
                         $this->refArrayOfObjectsUnion,
                         fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative1Item,
                     )))
+                )
                     ? array_map(
                         fn (MyClassRefArrayOfObjectsUnionAlternative1Item $i) => clone $i,
                         $this->refArrayOfObjectsUnion,
@@ -872,38 +885,42 @@ class MyClass
             );
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
-            $this->refAndNotRefArrayOfObjectsUnion = ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+            $this->refAndNotRefArrayOfObjectsUnion = (((is_array($this->refAndNotRefArrayOfObjectsUnion)
                 && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                     $this->refAndNotRefArrayOfObjectsUnion,
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item,
                 )))
+            )
                 ? array_map(
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => clone $i,
                     $this->refAndNotRefArrayOfObjectsUnion,
                 )
-                : ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+                : (((is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item,
                     )))
+                )
                     ? array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $i) => clone $i,
                         $this->refAndNotRefArrayOfObjectsUnion,
                     )
-                    : ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+                    : (((is_array($this->refAndNotRefArrayOfObjectsUnion)
                         && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                             $this->refAndNotRefArrayOfObjectsUnion,
                             fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item,
                         )))
+                    )
                         ? array_map(
                             fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $i) => clone $i,
                             $this->refAndNotRefArrayOfObjectsUnion,
                         )
-                        : ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+                        : (((is_array($this->refAndNotRefArrayOfObjectsUnion)
                             && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                                 $this->refAndNotRefArrayOfObjectsUnion,
                                 fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item,
                             )))
+                        )
                             ? array_map(
                                 fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $i) => clone $i,
                                 $this->refAndNotRefArrayOfObjectsUnion,
@@ -915,19 +932,17 @@ class MyClass
             );
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
-            $this->arrayOfObjAndStringUnion = (is_string($this->arrayOfObjAndStringUnion)
-                ? $this->arrayOfObjAndStringUnion
-                : ((is_array($this->arrayOfObjAndStringUnion)
-                    && count($this->arrayOfObjAndStringUnion) === count(array_filter(
-                        $this->arrayOfObjAndStringUnion,
-                        fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjAndStringUnionAlternative1Item,
-                    )))
-                    ? array_map(
-                        fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => clone $i,
-                        $this->arrayOfObjAndStringUnion,
-                    )
-                    : $this->arrayOfObjAndStringUnion
+            $this->arrayOfObjAndStringUnion = (((is_array($this->arrayOfObjAndStringUnion)
+                && count($this->arrayOfObjAndStringUnion) === count(array_filter(
+                    $this->arrayOfObjAndStringUnion,
+                    fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjAndStringUnionAlternative1Item,
+                )))
+            )
+                ? array_map(
+                    fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => clone $i,
+                    $this->arrayOfObjAndStringUnion,
                 )
+                : $this->arrayOfObjAndStringUnion
             );
         }
         if (isset($this->unionOfOneArrayOfObjects)) {

--- a/tests/Generator/Fixtures/UnionArrayTyped/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayTyped/Output-7.4/MyClass.php
@@ -381,42 +381,26 @@ class MyClass
         }
 
         $unionOfTypedArrays = isset($input->{'unionOfTypedArrays'})
-            ? (is_array($input->{'unionOfTypedArrays'})
-                ? $input->{'unionOfTypedArrays'}
-                : (is_array($input->{'unionOfTypedArrays'}) ? $input->{'unionOfTypedArrays'} : null)
-            )
+            ? ((is_array($input->{'unionOfTypedArrays'})) ? $input->{'unionOfTypedArrays'} : null)
             : null;
         $refUnionOfTypedArrays = isset($input->{'refUnionOfTypedArrays'})
-            ? (is_array($input->{'refUnionOfTypedArrays'})
+            ? ((is_array($input->{'refUnionOfTypedArrays'}))
                 ? $input->{'refUnionOfTypedArrays'}
-                : (is_array($input->{'refUnionOfTypedArrays'})
-                    ? $input->{'refUnionOfTypedArrays'}
-                    : null
-                )
+                : null
             )
             : null;
         $refAndNotRefUnionOfTypedArrays = isset($input->{'refAndNotRefUnionOfTypedArrays'})
-            ? (is_array($input->{'refAndNotRefUnionOfTypedArrays'})
+            ? ((is_array($input->{'refAndNotRefUnionOfTypedArrays'}))
                 ? $input->{'refAndNotRefUnionOfTypedArrays'}
-                : (is_array($input->{'refAndNotRefUnionOfTypedArrays'})
-                    ? $input->{'refAndNotRefUnionOfTypedArrays'}
-                    : (is_array($input->{'refAndNotRefUnionOfTypedArrays'})
-                        ? $input->{'refAndNotRefUnionOfTypedArrays'}
-                        : (is_array($input->{'refAndNotRefUnionOfTypedArrays'})
-                            ? $input->{'refAndNotRefUnionOfTypedArrays'}
-                            : null
-                        )
-                    )
-                )
+                : null
             )
             : null;
         $unionOfTypedArrayAndString = isset($input->{'unionOfTypedArrayAndString'})
-            ? (is_string($input->{'unionOfTypedArrayAndString'})
+            ? ((is_array($input->{'unionOfTypedArrayAndString'})
+                || is_string($input->{'unionOfTypedArrayAndString'})
+            )
                 ? $input->{'unionOfTypedArrayAndString'}
-                : (is_array($input->{'unionOfTypedArrayAndString'})
-                    ? $input->{'unionOfTypedArrayAndString'}
-                    : null
-                )
+                : null
             )
             : null;
         $unionOfOneTypedArray = isset($input->{'unionOfOneTypedArray'}) ? $input->{'unionOfOneTypedArray'} : null;
@@ -447,21 +431,17 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->unionOfTypedArrays)) {
-            if (is_array($this->unionOfTypedArrays) || is_array($this->unionOfTypedArrays)) {
+            if (is_array($this->unionOfTypedArrays)) {
                 $output['unionOfTypedArrays'] = $this->unionOfTypedArrays;
             }
         }
         if (isset($this->refUnionOfTypedArrays)) {
-            if (is_array($this->refUnionOfTypedArrays) || is_array($this->refUnionOfTypedArrays)) {
+            if (is_array($this->refUnionOfTypedArrays)) {
                 $output['refUnionOfTypedArrays'] = $this->refUnionOfTypedArrays;
             }
         }
         if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            if (is_array($this->refAndNotRefUnionOfTypedArrays)
-                || is_array($this->refAndNotRefUnionOfTypedArrays)
-                || is_array($this->refAndNotRefUnionOfTypedArrays)
-                || is_array($this->refAndNotRefUnionOfTypedArrays)
-            ) {
+            if (is_array($this->refAndNotRefUnionOfTypedArrays)) {
                 $output['refAndNotRefUnionOfTypedArrays'] = $this->refAndNotRefUnionOfTypedArrays;
             }
         }
@@ -487,21 +467,17 @@ class MyClass
         $output = $this->_additionalProperties;
 
         if (isset($this->unionOfTypedArrays)) {
-            if (is_array($this->unionOfTypedArrays) || is_array($this->unionOfTypedArrays)) {
+            if (is_array($this->unionOfTypedArrays)) {
                 $output->{'unionOfTypedArrays'} = $this->unionOfTypedArrays;
             }
         }
         if (isset($this->refUnionOfTypedArrays)) {
-            if (is_array($this->refUnionOfTypedArrays) || is_array($this->refUnionOfTypedArrays)) {
+            if (is_array($this->refUnionOfTypedArrays)) {
                 $output->{'refUnionOfTypedArrays'} = $this->refUnionOfTypedArrays;
             }
         }
         if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            if (is_array($this->refAndNotRefUnionOfTypedArrays)
-                || is_array($this->refAndNotRefUnionOfTypedArrays)
-                || is_array($this->refAndNotRefUnionOfTypedArrays)
-                || is_array($this->refAndNotRefUnionOfTypedArrays)
-            ) {
+            if (is_array($this->refAndNotRefUnionOfTypedArrays)) {
                 $output->{'refAndNotRefUnionOfTypedArrays'} = $this->refAndNotRefUnionOfTypedArrays;
             }
         }
@@ -552,51 +528,5 @@ class MyClass
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->unionOfTypedArrays)) {
-            $this->unionOfTypedArrays = (is_array($this->unionOfTypedArrays)
-                ? $this->unionOfTypedArrays
-                : (is_array($this->unionOfTypedArrays)
-                    ? $this->unionOfTypedArrays
-                    : $this->unionOfTypedArrays
-                )
-            );
-        }
-        if (isset($this->refUnionOfTypedArrays)) {
-            $this->refUnionOfTypedArrays = (is_array($this->refUnionOfTypedArrays)
-                ? $this->refUnionOfTypedArrays
-                : (is_array($this->refUnionOfTypedArrays)
-                    ? $this->refUnionOfTypedArrays
-                    : $this->refUnionOfTypedArrays
-                )
-            );
-        }
-        if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            $this->refAndNotRefUnionOfTypedArrays = (is_array($this->refAndNotRefUnionOfTypedArrays)
-                ? $this->refAndNotRefUnionOfTypedArrays
-                : (is_array($this->refAndNotRefUnionOfTypedArrays)
-                    ? $this->refAndNotRefUnionOfTypedArrays
-                    : (is_array($this->refAndNotRefUnionOfTypedArrays)
-                        ? $this->refAndNotRefUnionOfTypedArrays
-                        : (is_array($this->refAndNotRefUnionOfTypedArrays)
-                            ? $this->refAndNotRefUnionOfTypedArrays
-                            : $this->refAndNotRefUnionOfTypedArrays
-                        )
-                    )
-                )
-            );
-        }
-        if (isset($this->unionOfTypedArrayAndString)) {
-            $this->unionOfTypedArrayAndString = (is_string($this->unionOfTypedArrayAndString)
-                ? $this->unionOfTypedArrayAndString
-                : (is_array($this->unionOfTypedArrayAndString)
-                    ? $this->unionOfTypedArrayAndString
-                    : $this->unionOfTypedArrayAndString
-                )
-            );
-        }
     }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
@@ -311,16 +311,7 @@ class MyClass
         $bar = $input->{'bar'};
         $baz = $input->{'baz'};
         $qux = ($input->{'qux'} !== null
-            ? (is_string($input->{'qux'})
-                ? $input->{'qux'}
-                : (is_string($input->{'qux'})
-                    ? $input->{'qux'}
-                    : (is_string($input->{'qux'})
-                        ? $input->{'qux'}
-                        : (is_string($input->{'qux'}) ? $input->{'qux'} : null)
-                    )
-                )
-            )
+            ? ((is_string($input->{'qux'})) ? $input->{'qux'} : null)
             : null
         );
 
@@ -343,16 +334,16 @@ class MyClass
     {
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
-        if (is_string($this->foo) || is_string($this->foo)) {
+        if (is_string($this->foo)) {
             $output['foo'] = $this->foo;
         }
-        if (is_string($this->bar) || is_string($this->bar)) {
+        if (is_string($this->bar)) {
             $output['bar'] = $this->bar;
         }
-        if (is_string($this->baz) || is_string($this->baz)) {
+        if (is_string($this->baz)) {
             $output['baz'] = $this->baz;
         }
-        if (is_string($this->qux) || is_string($this->qux) || is_string($this->qux) || is_string($this->qux)) {
+        if (is_string($this->qux)) {
             $output['qux'] = $this->qux;
         }
 
@@ -368,16 +359,16 @@ class MyClass
     {
         $output = $this->_additionalProperties;
 
-        if (is_string($this->foo) || is_string($this->foo)) {
+        if (is_string($this->foo)) {
             $output->{'foo'} = $this->foo;
         }
-        if (is_string($this->bar) || is_string($this->bar)) {
+        if (is_string($this->bar)) {
             $output->{'bar'} = $this->bar;
         }
-        if (is_string($this->baz) || is_string($this->baz)) {
+        if (is_string($this->baz)) {
             $output->{'baz'} = $this->baz;
         }
-        if (is_string($this->qux) || is_string($this->qux) || is_string($this->qux) || is_string($this->qux)) {
+        if (is_string($this->qux)) {
             $output->{'qux'} = $this->qux;
         }
 
@@ -418,31 +409,5 @@ class MyClass
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        $this->foo = (is_string($this->foo)
-            ? $this->foo
-            : (is_string($this->foo) ? $this->foo : $this->foo)
-        );
-        $this->bar = (is_string($this->bar)
-            ? $this->bar
-            : (is_string($this->bar) ? $this->bar : $this->bar)
-        );
-        $this->baz = (is_string($this->baz)
-            ? $this->baz
-            : (is_string($this->baz) ? $this->baz : $this->baz)
-        );
-        $this->qux = (is_string($this->qux)
-            ? $this->qux
-            : (is_string($this->qux)
-                ? $this->qux
-                : (is_string($this->qux)
-                    ? $this->qux
-                    : (is_string($this->qux) ? $this->qux : $this->qux)
-                )
-            )
-        );
     }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -254,16 +254,7 @@ class MyClass
         $bar = $input->{'bar'};
         $baz = $input->{'baz'};
         $qux = ($input->{'qux'} !== null
-            ? (is_string($input->{'qux'})
-                ? $input->{'qux'}
-                : (is_string($input->{'qux'})
-                    ? $input->{'qux'}
-                    : (is_string($input->{'qux'})
-                        ? $input->{'qux'}
-                        : (is_string($input->{'qux'}) ? $input->{'qux'} : null)
-                    )
-                )
-            )
+            ? ((is_string($input->{'qux'})) ? $input->{'qux'} : null)
             : null
         );
 
@@ -286,16 +277,16 @@ class MyClass
     {
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
-        if (is_string($this->foo) || is_string($this->foo)) {
+        if (is_string($this->foo)) {
             $output['foo'] = $this->foo;
         }
-        if (is_string($this->bar) || is_string($this->bar)) {
+        if (is_string($this->bar)) {
             $output['bar'] = $this->bar;
         }
-        if (is_string($this->baz) || is_string($this->baz)) {
+        if (is_string($this->baz)) {
             $output['baz'] = $this->baz;
         }
-        if (is_string($this->qux) || is_string($this->qux) || is_string($this->qux) || is_string($this->qux)) {
+        if (is_string($this->qux)) {
             $output['qux'] = $this->qux;
         }
 
@@ -311,16 +302,16 @@ class MyClass
     {
         $output = $this->_additionalProperties;
 
-        if (is_string($this->foo) || is_string($this->foo)) {
+        if (is_string($this->foo)) {
             $output->{'foo'} = $this->foo;
         }
-        if (is_string($this->bar) || is_string($this->bar)) {
+        if (is_string($this->bar)) {
             $output->{'bar'} = $this->bar;
         }
-        if (is_string($this->baz) || is_string($this->baz)) {
+        if (is_string($this->baz)) {
             $output->{'baz'} = $this->baz;
         }
-        if (is_string($this->qux) || is_string($this->qux) || is_string($this->qux) || is_string($this->qux)) {
+        if (is_string($this->qux)) {
             $output->{'qux'} = $this->qux;
         }
 
@@ -362,31 +353,5 @@ class MyClass
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        $this->foo = (is_string($this->foo)
-            ? $this->foo
-            : (is_string($this->foo) ? $this->foo : $this->foo)
-        );
-        $this->bar = (is_string($this->bar)
-            ? $this->bar
-            : (is_string($this->bar) ? $this->bar : $this->bar)
-        );
-        $this->baz = (is_string($this->baz)
-            ? $this->baz
-            : (is_string($this->baz) ? $this->baz : $this->baz)
-        );
-        $this->qux = (is_string($this->qux)
-            ? $this->qux
-            : (is_string($this->qux)
-                ? $this->qux
-                : (is_string($this->qux)
-                    ? $this->qux
-                    : (is_string($this->qux) ? $this->qux : $this->qux)
-                )
-            )
-        );
     }
 }

--- a/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
@@ -434,31 +434,31 @@ class MyClass
 
         $_providedOptionals = [];
         $objectsUnion = isset($input->{'objectsUnion'})
-            ? (MyClassObjectsUnionAlternative2::validateInput($input->{'objectsUnion'}, true)
+            ? ((MyClassObjectsUnionAlternative2::validateInput($input->{'objectsUnion'}, true))
                 ? MyClassObjectsUnionAlternative2::fromInput($input->{'objectsUnion'}, $validate)
-                : (MyClassObjectsUnionAlternative1::validateInput($input->{'objectsUnion'}, true)
+                : ((MyClassObjectsUnionAlternative1::validateInput($input->{'objectsUnion'}, true))
                     ? MyClassObjectsUnionAlternative1::fromInput($input->{'objectsUnion'}, $validate)
                     : null
                 )
             )
             : null;
         $refObjectsUnion = isset($input->{'refObjectsUnion'})
-            ? (SomeObj2::validateInput($input->{'refObjectsUnion'}, true)
+            ? ((SomeObj2::validateInput($input->{'refObjectsUnion'}, true))
                 ? SomeObj2::fromInput($input->{'refObjectsUnion'}, $validate)
-                : (SomeObj1::validateInput($input->{'refObjectsUnion'}, true)
+                : ((SomeObj1::validateInput($input->{'refObjectsUnion'}, true))
                     ? SomeObj1::fromInput($input->{'refObjectsUnion'}, $validate)
                     : null
                 )
             )
             : null;
         $refAndNotRefObjectsUnion = isset($input->{'refAndNotRefObjectsUnion'})
-            ? (MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true)
+            ? ((MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
                 ? MyClassRefAndNotRefObjectsUnionAlternative4::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                : (SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)
+                : ((SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
                     ? SomeObj2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                    : (MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)
+                    : ((MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
                         ? MyClassRefAndNotRefObjectsUnionAlternative2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                        : (SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true)
+                        : ((SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
                             ? SomeObj1::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
                             : null
                         )
@@ -467,9 +467,9 @@ class MyClass
             )
             : null;
         $objAndStringUnion = isset($input->{'objAndStringUnion'})
-            ? (is_string($input->{'objAndStringUnion'})
+            ? ((is_string($input->{'objAndStringUnion'}))
                 ? $input->{'objAndStringUnion'}
-                : (MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true)
+                : ((MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true))
                     ? MyClassObjAndStringUnionAlternative1::fromInput($input->{'objAndStringUnion'}, $validate)
                     : null
                 )
@@ -636,45 +636,25 @@ class MyClass
     public function __clone()
     {
         if (isset($this->objectsUnion)) {
-            $this->objectsUnion = ($this->objectsUnion instanceof MyClassObjectsUnionAlternative2
+            $this->objectsUnion = (($this->objectsUnion instanceof MyClassObjectsUnionAlternative1
+                || $this->objectsUnion instanceof MyClassObjectsUnionAlternative2
+            )
                 ? clone $this->objectsUnion
-                : ($this->objectsUnion instanceof MyClassObjectsUnionAlternative1
-                    ? clone $this->objectsUnion
-                    : $this->objectsUnion
-                )
-            );
-        }
-        if (isset($this->refObjectsUnion)) {
-            $this->refObjectsUnion = ($this->refObjectsUnion instanceof SomeObj2
-                ? $this->refObjectsUnion
-                : ($this->refObjectsUnion instanceof SomeObj1
-                    ? $this->refObjectsUnion
-                    : $this->refObjectsUnion
-                )
+                : $this->objectsUnion
             );
         }
         if (isset($this->refAndNotRefObjectsUnion)) {
-            $this->refAndNotRefObjectsUnion = ($this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4
+            $this->refAndNotRefObjectsUnion = (($this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
+                || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4
+            )
                 ? clone $this->refAndNotRefObjectsUnion
-                : ($this->refAndNotRefObjectsUnion instanceof SomeObj2
-                    ? $this->refAndNotRefObjectsUnion
-                    : ($this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
-                        ? clone $this->refAndNotRefObjectsUnion
-                        : ($this->refAndNotRefObjectsUnion instanceof SomeObj1
-                            ? $this->refAndNotRefObjectsUnion
-                            : $this->refAndNotRefObjectsUnion
-                        )
-                    )
-                )
+                : $this->refAndNotRefObjectsUnion
             );
         }
         if (isset($this->objAndStringUnion)) {
-            $this->objAndStringUnion = (is_string($this->objAndStringUnion)
-                ? $this->objAndStringUnion
-                : ($this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1
-                    ? clone $this->objAndStringUnion
-                    : $this->objAndStringUnion
-                )
+            $this->objAndStringUnion = (($this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1)
+                ? clone $this->objAndStringUnion
+                : $this->objAndStringUnion
             );
         }
         if (isset($this->unionOfOneObj)) {


### PR DESCRIPTION
## Summary
- avoid repeating `is_array` guards when generating unions of array types
- merge duplicate union branches in input/output/clone logic
- regenerate fixtures

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_689fb369be0c832d8cc2764b197935db