### PR TITLE
Deduplicate is_array checks in union property handling

### DIFF
--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -63,13 +63,29 @@ class UnionProperty extends AbstractProperty
     {
         $inputVarName = ArgumentNames::INPUT;
         $accessor = "\${$inputVarName}->{{$this->keyStr()}}";
-
-        $match = new MatchGenerator("true");
-
+        $arms = [];
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->inputMappingExpr($accessor, asserted: true);
             $discriminator = $subProperty->inputAssertionExpr($accessor);
-            $match->addArm($discriminator, $mapping);
+
+            if (
+                $subProperty instanceof ReferenceArrayProperty
+                || $subProperty instanceof ObjectArrayProperty
+                || $subProperty instanceof PrimitiveArrayProperty
+            ) {
+                $isArrayCheck = "is_array({$accessor})";
+                if (!str_contains($discriminator, $isArrayCheck)) {
+                    $discriminator = "({$isArrayCheck} && {$discriminator})";
+                }
+            }
+
+            $arms[$mapping][] = $discriminator;
+        }
+
+        $match = new MatchGenerator("true");
+        foreach ($arms as $mapping => $discriminators) {
+            $conditions = array_values(array_unique($discriminators));
+            $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
         }
 
         $match->addArm(
@@ -105,13 +121,16 @@ class UnionProperty extends AbstractProperty
             $assignment    = "\${$name} = {$mapping};";
             $discriminator = $subProp->inputAssertionExpr($accessor);
     
-            // If this arm is an "array" type, prefix its test with is_array(...)
+            // If this arm is an "array" type, ensure its test guards against non-arrays
             if (
                 $subProp instanceof ReferenceArrayProperty
                 || $subProp instanceof ObjectArrayProperty
                 || $subProp instanceof PrimitiveArrayProperty
             ) {
-                $discriminator = "(is_array({$accessor}) && {$discriminator})";
+                $isArrayCheck = "is_array({$accessor})";
+                if (!str_contains($discriminator, $isArrayCheck)) {
+                    $discriminator = "({$isArrayCheck} && {$discriminator})";
+                }
             }
     
             if (! isset($conversions[$assignment])) {
@@ -133,7 +152,8 @@ class UnionProperty extends AbstractProperty
             }
 
             $keyword = count($branches) ? "elseif" : "if";
-            $parenthesizedCondition = OrGenerator::make($info["discriminators"]);
+            $conditions = array_values(array_unique($info["discriminators"]));
+            $parenthesizedCondition = OrGenerator::make($conditions);
 
             $branches[] = 
                 <<<PHP
@@ -165,13 +185,18 @@ class UnionProperty extends AbstractProperty
     {
         $name   = $this->propName();
         $keyStr = $this->keyStr();
-        $match  = new MatchGenerator("true");
+        $arms  = [];
 
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExpr("\$this->{$name}");
             $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+            $arms[$mapping][] = $discriminator;
+        }
 
-            $match->addArm($discriminator, $mapping);
+        $match = new MatchGenerator("true");
+        foreach ($arms as $mapping => $discriminators) {
+            $conditions = array_values(array_unique($discriminators));
+            $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
         }
         $outputVarName = VariableNames::OUTPUT;
         return "\${$outputVarName}[{$keyStr}] = {$match->generate()};";
@@ -181,12 +206,18 @@ class UnionProperty extends AbstractProperty
     {
         $name   = $this->propName();
         $keyStr = $this->keyStr();
-        $match  = new MatchGenerator("true");
+        $arms  = [];
 
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExprStdClass("\$this->{$name}");
             $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
-            $match->addArm($discriminator, $mapping);
+            $arms[$mapping][] = $discriminator;
+        }
+
+        $match = new MatchGenerator("true");
+        foreach ($arms as $mapping => $discriminators) {
+            $conditions = array_values(array_unique($discriminators));
+            $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
         }
 
         $outputVarName = VariableNames::OUTPUT;
@@ -220,7 +251,8 @@ class UnionProperty extends AbstractProperty
 
         $branches = [];
         foreach ($conversions as $assignment => $conversion) {
-            $parenthesizedCondition = OrGenerator::make($conversion["discriminators"]);
+            $conditions = array_values(array_unique($conversion["discriminators"]));
+            $parenthesizedCondition = OrGenerator::make($conditions);
             $keyword = count($branches) ? "elseif" : "if";
             $branches[] =
                 <<<PHP
@@ -260,7 +292,8 @@ class UnionProperty extends AbstractProperty
 
         $branches = [];
         foreach ($conversions as $assignment => $conversion) {
-            $parenthesizedCondition = OrGenerator::make($conversion["discriminators"]);
+            $conditions = array_values(array_unique($conversion["discriminators"]));
+            $parenthesizedCondition = OrGenerator::make($conditions);
             $keyword = count($branches) ? "elseif" : "if";
             $branches[] =
                 <<<PHP
@@ -394,25 +427,35 @@ class UnionProperty extends AbstractProperty
     public function inputMappingExpr(string $expr, bool $asserted = false): string
     {
         if ($this->request->isAtLeastPHP("8.0")) {
-            $match = new MatchGenerator("true");
-
+            $arms = [];
             foreach ($this->subProperties as $subProperty) {
+                $map = $subProperty->inputMappingExpr($expr);
                 $assert = $subProperty->inputAssertionExpr($expr);
-                $map    = $subProperty->inputMappingExpr($expr);
-                $match->addArm($assert, $map);
+                $arms[$map][] = $assert;
             }
-            
+
+            $match = new MatchGenerator("true");
+            foreach ($arms as $map => $asserts) {
+                $conditions = array_values(array_unique($asserts));
+                $match->addArm(OrGenerator::make($conditions, parens: false), $map);
+            }
             $match->addArm("default", "null");
 
             return $match->generate();
         }
 
-        $out = "null";
-
+        $conversions = [];
         foreach ($this->subProperties as $subProperty) {
+            $map = $subProperty->inputMappingExpr($expr);
             $assert = $subProperty->inputAssertionExpr($expr);
-            $map    = $subProperty->inputMappingExpr($expr);
-            $out    = TernaryGenerator::make($assert, $map, $out);
+            $conversions[$map][] = $assert;
+        }
+
+        $out = "null";
+        foreach (array_reverse($conversions) as $map => $asserts) {
+            $conditions = array_values(array_unique($asserts));
+            $cond = OrGenerator::make($conditions);
+            $out = TernaryGenerator::make($cond, $map, $out);
         }
 
         return $out;
@@ -421,24 +464,35 @@ class UnionProperty extends AbstractProperty
     public function outputMappingExpr(string $expr): string
     {
         if ($this->request->isAtLeastPHP("8.0")) {
-            $match = new MatchGenerator("true");
-            $match->addArm("default", "null");
-
+            $arms = [];
             foreach ($this->subProperties as $subProperty) {
+                $map = $subProperty->outputMappingExpr($expr);
                 $assert = $subProperty->typeAssertionExpr($expr);
-                $map    = $subProperty->outputMappingExpr($expr);
-                $match->addArm($assert, $map);
+                $arms[$map][] = $assert;
             }
+
+            $match = new MatchGenerator("true");
+            foreach ($arms as $map => $asserts) {
+                $conditions = array_values(array_unique($asserts));
+                $match->addArm(OrGenerator::make($conditions, parens: false), $map);
+            }
+            $match->addArm("default", "null");
 
             return $match->generate();
         }
 
-        $out = "null";
-
+        $conversions = [];
         foreach ($this->subProperties as $subProperty) {
+            $map = $subProperty->outputMappingExpr($expr);
             $assert = $subProperty->typeAssertionExpr($expr);
-            $map    = $subProperty->outputMappingExpr($expr);
-            $out    = TernaryGenerator::make($assert, $map, $out);
+            $conversions[$map][] = $assert;
+        }
+
+        $out = "null";
+        foreach (array_reverse($conversions) as $map => $asserts) {
+            $conditions = array_values(array_unique($asserts));
+            $cond = OrGenerator::make($conditions);
+            $out = TernaryGenerator::make($cond, $map, $out);
         }
 
         return $out;
@@ -447,24 +501,35 @@ class UnionProperty extends AbstractProperty
     public function outputMappingExprStdClass(string $expr): string
     {
         if ($this->request->isAtLeastPHP("8.0")) {
-            $match = new MatchGenerator("true");
-            $match->addArm("default", "null");
-
+            $arms = [];
             foreach ($this->subProperties as $subProperty) {
+                $map = $subProperty->outputMappingExprStdClass($expr);
                 $assert = $subProperty->typeAssertionExpr($expr);
-                $map    = $subProperty->outputMappingExprStdClass($expr);
-                $match->addArm($assert, $map);
+                $arms[$map][] = $assert;
             }
+
+            $match = new MatchGenerator("true");
+            foreach ($arms as $map => $asserts) {
+                $conditions = array_values(array_unique($asserts));
+                $match->addArm(OrGenerator::make($conditions, parens: false), $map);
+            }
+            $match->addArm("default", "null");
 
             return $match->generate();
         }
 
-        $out = "null";
-
+        $conversions = [];
         foreach ($this->subProperties as $subProperty) {
+            $map = $subProperty->outputMappingExprStdClass($expr);
             $assert = $subProperty->typeAssertionExpr($expr);
-            $map    = $subProperty->outputMappingExprStdClass($expr);
-            $out    = TernaryGenerator::make($assert, $map, $out);
+            $conversions[$map][] = $assert;
+        }
+
+        $out = "null";
+        foreach (array_reverse($conversions) as $map => $asserts) {
+            $conditions = array_values(array_unique($asserts));
+            $cond = OrGenerator::make($conditions);
+            $out = TernaryGenerator::make($cond, $map, $out);
         }
 
         return $out;
@@ -473,23 +538,34 @@ class UnionProperty extends AbstractProperty
     public function cloneExpr(string $expr): string
     {
         if ($this->request->isAtLeastPHP("8.0")) {
-            $match = new MatchGenerator("true");
-
+            $arms = [];
             foreach ($this->subProperties as $subProperty) {
+                $map = $subProperty->cloneExpr($expr);
                 $assert = $subProperty->typeAssertionExpr($expr);
-                $map    = $subProperty->cloneExpr($expr);
-                $match->addArm($assert, $map);
+                $arms[$map][] = $assert;
+            }
+
+            $match = new MatchGenerator("true");
+            foreach ($arms as $map => $asserts) {
+                $conditions = array_values(array_unique($asserts));
+                $match->addArm(OrGenerator::make($conditions, parens: false), $map);
             }
 
             return $match->generate();
         }
 
-        $out = $expr;
-
+        $conversions = [];
         foreach ($this->subProperties as $subProperty) {
+            $map = $subProperty->cloneExpr($expr);
             $assert = $subProperty->typeAssertionExpr($expr);
-            $map    = $subProperty->cloneExpr($expr);
-            $out    = TernaryGenerator::make($assert, $map, $out);
+            $conversions[$map][] = $assert;
+        }
+
+        $out = $expr;
+        foreach (array_reverse($conversions) as $map => $asserts) {
+            $conditions = array_values(array_unique($asserts));
+            $cond = OrGenerator::make($conditions);
+            $out = TernaryGenerator::make($cond, $map, $out);
         }
 
         return $out;

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
@@ -186,9 +186,9 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'})
-            ? (is_int($input->{'foo'})
-                ? (int)$input->{'foo'}
-                : (is_string($input->{'foo'}) ? $input->{'foo'} : null)
+            ? ((is_string($input->{'foo'}))
+                ? $input->{'foo'}
+                : ((is_int($input->{'foo'})) ? (int)$input->{'foo'} : null)
             )
             : null;
 
@@ -297,7 +297,7 @@ class MyClass
     public function __clone()
     {
         if (isset($this->foo)) {
-            $this->foo = (is_int($this->foo) ? $this->foo : (is_string($this->foo) ? $this->foo : $this->foo));
+            $this->foo = ((is_string($this->foo) || is_int($this->foo)) ? $this->foo : $this->foo);
         }
     }
 }

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
@@ -174,8 +174,7 @@ class MyClass
 
         if (isset($this->foo)) {
             $output['foo'] = match (true) {
-                is_string($this->foo),
-                is_int($this->foo) => $this->foo,
+                is_string($this->foo) || is_int($this->foo) => $this->foo,
             };
         }
 
@@ -202,8 +201,7 @@ class MyClass
 
         if (isset($this->foo)) {
             $output->{'foo'} = match (true) {
-                is_string($this->foo),
-                is_int($this->foo) => $this->foo,
+                is_string($this->foo) || is_int($this->foo) => $this->foo,
             };
         }
 
@@ -261,8 +259,7 @@ class MyClass
     {
         if (isset($this->foo)) {
             $this->foo = match (true) {
-                is_string($this->foo),
-                is_int($this->foo) => $this->foo,
+                is_string($this->foo) || is_int($this->foo) => $this->foo,
             };
         }
     }

--- a/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
@@ -149,8 +149,7 @@ class Cat
 
         $hasFur = isset($input->{'hasFur'})
             ? match (true) {
-                in_array($input->{'hasFur'}, ['a', 'b'], true),
-                is_array($input->{'hasFur'}) => $input->{'hasFur'},
+                in_array($input->{'hasFur'}, ['a', 'b'], true) || is_array($input->{'hasFur'}) => $input->{'hasFur'},
                 default => null,
             }
             : null;
@@ -176,8 +175,7 @@ class Cat
 
         if (isset($this->hasFur)) {
             $output['hasFur'] = match (true) {
-                in_array($this->hasFur, ['a', 'b'], true),
-                is_array($this->hasFur) => $this->hasFur,
+                in_array($this->hasFur, ['a', 'b'], true) || is_array($this->hasFur) => $this->hasFur,
             };
         }
 
@@ -195,8 +193,7 @@ class Cat
 
         if (isset($this->hasFur)) {
             $output->{'hasFur'} = match (true) {
-                in_array($this->hasFur, ['a', 'b'], true),
-                is_array($this->hasFur) => $this->hasFur,
+                in_array($this->hasFur, ['a', 'b'], true) || is_array($this->hasFur) => $this->hasFur,
             };
         }
 
@@ -244,8 +241,7 @@ class Cat
     {
         if (isset($this->hasFur)) {
             $this->hasFur = match (true) {
-                in_array($this->hasFur, ['a', 'b'], true),
-                is_array($this->hasFur) => $this->hasFur,
+                in_array($this->hasFur, ['a', 'b'], true) || is_array($this->hasFur) => $this->hasFur,
             };
         }
     }

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -368,15 +368,13 @@ class MyClass
         $_providedOptionals = [];
         $a = $input->{'a'};
         $b = match (true) {
-            is_array($input->{'b'}),
-            is_string($input->{'b'}) => $input->{'b'},
+            is_array($input->{'b'}) || is_string($input->{'b'}) => $input->{'b'},
             default => throw new \InvalidArgumentException("could not build property 'b' from JSON"),
         };
         $c = ($input->{'c'} !== null ? $input->{'c'} : null);
         $d = ($input->{'d'} !== null
             ? match (true) {
-                is_array($input->{'d'}),
-                is_string($input->{'d'}) => $input->{'d'},
+                is_array($input->{'d'}) || is_string($input->{'d'}) => $input->{'d'},
                 default => null,
             }
             : null
@@ -384,8 +382,7 @@ class MyClass
         $e = isset($input->{'e'}) ? $input->{'e'} : null;
         $f = isset($input->{'f'})
             ? match (true) {
-                is_array($input->{'f'}),
-                is_string($input->{'f'}) => $input->{'f'},
+                is_array($input->{'f'}) || is_string($input->{'f'}) => $input->{'f'},
                 default => null,
             }
             : null;
@@ -398,8 +395,7 @@ class MyClass
         if (property_exists($input, 'h')) {
             $h = ($input->{'h'} !== null
                 ? match (true) {
-                    is_array($input->{'h'}),
-                    is_string($input->{'h'}) => $input->{'h'},
+                    is_array($input->{'h'}) || is_string($input->{'h'}) => $input->{'h'},
                     default => null,
                 }
                 : null
@@ -410,9 +406,10 @@ class MyClass
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
                 ? match (true) {
-                    is_array($input->{'i'}),
-                    is_string($input->{'i'}),
-                    is_array($input->{'i'}) || is_object($input->{'i'}) => $input->{'i'},
+                    is_array($input->{'i'})
+                        || is_string($input->{'i'})
+                        || is_array($input->{'i'}) || is_object($input->{'i'}) =>
+                        $input->{'i'},
                     default => null,
                 }
                 : null
@@ -442,21 +439,18 @@ class MyClass
 
         $output['a'] = $this->a;
         $output['b'] = match (true) {
-            is_array($this->b),
-            is_string($this->b) => $this->b,
+            is_array($this->b) || is_string($this->b) => $this->b,
         };
         $output['c'] = $this->c;
         $output['d'] = match (true) {
-            is_array($this->d),
-            is_string($this->d) => $this->d,
+            is_array($this->d) || is_string($this->d) => $this->d,
         };
         if (isset($this->e)) {
             $output['e'] = $this->e;
         }
         if (isset($this->f)) {
             $output['f'] = match (true) {
-                is_array($this->f),
-                is_string($this->f) => $this->f,
+                is_array($this->f) || is_string($this->f) => $this->f,
             };
         }
         if (isset($this->g) || array_key_exists('g', $this->_providedOptionals)) {
@@ -465,9 +459,8 @@ class MyClass
         if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
             $output['h'] = ($this->h !== null
                 ? match (true) {
+                    is_array($this->h) || is_string($this->h) => $this->h,
                     default => null,
-                    is_array($this->h),
-                    is_string($this->h) => $this->h,
                 }
                 : null
             );
@@ -475,10 +468,9 @@ class MyClass
         if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
             $output['i'] = ($this->i !== null
                 ? match (true) {
-                    default => null,
-                    is_array($this->i),
-                    is_string($this->i) => $this->i,
+                    is_array($this->i) || is_string($this->i) => $this->i,
                     is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), true),
+                    default => null,
                 }
                 : null
             );
@@ -498,21 +490,18 @@ class MyClass
 
         $output->{'a'} = $this->a;
         $output->{'b'} = match (true) {
-            is_array($this->b),
-            is_string($this->b) => $this->b,
+            is_array($this->b) || is_string($this->b) => $this->b,
         };
         $output->{'c'} = $this->c;
         $output->{'d'} = match (true) {
-            is_array($this->d),
-            is_string($this->d) => $this->d,
+            is_array($this->d) || is_string($this->d) => $this->d,
         };
         if (isset($this->e)) {
             $output->{'e'} = $this->e;
         }
         if (isset($this->f)) {
             $output->{'f'} = match (true) {
-                is_array($this->f),
-                is_string($this->f) => $this->f,
+                is_array($this->f) || is_string($this->f) => $this->f,
             };
         }
         if (isset($this->g) || array_key_exists('g', $this->_providedOptionals)) {
@@ -521,9 +510,8 @@ class MyClass
         if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
             $output->{'h'} = ($this->h !== null
                 ? match (true) {
+                    is_array($this->h) || is_string($this->h) => $this->h,
                     default => null,
-                    is_array($this->h),
-                    is_string($this->h) => $this->h,
                 }
                 : null
             );
@@ -531,10 +519,9 @@ class MyClass
         if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
             $output->{'i'} = ($this->i !== null
                 ? match (true) {
-                    default => null,
-                    is_array($this->i),
-                    is_string($this->i) => $this->i,
+                    is_array($this->i) || is_string($this->i) => $this->i,
                     is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i)),
+                    default => null,
                 }
                 : null
             );
@@ -583,30 +570,24 @@ class MyClass
     public function __clone()
     {
         $this->b = match (true) {
-            is_array($this->b),
-            is_string($this->b) => $this->b,
+            is_array($this->b) || is_string($this->b) => $this->b,
         };
         $this->d = match (true) {
-            is_array($this->d),
-            is_string($this->d) => $this->d,
+            is_array($this->d) || is_string($this->d) => $this->d,
         };
         if (isset($this->f)) {
             $this->f = match (true) {
-                is_array($this->f),
-                is_string($this->f) => $this->f,
+                is_array($this->f) || is_string($this->f) => $this->f,
             };
         }
         if (isset($this->h)) {
             $this->h = match (true) {
-                is_array($this->h),
-                is_string($this->h) => $this->h,
+                is_array($this->h) || is_string($this->h) => $this->h,
             };
         }
         if (isset($this->i)) {
             $this->i = match (true) {
-                is_array($this->i),
-                is_string($this->i),
-                is_array($this->i) || is_object($this->i) => $this->i,
+                is_array($this->i) || is_string($this->i) || is_array($this->i) || is_object($this->i) => $this->i,
             };
         }
     }

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -489,8 +489,7 @@ class MyClass
         }
         if (isset($this->qwert)) {
             $output['qwert'] = match (true) {
-                is_string($this->qwert),
-                (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
+                is_string($this->qwert) || (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
             };
         }
         if (isset($this->zyx)) {
@@ -538,8 +537,7 @@ class MyClass
         }
         if (isset($this->qwert)) {
             $output->{'qwert'} = match (true) {
-                is_string($this->qwert),
-                (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
+                is_string($this->qwert) || (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
             };
         }
         if (isset($this->zyx)) {
@@ -600,8 +598,7 @@ class MyClass
     {
         if (isset($this->qwert)) {
             $this->qwert = match (true) {
-                is_string($this->qwert),
-                (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
+                is_string($this->qwert) || (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
             };
         }
     }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
@@ -182,12 +182,12 @@ class BarTest
         }
 
         $exampleProp = isset($input->{'exampleProp'})
-            ? (FooTest_1::validateInput($input->{'exampleProp'}, true)
-                ? FooTest_1::fromInput($input->{'exampleProp'}, $validate)
-                : (MoiKlass::validateInput($input->{'exampleProp'}, true)
+            ? ((FooTest::validateInput($input->{'exampleProp'}, true))
+                ? FooTest::fromInput($input->{'exampleProp'}, $validate)
+                : ((MoiKlass::validateInput($input->{'exampleProp'}, true))
                     ? MoiKlass::fromInput($input->{'exampleProp'}, $validate)
-                    : (FooTest::validateInput($input->{'exampleProp'}, true)
-                        ? FooTest::fromInput($input->{'exampleProp'}, $validate)
+                    : ((FooTest_1::validateInput($input->{'exampleProp'}, true))
+                        ? FooTest_1::fromInput($input->{'exampleProp'}, $validate)
                         : null
                     )
                 )
@@ -285,12 +285,12 @@ class BarTest
     public function __clone()
     {
         if (isset($this->exampleProp)) {
-            $this->exampleProp = ($this->exampleProp instanceof FooTest_1
+            $this->exampleProp = (($this->exampleProp instanceof FooTest
+                || $this->exampleProp instanceof MoiKlass
+                || $this->exampleProp instanceof FooTest_1
+            )
                 ? $this->exampleProp
-                : ($this->exampleProp instanceof MoiKlass
-                    ? $this->exampleProp
-                    : ($this->exampleProp instanceof FooTest ? $this->exampleProp : $this->exampleProp)
-                )
+                : $this->exampleProp
             );
         }
     }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -170,12 +170,12 @@ class BarTest
         }
 
         $exampleProp = isset($input->{'exampleProp'})
-            ? (FooTest_1::validateInput($input->{'exampleProp'}, true)
-                ? FooTest_1::fromInput($input->{'exampleProp'}, $validate)
-                : (MoiKlass::validateInput($input->{'exampleProp'}, true)
+            ? ((FooTest::validateInput($input->{'exampleProp'}, true))
+                ? FooTest::fromInput($input->{'exampleProp'}, $validate)
+                : ((MoiKlass::validateInput($input->{'exampleProp'}, true))
                     ? MoiKlass::fromInput($input->{'exampleProp'}, $validate)
-                    : (FooTest::validateInput($input->{'exampleProp'}, true)
-                        ? FooTest::fromInput($input->{'exampleProp'}, $validate)
+                    : ((FooTest_1::validateInput($input->{'exampleProp'}, true))
+                        ? FooTest_1::fromInput($input->{'exampleProp'}, $validate)
                         : null
                     )
                 )
@@ -274,12 +274,12 @@ class BarTest
     public function __clone()
     {
         if (isset($this->exampleProp)) {
-            $this->exampleProp = ($this->exampleProp instanceof FooTest_1
+            $this->exampleProp = (($this->exampleProp instanceof FooTest
+                || $this->exampleProp instanceof MoiKlass
+                || $this->exampleProp instanceof FooTest_1
+            )
                 ? $this->exampleProp
-                : ($this->exampleProp instanceof MoiKlass
-                    ? $this->exampleProp
-                    : ($this->exampleProp instanceof FooTest ? $this->exampleProp : $this->exampleProp)
-                )
+                : $this->exampleProp
             );
         }
     }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
@@ -178,9 +178,10 @@ class BarTest
 
         if (isset($this->exampleProp)) {
             $output['exampleProp'] = match (true) {
-                $this->exampleProp instanceof FooTest,
-                $this->exampleProp instanceof MoiKlass,
-                $this->exampleProp instanceof FooTest_1 => $this->exampleProp->toArray(),
+                $this->exampleProp instanceof FooTest
+                    || $this->exampleProp instanceof MoiKlass
+                    || $this->exampleProp instanceof FooTest_1 =>
+                    $this->exampleProp->toArray(),
             };
         }
 
@@ -198,9 +199,10 @@ class BarTest
 
         if (isset($this->exampleProp)) {
             $output->{'exampleProp'} = match (true) {
-                $this->exampleProp instanceof FooTest,
-                $this->exampleProp instanceof MoiKlass,
-                $this->exampleProp instanceof FooTest_1 => $this->exampleProp->toStdClass(),
+                $this->exampleProp instanceof FooTest
+                    || $this->exampleProp instanceof MoiKlass
+                    || $this->exampleProp instanceof FooTest_1 =>
+                    $this->exampleProp->toStdClass(),
             };
         }
 
@@ -248,9 +250,10 @@ class BarTest
     {
         if (isset($this->exampleProp)) {
             $this->exampleProp = match (true) {
-                $this->exampleProp instanceof FooTest,
-                $this->exampleProp instanceof MoiKlass,
-                $this->exampleProp instanceof FooTest_1 => $this->exampleProp,
+                $this->exampleProp instanceof FooTest
+                    || $this->exampleProp instanceof MoiKlass
+                    || $this->exampleProp instanceof FooTest_1 =>
+                    $this->exampleProp,
             };
         }
     }

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -2357,14 +2357,11 @@ class MyClass
             : null;
         $_providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? (is_string($input->{'ensureArgs1'})
-                ? $input->{'ensureArgs1'}
-                : (MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)
+            ? ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
+                ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
+                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : (MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)
-                        ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                        : null
-                    )
+                    : ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : null)
                 )
             )
             : null;
@@ -2671,15 +2668,11 @@ class MyClass
             $this->testObj = clone $this->testObj;
         }
         if (isset($this->ensureArgs1)) {
-            $this->ensureArgs1 = (is_string($this->ensureArgs1)
-                ? $this->ensureArgs1
-                : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
-                    ? clone $this->ensureArgs1
-                    : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
-                        ? clone $this->ensureArgs1
-                        : $this->ensureArgs1
-                    )
-                )
+            $this->ensureArgs1 = (($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
+            )
+                ? clone $this->ensureArgs1
+                : ((is_string($this->ensureArgs1)) ? $this->ensureArgs1 : $this->ensureArgs1)
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -1383,14 +1383,11 @@ class MyClass
             : null;
         $_providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? (is_string($input->{'ensureArgs1'})
-                ? $input->{'ensureArgs1'}
-                : (MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)
+            ? ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
+                ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
+                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : (MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)
-                        ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                        : null
-                    )
+                    : ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : null)
                 )
             )
             : null;
@@ -1695,15 +1692,11 @@ class MyClass
             $this->testObj = clone $this->testObj;
         }
         if (isset($this->ensureArgs1)) {
-            $this->ensureArgs1 = (is_string($this->ensureArgs1)
-                ? $this->ensureArgs1
-                : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
-                    ? clone $this->ensureArgs1
-                    : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
-                        ? clone $this->ensureArgs1
-                        : $this->ensureArgs1
-                    )
-                )
+            $this->ensureArgs1 = (($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
+            )
+                ? clone $this->ensureArgs1
+                : ((is_string($this->ensureArgs1)) ? $this->ensureArgs1 : $this->ensureArgs1)
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
@@ -1506,8 +1506,9 @@ class MyClass
         $output['this'] = $this->_this;
         if (isset($this->ensureArgs1)) {
             $output['ensureArgs1'] = match (true) {
-                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1,
-                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 => $this->ensureArgs1->toArray($includeDefaults),
+                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                    || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 =>
+                    $this->ensureArgs1->toArray($includeDefaults),
                 is_string($this->ensureArgs1) => $this->ensureArgs1,
             };
         }
@@ -1596,8 +1597,9 @@ class MyClass
         $output->{'this'} = $this->_this;
         if (isset($this->ensureArgs1)) {
             $output->{'ensureArgs1'} = match (true) {
-                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1,
-                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 => $this->ensureArgs1->toStdClass($includeDefaults),
+                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                    || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 =>
+                    $this->ensureArgs1->toStdClass($includeDefaults),
                 is_string($this->ensureArgs1) => $this->ensureArgs1,
             };
         }
@@ -1665,8 +1667,9 @@ class MyClass
         }
         if (isset($this->ensureArgs1)) {
             $this->ensureArgs1 = match (true) {
-                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1,
-                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 => clone $this->ensureArgs1,
+                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                    || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 =>
+                    clone $this->ensureArgs1,
                 is_string($this->ensureArgs1) => $this->ensureArgs1,
             };
         }

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -2357,14 +2357,11 @@ class MyClass
             : null;
         $__providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? (is_string($input->{'ensureArgs1'})
-                ? $input->{'ensureArgs1'}
-                : (MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)
+            ? ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
+                ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
+                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : (MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)
-                        ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                        : null
-                    )
+                    : ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : null)
                 )
             )
             : null;
@@ -2671,15 +2668,11 @@ class MyClass
             $this->testObj = clone $this->testObj;
         }
         if (isset($this->ensureArgs1)) {
-            $this->ensureArgs1 = (is_string($this->ensureArgs1)
-                ? $this->ensureArgs1
-                : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
-                    ? clone $this->ensureArgs1
-                    : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
-                        ? clone $this->ensureArgs1
-                        : $this->ensureArgs1
-                    )
-                )
+            $this->ensureArgs1 = (($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
+            )
+                ? clone $this->ensureArgs1
+                : ((is_string($this->ensureArgs1)) ? $this->ensureArgs1 : $this->ensureArgs1)
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -1383,14 +1383,11 @@ class MyClass
             : null;
         $__providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? (is_string($input->{'ensureArgs1'})
-                ? $input->{'ensureArgs1'}
-                : (MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)
+            ? ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
+                ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
+                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : (MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)
-                        ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                        : null
-                    )
+                    : ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : null)
                 )
             )
             : null;
@@ -1695,15 +1692,11 @@ class MyClass
             $this->testObj = clone $this->testObj;
         }
         if (isset($this->ensureArgs1)) {
-            $this->ensureArgs1 = (is_string($this->ensureArgs1)
-                ? $this->ensureArgs1
-                : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
-                    ? clone $this->ensureArgs1
-                    : ($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
-                        ? clone $this->ensureArgs1
-                        : $this->ensureArgs1
-                    )
-                )
+            $this->ensureArgs1 = (($this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
+            )
+                ? clone $this->ensureArgs1
+                : ((is_string($this->ensureArgs1)) ? $this->ensureArgs1 : $this->ensureArgs1)
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
@@ -1506,8 +1506,9 @@ class MyClass
         $output['this'] = $this->_this;
         if (isset($this->ensureArgs1)) {
             $output['ensureArgs1'] = match (true) {
-                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1,
-                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 => $this->ensureArgs1->toArray($includeDefaults),
+                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                    || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 =>
+                    $this->ensureArgs1->toArray($includeDefaults),
                 is_string($this->ensureArgs1) => $this->ensureArgs1,
             };
         }
@@ -1596,8 +1597,9 @@ class MyClass
         $output->{'this'} = $this->_this;
         if (isset($this->ensureArgs1)) {
             $output->{'ensureArgs1'} = match (true) {
-                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1,
-                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 => $this->ensureArgs1->toStdClass($includeDefaults),
+                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                    || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 =>
+                    $this->ensureArgs1->toStdClass($includeDefaults),
                 is_string($this->ensureArgs1) => $this->ensureArgs1,
             };
         }
@@ -1665,8 +1667,9 @@ class MyClass
         }
         if (isset($this->ensureArgs1)) {
             $this->ensureArgs1 = match (true) {
-                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1,
-                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 => clone $this->ensureArgs1,
+                $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
+                    || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 =>
+                    clone $this->ensureArgs1,
                 is_string($this->ensureArgs1) => $this->ensureArgs1,
             };
         }

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -806,24 +806,21 @@ class MyClass
         }
         $xyyz = isset($input->{'xyyz'})
             ? match (true) {
-                is_string($input->{'xyyz'}),
-                is_array($input->{'xyyz'}) => $input->{'xyyz'},
+                is_string($input->{'xyyz'}) || is_array($input->{'xyyz'}) => $input->{'xyyz'},
                 ObjDef::validateInput($input->{'xyyz'}, true) => ObjDef::fromInput($input->{'xyyz'}, $validate, $materializeDefaults),
                 default => null,
             }
             : null;
         $buux = isset($input->{'buux'})
             ? match (true) {
-                is_string($input->{'buux'}),
-                is_array($input->{'buux'}) => $input->{'buux'},
+                is_string($input->{'buux'}) || is_array($input->{'buux'}) => $input->{'buux'},
                 ObjDef::validateInput($input->{'buux'}, true) => ObjDef::fromInput($input->{'buux'}, $validate, $materializeDefaults),
                 default => null,
             }
             : null;
         $boic = isset($input->{'boic'})
             ? match (true) {
-                is_string($input->{'boic'}),
-                is_array($input->{'boic'}) => $input->{'boic'},
+                is_string($input->{'boic'}) || is_array($input->{'boic'}) => $input->{'boic'},
                 ObjDef::validateInput($input->{'boic'}, true) => ObjDef::fromInput($input->{'boic'}, $validate, $materializeDefaults),
                 default => null,
             }
@@ -838,15 +835,17 @@ class MyClass
             : null;
         $arrObjUnion = isset($input->{'arrObjUnion'})
             ? match (true) {
-                is_array($input->{'arrObjUnion'}),
-                is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) => $input->{'arrObjUnion'},
+                is_array($input->{'arrObjUnion'})
+                    || is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) =>
+                    $input->{'arrObjUnion'},
                 default => null,
             }
             : null;
         $objArrUnion = isset($input->{'objArrUnion'})
             ? match (true) {
-                is_array($input->{'objArrUnion'}),
-                is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) => $input->{'objArrUnion'},
+                is_array($input->{'objArrUnion'})
+                    || is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) =>
+                    $input->{'objArrUnion'},
                 default => null,
             }
             : null;
@@ -905,22 +904,19 @@ class MyClass
         }
         if (isset($this->xyyz)) {
             $output['xyyz'] = match (true) {
-                is_string($this->xyyz),
-                is_array($this->xyyz) => $this->xyyz,
+                is_string($this->xyyz) || is_array($this->xyyz) => $this->xyyz,
                 $this->xyyz instanceof ObjDef => $this->xyyz->toArray($includeDefaults),
             };
         }
         if (isset($this->buux)) {
             $output['buux'] = match (true) {
-                is_string($this->buux),
-                is_array($this->buux) => $this->buux,
+                is_string($this->buux) || is_array($this->buux) => $this->buux,
                 $this->buux instanceof ObjDef => $this->buux->toArray($includeDefaults),
             };
         }
         if (isset($this->boic)) {
             $output['boic'] = match (true) {
-                is_string($this->boic),
-                is_array($this->boic) => $this->boic,
+                is_string($this->boic) || is_array($this->boic) => $this->boic,
                 $this->boic instanceof ObjDef => $this->boic->toArray($includeDefaults),
             };
         }
@@ -983,22 +979,19 @@ class MyClass
         }
         if (isset($this->xyyz)) {
             $output->{'xyyz'} = match (true) {
-                is_string($this->xyyz),
-                is_array($this->xyyz) => $this->xyyz,
+                is_string($this->xyyz) || is_array($this->xyyz) => $this->xyyz,
                 $this->xyyz instanceof ObjDef => $this->xyyz->toStdClass($includeDefaults),
             };
         }
         if (isset($this->buux)) {
             $output->{'buux'} = match (true) {
-                is_string($this->buux),
-                is_array($this->buux) => $this->buux,
+                is_string($this->buux) || is_array($this->buux) => $this->buux,
                 $this->buux instanceof ObjDef => $this->buux->toStdClass($includeDefaults),
             };
         }
         if (isset($this->boic)) {
             $output->{'boic'} = match (true) {
-                is_string($this->boic),
-                is_array($this->boic) => $this->boic,
+                is_string($this->boic) || is_array($this->boic) => $this->boic,
                 $this->boic instanceof ObjDef => $this->boic->toStdClass($includeDefaults),
             };
         }
@@ -1091,41 +1084,32 @@ class MyClass
         }
         if (isset($this->xyyz)) {
             $this->xyyz = match (true) {
-                is_string($this->xyyz),
-                $this->xyyz instanceof ObjDef,
-                is_array($this->xyyz) => $this->xyyz,
+                is_string($this->xyyz) || $this->xyyz instanceof ObjDef || is_array($this->xyyz) => $this->xyyz,
             };
         }
         if (isset($this->buux)) {
             $this->buux = match (true) {
-                is_string($this->buux),
-                is_array($this->buux),
-                $this->buux instanceof ObjDef => $this->buux,
+                is_string($this->buux) || is_array($this->buux) || $this->buux instanceof ObjDef => $this->buux,
             };
         }
         if (isset($this->boic)) {
             $this->boic = match (true) {
-                is_string($this->boic),
-                is_array($this->boic),
-                $this->boic instanceof ObjDef => $this->boic,
+                is_string($this->boic) || is_array($this->boic) || $this->boic instanceof ObjDef => $this->boic,
             };
         }
         if (isset($this->poox)) {
             $this->poox = match (true) {
-                is_string($this->poox),
-                $this->poox instanceof NumericKeysObj => $this->poox,
+                is_string($this->poox) || $this->poox instanceof NumericKeysObj => $this->poox,
             };
         }
         if (isset($this->arrObjUnion)) {
             $this->arrObjUnion = match (true) {
-                is_array($this->arrObjUnion),
-                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => $this->arrObjUnion,
+                is_array($this->arrObjUnion) || is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => $this->arrObjUnion,
             };
         }
         if (isset($this->objArrUnion)) {
             $this->objArrUnion = match (true) {
-                is_array($this->objArrUnion),
-                is_array($this->objArrUnion) || is_object($this->objArrUnion) => $this->objArrUnion,
+                is_array($this->objArrUnion) || is_array($this->objArrUnion) || is_object($this->objArrUnion) => $this->objArrUnion,
             };
         }
         if (isset($this->numKeysDefaults)) {

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
@@ -182,10 +182,10 @@ class Baz
         }
 
         $grox = isset($input->{'grox'})
-            ? (Bar::validateInput($input->{'grox'}, true)
-                ? Bar::fromInput($input->{'grox'}, $validate)
-                : (Foo::validateInput($input->{'grox'}, true)
-                    ? Foo::fromInput($input->{'grox'}, $validate)
+            ? ((Foo::validateInput($input->{'grox'}, true))
+                ? Foo::fromInput($input->{'grox'}, $validate)
+                : ((Bar::validateInput($input->{'grox'}, true))
+                    ? Bar::fromInput($input->{'grox'}, $validate)
                     : null
                 )
             )
@@ -276,9 +276,9 @@ class Baz
     public function __clone()
     {
         if (isset($this->grox)) {
-            $this->grox = ($this->grox instanceof Bar
+            $this->grox = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                 ? $this->grox
-                : ($this->grox instanceof Foo ? $this->grox : $this->grox)
+                : $this->grox
             );
         }
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -195,17 +195,17 @@ class Qux
         }
 
         $grox = isset($input->{'grox'})
-            ? ((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true))
-                ? (Bar::validateInput($input->{'grox'}, true)
-                    ? Bar::fromInput($input->{'grox'}, $validate)
-                    : (Foo::validateInput($input->{'grox'}, true)
+            ? ((is_string($input->{'grox'}) || is_array($input->{'grox'}))
+                ? $input->{'grox'}
+                : (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
+                    ? ((Foo::validateInput($input->{'grox'}, true))
                         ? Foo::fromInput($input->{'grox'}, $validate)
-                        : null
+                        : ((Bar::validateInput($input->{'grox'}, true))
+                            ? Bar::fromInput($input->{'grox'}, $validate)
+                            : null
+                        )
                     )
-                )
-                : (is_array($input->{'grox'})
-                    ? $input->{'grox'}
-                    : (is_string($input->{'grox'}) ? $input->{'grox'} : null)
+                    : null
                 )
             )
             : null;
@@ -233,9 +233,9 @@ class Qux
             if (is_string($this->grox) || is_array($this->grox)) {
                 $output['grox'] = $this->grox;
             } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
-                $output['grox'] = ($this->grox instanceof Bar
+                $output['grox'] = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toArray()
-                    : ($this->grox instanceof Foo ? $this->grox->toArray() : null)
+                    : null
                 );
             }
         }
@@ -256,9 +256,9 @@ class Qux
             if (is_string($this->grox) || is_array($this->grox)) {
                 $output->{'grox'} = $this->grox;
             } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
-                $output->{'grox'} = ($this->grox instanceof Bar
+                $output->{'grox'} = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toStdClass()
-                    : ($this->grox instanceof Foo ? $this->grox->toStdClass() : null)
+                    : null
                 );
             }
         }
@@ -305,14 +305,14 @@ class Qux
     public function __clone()
     {
         if (isset($this->grox)) {
-            $this->grox = (($this->grox instanceof Foo || $this->grox instanceof Bar)
-                ? ($this->grox instanceof Bar
-                    ? $this->grox
-                    : ($this->grox instanceof Foo ? $this->grox : $this->grox)
-                )
-                : (is_array($this->grox)
-                    ? $this->grox
-                    : (is_string($this->grox) ? $this->grox : $this->grox)
+            $this->grox = ((is_string($this->grox) || is_array($this->grox))
+                ? $this->grox
+                : ((($this->grox instanceof Foo || $this->grox instanceof Bar))
+                    ? (($this->grox instanceof Foo || $this->grox instanceof Bar)
+                        ? $this->grox
+                        : $this->grox
+                    )
+                    : $this->grox
                 )
             );
         }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -170,10 +170,10 @@ class Baz
         }
 
         $grox = isset($input->{'grox'})
-            ? (Bar::validateInput($input->{'grox'}, true)
-                ? Bar::fromInput($input->{'grox'}, $validate)
-                : (Foo::validateInput($input->{'grox'}, true)
-                    ? Foo::fromInput($input->{'grox'}, $validate)
+            ? ((Foo::validateInput($input->{'grox'}, true))
+                ? Foo::fromInput($input->{'grox'}, $validate)
+                : ((Bar::validateInput($input->{'grox'}, true))
+                    ? Bar::fromInput($input->{'grox'}, $validate)
                     : null
                 )
             )
@@ -265,9 +265,9 @@ class Baz
     public function __clone()
     {
         if (isset($this->grox)) {
-            $this->grox = ($this->grox instanceof Bar
+            $this->grox = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                 ? $this->grox
-                : ($this->grox instanceof Foo ? $this->grox : $this->grox)
+                : $this->grox
             );
         }
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -183,17 +183,17 @@ class Qux
         }
 
         $grox = isset($input->{'grox'})
-            ? ((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true))
-                ? (Bar::validateInput($input->{'grox'}, true)
-                    ? Bar::fromInput($input->{'grox'}, $validate)
-                    : (Foo::validateInput($input->{'grox'}, true)
+            ? ((is_string($input->{'grox'}) || is_array($input->{'grox'}))
+                ? $input->{'grox'}
+                : (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
+                    ? ((Foo::validateInput($input->{'grox'}, true))
                         ? Foo::fromInput($input->{'grox'}, $validate)
-                        : null
+                        : ((Bar::validateInput($input->{'grox'}, true))
+                            ? Bar::fromInput($input->{'grox'}, $validate)
+                            : null
+                        )
                     )
-                )
-                : (is_array($input->{'grox'})
-                    ? $input->{'grox'}
-                    : (is_string($input->{'grox'}) ? $input->{'grox'} : null)
+                    : null
                 )
             )
             : null;
@@ -221,9 +221,9 @@ class Qux
             if (is_string($this->grox) || is_array($this->grox)) {
                 $output['grox'] = $this->grox;
             } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
-                $output['grox'] = ($this->grox instanceof Bar
+                $output['grox'] = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toArray()
-                    : ($this->grox instanceof Foo ? $this->grox->toArray() : null)
+                    : null
                 );
             }
         }
@@ -244,9 +244,9 @@ class Qux
             if (is_string($this->grox) || is_array($this->grox)) {
                 $output->{'grox'} = $this->grox;
             } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
-                $output->{'grox'} = ($this->grox instanceof Bar
+                $output->{'grox'} = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toStdClass()
-                    : ($this->grox instanceof Foo ? $this->grox->toStdClass() : null)
+                    : null
                 );
             }
         }
@@ -294,14 +294,14 @@ class Qux
     public function __clone()
     {
         if (isset($this->grox)) {
-            $this->grox = (($this->grox instanceof Foo || $this->grox instanceof Bar)
-                ? ($this->grox instanceof Bar
-                    ? $this->grox
-                    : ($this->grox instanceof Foo ? $this->grox : $this->grox)
-                )
-                : (is_array($this->grox)
-                    ? $this->grox
-                    : (is_string($this->grox) ? $this->grox : $this->grox)
+            $this->grox = ((is_string($this->grox) || is_array($this->grox))
+                ? $this->grox
+                : ((($this->grox instanceof Foo || $this->grox instanceof Bar))
+                    ? (($this->grox instanceof Foo || $this->grox instanceof Bar)
+                        ? $this->grox
+                        : $this->grox
+                    )
+                    : $this->grox
                 )
             );
         }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
@@ -177,8 +177,7 @@ class Baz
 
         if (isset($this->grox)) {
             $output['grox'] = match (true) {
-                $this->grox instanceof Foo,
-                $this->grox instanceof Bar => $this->grox->toArray(),
+                $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toArray(),
             };
         }
 
@@ -196,8 +195,7 @@ class Baz
 
         if (isset($this->grox)) {
             $output->{'grox'} = match (true) {
-                $this->grox instanceof Foo,
-                $this->grox instanceof Bar => $this->grox->toStdClass(),
+                $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toStdClass(),
             };
         }
 
@@ -245,8 +243,7 @@ class Baz
     {
         if (isset($this->grox)) {
             $this->grox = match (true) {
-                $this->grox instanceof Foo,
-                $this->grox instanceof Bar => $this->grox,
+                $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox,
             };
         }
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
@@ -177,8 +177,7 @@ class Qux
 
         $grox = isset($input->{'grox'})
             ? match (true) {
-                is_string($input->{'grox'}),
-                is_array($input->{'grox'}) => $input->{'grox'},
+                is_string($input->{'grox'}) || is_array($input->{'grox'}) => $input->{'grox'},
                 (Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)) =>
                     match (true) {
                         Foo::validateInput($input->{'grox'}, true) => Foo::fromInput($input->{'grox'}, $validate),
@@ -210,13 +209,11 @@ class Qux
 
         if (isset($this->grox)) {
             $output['grox'] = match (true) {
-                is_string($this->grox),
-                is_array($this->grox) => $this->grox,
+                is_string($this->grox) || is_array($this->grox) => $this->grox,
                 ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
                     match (true) {
+                        $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toArray(),
                         default => null,
-                        $this->grox instanceof Foo,
-                        $this->grox instanceof Bar => $this->grox->toArray(),
                     },
             };
         }
@@ -235,13 +232,11 @@ class Qux
 
         if (isset($this->grox)) {
             $output->{'grox'} = match (true) {
-                is_string($this->grox),
-                is_array($this->grox) => $this->grox,
+                is_string($this->grox) || is_array($this->grox) => $this->grox,
                 ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
                     match (true) {
+                        $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toStdClass(),
                         default => null,
-                        $this->grox instanceof Foo,
-                        $this->grox instanceof Bar => $this->grox->toStdClass(),
                     },
             };
         }
@@ -290,12 +285,10 @@ class Qux
     {
         if (isset($this->grox)) {
             $this->grox = match (true) {
-                is_string($this->grox),
-                is_array($this->grox) => $this->grox,
+                is_string($this->grox) || is_array($this->grox) => $this->grox,
                 ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
                     match (true) {
-                        $this->grox instanceof Foo,
-                        $this->grox instanceof Bar => $this->grox,
+                        $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox,
                     },
             };
         }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -201,9 +201,9 @@ class MyClass
 
         $foo = $input->{'foo'};
         $bar = isset($input->{'bar'})
-            ? (is_array($input->{'bar'}) || is_object($input->{'bar'})
+            ? ((is_string($input->{'bar'}) || is_array($input->{'bar'}) || is_object($input->{'bar'}))
                 ? $input->{'bar'}
-                : (is_string($input->{'bar'}) ? $input->{'bar'} : null)
+                : null
             )
             : null;
 
@@ -305,14 +305,14 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = (is_array($this->foo) || is_object($this->foo)
+        $this->foo = ((is_string($this->foo) || is_array($this->foo) || is_object($this->foo))
             ? $this->foo
-            : (is_string($this->foo) ? $this->foo : $this->foo)
+            : $this->foo
         );
         if (isset($this->bar)) {
-            $this->bar = (is_array($this->bar) || is_object($this->bar)
+            $this->bar = ((is_string($this->bar) || is_array($this->bar) || is_object($this->bar))
                 ? $this->bar
-                : (is_string($this->bar) ? $this->bar : $this->bar)
+                : $this->bar
             );
         }
     }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -187,9 +187,9 @@ class MyClass
 
         $foo = $input->{'foo'};
         $bar = isset($input->{'bar'})
-            ? (is_array($input->{'bar'}) || is_object($input->{'bar'})
+            ? ((is_string($input->{'bar'}) || is_array($input->{'bar'}) || is_object($input->{'bar'}))
                 ? $input->{'bar'}
-                : (is_string($input->{'bar'}) ? $input->{'bar'} : null)
+                : null
             )
             : null;
 
@@ -292,14 +292,14 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = (is_array($this->foo) || is_object($this->foo)
+        $this->foo = ((is_string($this->foo) || is_array($this->foo) || is_object($this->foo))
             ? $this->foo
-            : (is_string($this->foo) ? $this->foo : $this->foo)
+            : $this->foo
         );
         if (isset($this->bar)) {
-            $this->bar = (is_array($this->bar) || is_object($this->bar)
+            $this->bar = ((is_string($this->bar) || is_array($this->bar) || is_object($this->bar))
                 ? $this->bar
-                : (is_string($this->bar) ? $this->bar : $this->bar)
+                : $this->bar
             );
         }
     }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
@@ -141,14 +141,12 @@ class MyClass
         }
 
         $foo = match (true) {
-            is_string($input->{'foo'}),
-            is_array($input->{'foo'}) || is_object($input->{'foo'}) => $input->{'foo'},
+            is_string($input->{'foo'}) || is_array($input->{'foo'}) || is_object($input->{'foo'}) => $input->{'foo'},
             default => throw new \InvalidArgumentException("could not build property 'foo' from JSON"),
         };
         $bar = isset($input->{'bar'})
             ? match (true) {
-                is_string($input->{'bar'}),
-                is_array($input->{'bar'}) || is_object($input->{'bar'}) => $input->{'bar'},
+                is_string($input->{'bar'}) || is_array($input->{'bar'}) || is_object($input->{'bar'}) => $input->{'bar'},
                 default => null,
             }
             : null;
@@ -249,13 +247,11 @@ class MyClass
     public function __clone()
     {
         $this->foo = match (true) {
-            is_string($this->foo),
-            is_array($this->foo) || is_object($this->foo) => $this->foo,
+            is_string($this->foo) || is_array($this->foo) || is_object($this->foo) => $this->foo,
         };
         if (isset($this->bar)) {
             $this->bar = match (true) {
-                is_string($this->bar),
-                is_array($this->bar) || is_object($this->bar) => $this->bar,
+                is_string($this->bar) || is_array($this->bar) || is_object($this->bar) => $this->bar,
             };
         }
     }

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -399,38 +399,43 @@ class MyClass
 
         $_providedOptionals = [];
         $foo = match (true) {
-            is_string($input->{'foo'}),
-            (is_int($input->{'foo'}) || is_float($input->{'foo'})),
-            is_bool($input->{'foo'}) => $input->{'foo'},
+            is_string($input->{'foo'})
+                || (is_int($input->{'foo'}) || is_float($input->{'foo'}))
+                || is_bool($input->{'foo'}) =>
+                $input->{'foo'},
             default => throw new \InvalidArgumentException("could not build property 'foo' from JSON"),
         };
         $bar = match (true) {
-            is_string($input->{'bar'}),
-            (is_int($input->{'bar'}) || is_float($input->{'bar'})),
-            is_bool($input->{'bar'}),
-            is_array($input->{'bar'}) => $input->{'bar'},
+            is_string($input->{'bar'})
+                || (is_int($input->{'bar'}) || is_float($input->{'bar'}))
+                || is_bool($input->{'bar'})
+                || is_array($input->{'bar'}) =>
+                $input->{'bar'},
             default => throw new \InvalidArgumentException("could not build property 'bar' from JSON"),
         };
         $baz = match (true) {
-            is_string($input->{'baz'}),
-            (is_int($input->{'baz'}) || is_float($input->{'baz'})),
-            is_bool($input->{'baz'}),
-            is_array($input->{'baz'}) || is_object($input->{'baz'}) => $input->{'baz'},
+            is_string($input->{'baz'})
+                || (is_int($input->{'baz'}) || is_float($input->{'baz'}))
+                || is_bool($input->{'baz'})
+                || is_array($input->{'baz'}) || is_object($input->{'baz'}) =>
+                $input->{'baz'},
             default => throw new \InvalidArgumentException("could not build property 'baz' from JSON"),
         };
         $qux = match (true) {
-            is_string($input->{'qux'}),
-            (is_int($input->{'qux'}) || is_float($input->{'qux'})),
-            is_bool($input->{'qux'}),
-            is_array($input->{'qux'}),
-            is_array($input->{'qux'}) || is_object($input->{'qux'}) => $input->{'qux'},
+            is_string($input->{'qux'})
+                || (is_int($input->{'qux'}) || is_float($input->{'qux'}))
+                || is_bool($input->{'qux'})
+                || is_array($input->{'qux'})
+                || is_array($input->{'qux'}) || is_object($input->{'qux'}) =>
+                $input->{'qux'},
             default => throw new \InvalidArgumentException("could not build property 'qux' from JSON"),
         };
         $thud = ($input->{'thud'} !== null
             ? match (true) {
-                is_string($input->{'thud'}),
-                is_array($input->{'thud'}),
-                is_array($input->{'thud'}) || is_object($input->{'thud'}) => $input->{'thud'},
+                is_string($input->{'thud'})
+                    || is_array($input->{'thud'})
+                    || is_array($input->{'thud'}) || is_object($input->{'thud'}) =>
+                    $input->{'thud'},
                 (is_int($input->{'thud'}) || is_float($input->{'thud'})) =>
                     (str_contains((string)$input->{'thud'}, '.')
                         ? (float)$input->{'thud'}
@@ -455,8 +460,7 @@ class MyClass
             : null;
         $optBar = isset($input->{'optBar'})
             ? match (true) {
-                is_string($input->{'optBar'}),
-                is_array($input->{'optBar'}) => $input->{'optBar'},
+                is_string($input->{'optBar'}) || is_array($input->{'optBar'}) => $input->{'optBar'},
                 (is_int($input->{'optBar'}) || is_float($input->{'optBar'})) =>
                     (str_contains((string)$input->{'optBar'}, '.')
                         ? (float)$input->{'optBar'}
@@ -468,8 +472,7 @@ class MyClass
             : null;
         $optBaz = isset($input->{'optBaz'})
             ? match (true) {
-                is_string($input->{'optBaz'}),
-                is_array($input->{'optBaz'}) || is_object($input->{'optBaz'}) => $input->{'optBaz'},
+                is_string($input->{'optBaz'}) || is_array($input->{'optBaz'}) || is_object($input->{'optBaz'}) => $input->{'optBaz'},
                 (is_int($input->{'optBaz'}) || is_float($input->{'optBaz'})) =>
                     (str_contains((string)$input->{'optBaz'}, '.')
                         ? (float)$input->{'optBaz'}
@@ -481,9 +484,10 @@ class MyClass
             : null;
         $optQux = isset($input->{'optQux'})
             ? match (true) {
-                is_string($input->{'optQux'}),
-                is_array($input->{'optQux'}),
-                is_array($input->{'optQux'}) || is_object($input->{'optQux'}) => $input->{'optQux'},
+                is_string($input->{'optQux'})
+                    || is_array($input->{'optQux'})
+                    || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) =>
+                    $input->{'optQux'},
                 (is_int($input->{'optQux'}) || is_float($input->{'optQux'})) =>
                     (str_contains((string)$input->{'optQux'}, '.')
                         ? (float)$input->{'optQux'}
@@ -497,9 +501,10 @@ class MyClass
         if (property_exists($input, 'optThud')) {
             $optThud = ($input->{'optThud'} !== null
                 ? match (true) {
-                    is_string($input->{'optThud'}),
-                    is_array($input->{'optThud'}),
-                    is_array($input->{'optThud'}) || is_object($input->{'optThud'}) => $input->{'optThud'},
+                    is_string($input->{'optThud'})
+                        || is_array($input->{'optThud'})
+                        || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) =>
+                        $input->{'optThud'},
                     (is_int($input->{'optThud'}) || is_float($input->{'optThud'})) =>
                         (str_contains((string)$input->{'optThud'}, '.')
                             ? (float)$input->{'optThud'}
@@ -545,77 +550,81 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         $output['foo'] = match (true) {
-            is_string($this->foo),
-            (is_int($this->foo) || is_float($this->foo)),
-            is_bool($this->foo) => $this->foo,
+            is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) || is_bool($this->foo) => $this->foo,
         };
         $output['bar'] = match (true) {
-            is_string($this->bar),
-            (is_int($this->bar) || is_float($this->bar)),
-            is_bool($this->bar),
-            is_array($this->bar) => $this->bar,
+            is_string($this->bar)
+                || (is_int($this->bar) || is_float($this->bar))
+                || is_bool($this->bar)
+                || is_array($this->bar) =>
+                $this->bar,
         };
         $output['baz'] = match (true) {
-            is_string($this->baz),
-            (is_int($this->baz) || is_float($this->baz)),
-            is_bool($this->baz) => $this->baz,
+            is_string($this->baz) || (is_int($this->baz) || is_float($this->baz)) || is_bool($this->baz) => $this->baz,
             is_array($this->baz) || is_object($this->baz) => json_decode(json_encode($this->baz), true),
         };
         $output['qux'] = match (true) {
-            is_string($this->qux),
-            (is_int($this->qux) || is_float($this->qux)),
-            is_bool($this->qux),
-            is_array($this->qux) => $this->qux,
+            is_string($this->qux)
+                || (is_int($this->qux) || is_float($this->qux))
+                || is_bool($this->qux)
+                || is_array($this->qux) =>
+                $this->qux,
             is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux), true),
         };
         $output['thud'] = match (true) {
-            is_string($this->thud),
-            (is_int($this->thud) || is_float($this->thud)),
-            is_bool($this->thud),
-            is_array($this->thud) => $this->thud,
+            is_string($this->thud)
+                || (is_int($this->thud) || is_float($this->thud))
+                || is_bool($this->thud)
+                || is_array($this->thud) =>
+                $this->thud,
             is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud), true),
         };
         if (isset($this->optFoo)) {
             $output['optFoo'] = match (true) {
-                is_string($this->optFoo),
-                (is_int($this->optFoo) || is_float($this->optFoo)),
-                is_bool($this->optFoo) => $this->optFoo,
+                is_string($this->optFoo)
+                    || (is_int($this->optFoo) || is_float($this->optFoo))
+                    || is_bool($this->optFoo) =>
+                    $this->optFoo,
             };
         }
         if (isset($this->optBar)) {
             $output['optBar'] = match (true) {
-                is_string($this->optBar),
-                (is_int($this->optBar) || is_float($this->optBar)),
-                is_bool($this->optBar),
-                is_array($this->optBar) => $this->optBar,
+                is_string($this->optBar)
+                    || (is_int($this->optBar) || is_float($this->optBar))
+                    || is_bool($this->optBar)
+                    || is_array($this->optBar) =>
+                    $this->optBar,
             };
         }
         if (isset($this->optBaz)) {
             $output['optBaz'] = match (true) {
-                is_string($this->optBaz),
-                (is_int($this->optBaz) || is_float($this->optBaz)),
-                is_bool($this->optBaz) => $this->optBaz,
+                is_string($this->optBaz)
+                    || (is_int($this->optBaz) || is_float($this->optBaz))
+                    || is_bool($this->optBaz) =>
+                    $this->optBaz,
                 is_array($this->optBaz) || is_object($this->optBaz) => json_decode(json_encode($this->optBaz), true),
             };
         }
         if (isset($this->optQux)) {
             $output['optQux'] = match (true) {
-                is_string($this->optQux),
-                (is_int($this->optQux) || is_float($this->optQux)),
-                is_bool($this->optQux),
-                is_array($this->optQux) => $this->optQux,
+                is_string($this->optQux)
+                    || (is_int($this->optQux) || is_float($this->optQux))
+                    || is_bool($this->optQux)
+                    || is_array($this->optQux) =>
+                    $this->optQux,
                 is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux), true),
             };
         }
         if (isset($this->optThud) || array_key_exists('optThud', $this->_providedOptionals)) {
             $output['optThud'] = ($this->optThud !== null
                 ? match (true) {
-                    default => null,
-                    is_string($this->optThud),
-                    (is_int($this->optThud) || is_float($this->optThud)),
-                    is_bool($this->optThud),
-                    is_array($this->optThud) => $this->optThud,
+                    is_string($this->optThud)
+                        || (is_int($this->optThud) || is_float($this->optThud))
+                        || is_bool($this->optThud)
+                        || is_array($this->optThud) =>
+                        $this->optThud,
                     is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud), true),
+                    default => null,
                 }
                 : null
             );
@@ -634,77 +643,81 @@ class MyClass
         $output = $this->_additionalProperties;
 
         $output->{'foo'} = match (true) {
-            is_string($this->foo),
-            (is_int($this->foo) || is_float($this->foo)),
-            is_bool($this->foo) => $this->foo,
+            is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) || is_bool($this->foo) => $this->foo,
         };
         $output->{'bar'} = match (true) {
-            is_string($this->bar),
-            (is_int($this->bar) || is_float($this->bar)),
-            is_bool($this->bar),
-            is_array($this->bar) => $this->bar,
+            is_string($this->bar)
+                || (is_int($this->bar) || is_float($this->bar))
+                || is_bool($this->bar)
+                || is_array($this->bar) =>
+                $this->bar,
         };
         $output->{'baz'} = match (true) {
-            is_string($this->baz),
-            (is_int($this->baz) || is_float($this->baz)),
-            is_bool($this->baz) => $this->baz,
+            is_string($this->baz) || (is_int($this->baz) || is_float($this->baz)) || is_bool($this->baz) => $this->baz,
             is_array($this->baz) || is_object($this->baz) => json_decode(json_encode($this->baz)),
         };
         $output->{'qux'} = match (true) {
-            is_string($this->qux),
-            (is_int($this->qux) || is_float($this->qux)),
-            is_bool($this->qux),
-            is_array($this->qux) => $this->qux,
+            is_string($this->qux)
+                || (is_int($this->qux) || is_float($this->qux))
+                || is_bool($this->qux)
+                || is_array($this->qux) =>
+                $this->qux,
             is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux)),
         };
         $output->{'thud'} = match (true) {
-            is_string($this->thud),
-            (is_int($this->thud) || is_float($this->thud)),
-            is_bool($this->thud),
-            is_array($this->thud) => $this->thud,
+            is_string($this->thud)
+                || (is_int($this->thud) || is_float($this->thud))
+                || is_bool($this->thud)
+                || is_array($this->thud) =>
+                $this->thud,
             is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud)),
         };
         if (isset($this->optFoo)) {
             $output->{'optFoo'} = match (true) {
-                is_string($this->optFoo),
-                (is_int($this->optFoo) || is_float($this->optFoo)),
-                is_bool($this->optFoo) => $this->optFoo,
+                is_string($this->optFoo)
+                    || (is_int($this->optFoo) || is_float($this->optFoo))
+                    || is_bool($this->optFoo) =>
+                    $this->optFoo,
             };
         }
         if (isset($this->optBar)) {
             $output->{'optBar'} = match (true) {
-                is_string($this->optBar),
-                (is_int($this->optBar) || is_float($this->optBar)),
-                is_bool($this->optBar),
-                is_array($this->optBar) => $this->optBar,
+                is_string($this->optBar)
+                    || (is_int($this->optBar) || is_float($this->optBar))
+                    || is_bool($this->optBar)
+                    || is_array($this->optBar) =>
+                    $this->optBar,
             };
         }
         if (isset($this->optBaz)) {
             $output->{'optBaz'} = match (true) {
-                is_string($this->optBaz),
-                (is_int($this->optBaz) || is_float($this->optBaz)),
-                is_bool($this->optBaz) => $this->optBaz,
+                is_string($this->optBaz)
+                    || (is_int($this->optBaz) || is_float($this->optBaz))
+                    || is_bool($this->optBaz) =>
+                    $this->optBaz,
                 is_array($this->optBaz) || is_object($this->optBaz) => json_decode(json_encode($this->optBaz)),
             };
         }
         if (isset($this->optQux)) {
             $output->{'optQux'} = match (true) {
-                is_string($this->optQux),
-                (is_int($this->optQux) || is_float($this->optQux)),
-                is_bool($this->optQux),
-                is_array($this->optQux) => $this->optQux,
+                is_string($this->optQux)
+                    || (is_int($this->optQux) || is_float($this->optQux))
+                    || is_bool($this->optQux)
+                    || is_array($this->optQux) =>
+                    $this->optQux,
                 is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux)),
             };
         }
         if (isset($this->optThud) || array_key_exists('optThud', $this->_providedOptionals)) {
             $output->{'optThud'} = ($this->optThud !== null
                 ? match (true) {
-                    default => null,
-                    is_string($this->optThud),
-                    (is_int($this->optThud) || is_float($this->optThud)),
-                    is_bool($this->optThud),
-                    is_array($this->optThud) => $this->optThud,
+                    is_string($this->optThud)
+                        || (is_int($this->optThud) || is_float($this->optThud))
+                        || is_bool($this->optThud)
+                        || is_array($this->optThud) =>
+                        $this->optThud,
                     is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud)),
+                    default => null,
                 }
                 : null
             );
@@ -753,75 +766,82 @@ class MyClass
     public function __clone()
     {
         $this->foo = match (true) {
-            is_string($this->foo),
-            (is_int($this->foo) || is_float($this->foo)),
-            is_bool($this->foo) => $this->foo,
+            is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) || is_bool($this->foo) => $this->foo,
         };
         $this->bar = match (true) {
-            is_string($this->bar),
-            (is_int($this->bar) || is_float($this->bar)),
-            is_bool($this->bar),
-            is_array($this->bar) => $this->bar,
+            is_string($this->bar)
+                || (is_int($this->bar) || is_float($this->bar))
+                || is_bool($this->bar)
+                || is_array($this->bar) =>
+                $this->bar,
         };
         $this->baz = match (true) {
-            is_string($this->baz),
-            (is_int($this->baz) || is_float($this->baz)),
-            is_bool($this->baz),
-            is_array($this->baz) || is_object($this->baz) => $this->baz,
+            is_string($this->baz)
+                || (is_int($this->baz) || is_float($this->baz))
+                || is_bool($this->baz)
+                || is_array($this->baz) || is_object($this->baz) =>
+                $this->baz,
         };
         $this->qux = match (true) {
-            is_string($this->qux),
-            (is_int($this->qux) || is_float($this->qux)),
-            is_bool($this->qux),
-            is_array($this->qux),
-            is_array($this->qux) || is_object($this->qux) => $this->qux,
+            is_string($this->qux)
+                || (is_int($this->qux) || is_float($this->qux))
+                || is_bool($this->qux)
+                || is_array($this->qux)
+                || is_array($this->qux) || is_object($this->qux) =>
+                $this->qux,
         };
         $this->thud = match (true) {
-            is_string($this->thud),
-            (is_int($this->thud) || is_float($this->thud)),
-            is_bool($this->thud),
-            is_array($this->thud),
-            is_array($this->thud) || is_object($this->thud) => $this->thud,
+            is_string($this->thud)
+                || (is_int($this->thud) || is_float($this->thud))
+                || is_bool($this->thud)
+                || is_array($this->thud)
+                || is_array($this->thud) || is_object($this->thud) =>
+                $this->thud,
         };
         if (isset($this->optFoo)) {
             $this->optFoo = match (true) {
-                is_string($this->optFoo),
-                (is_int($this->optFoo) || is_float($this->optFoo)),
-                is_bool($this->optFoo) => $this->optFoo,
+                is_string($this->optFoo)
+                    || (is_int($this->optFoo) || is_float($this->optFoo))
+                    || is_bool($this->optFoo) =>
+                    $this->optFoo,
             };
         }
         if (isset($this->optBar)) {
             $this->optBar = match (true) {
-                is_string($this->optBar),
-                (is_int($this->optBar) || is_float($this->optBar)),
-                is_bool($this->optBar),
-                is_array($this->optBar) => $this->optBar,
+                is_string($this->optBar)
+                    || (is_int($this->optBar) || is_float($this->optBar))
+                    || is_bool($this->optBar)
+                    || is_array($this->optBar) =>
+                    $this->optBar,
             };
         }
         if (isset($this->optBaz)) {
             $this->optBaz = match (true) {
-                is_string($this->optBaz),
-                (is_int($this->optBaz) || is_float($this->optBaz)),
-                is_bool($this->optBaz),
-                is_array($this->optBaz) || is_object($this->optBaz) => $this->optBaz,
+                is_string($this->optBaz)
+                    || (is_int($this->optBaz) || is_float($this->optBaz))
+                    || is_bool($this->optBaz)
+                    || is_array($this->optBaz) || is_object($this->optBaz) =>
+                    $this->optBaz,
             };
         }
         if (isset($this->optQux)) {
             $this->optQux = match (true) {
-                is_string($this->optQux),
-                (is_int($this->optQux) || is_float($this->optQux)),
-                is_bool($this->optQux),
-                is_array($this->optQux),
-                is_array($this->optQux) || is_object($this->optQux) => $this->optQux,
+                is_string($this->optQux)
+                    || (is_int($this->optQux) || is_float($this->optQux))
+                    || is_bool($this->optQux)
+                    || is_array($this->optQux)
+                    || is_array($this->optQux) || is_object($this->optQux) =>
+                    $this->optQux,
             };
         }
         if (isset($this->optThud)) {
             $this->optThud = match (true) {
-                is_string($this->optThud),
-                (is_int($this->optThud) || is_float($this->optThud)),
-                is_bool($this->optThud),
-                is_array($this->optThud),
-                is_array($this->optThud) || is_object($this->optThud) => $this->optThud,
+                is_string($this->optThud)
+                    || (is_int($this->optThud) || is_float($this->optThud))
+                    || is_bool($this->optThud)
+                    || is_array($this->optThud)
+                    || is_array($this->optThud) || is_object($this->optThud) =>
+                    $this->optThud,
             };
         }
     }

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-5.6/MyClass.php
@@ -243,9 +243,9 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = ($this->foo instanceof MyClassFooAlternative2
-            ? clone $this->foo
-            : (is_string($this->foo) ? $this->foo : $this->foo)
+        $this->foo = ((is_string($this->foo))
+            ? $this->foo
+            : (($this->foo instanceof MyClassFooAlternative2) ? clone $this->foo : $this->foo)
         );
     }
 }

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClass.php
@@ -235,9 +235,9 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = ($this->foo instanceof MyClassFooAlternative2
-            ? clone $this->foo
-            : (is_string($this->foo) ? $this->foo : $this->foo)
+        $this->foo = ((is_string($this->foo))
+            ? $this->foo
+            : (($this->foo instanceof MyClassFooAlternative2) ? clone $this->foo : $this->foo)
         );
     }
 }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-5.6/Record.php
@@ -355,18 +355,18 @@ class Record
             : null;
         $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'})
             ? array_map(function($i) use ($validate) {
-                return (Fio::validateInput($i, true)
-                    ? Fio::fromInput($i, $validate)
-                    : (Phone::validateInput($i, true) ? Phone::fromInput($i, $validate) : null)
+                return ((Phone::validateInput($i, true))
+                    ? Phone::fromInput($i, $validate)
+                    : ((Fio::validateInput($i, true)) ? Fio::fromInput($i, $validate) : null)
                 );
             }, $input->{'dataArrayAnyOf'})
             : null;
         $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'})
             ? array_map(function($i) use ($validate) {
                 return array_map(function($i) use ($validate) {
-                    return (Fio::validateInput($i, true)
-                        ? Fio::fromInput($i, $validate)
-                        : (Phone::validateInput($i, true) ? Phone::fromInput($i, $validate) : null)
+                    return ((Phone::validateInput($i, true))
+                        ? Phone::fromInput($i, $validate)
+                        : ((Fio::validateInput($i, true)) ? Fio::fromInput($i, $validate) : null)
                     );
                 }, $i);
             }, $input->{'dataArrayNestedAnyOf'})
@@ -407,13 +407,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output['dataArrayAnyOf'] = array_map(function($i) {
-                return ($i instanceof Fio ? $i->toArray() : ($i instanceof Phone ? $i->toArray() : null));
+                return (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : null);
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output['dataArrayNestedAnyOf'] = array_map(function($i) {
                 return array_map(function($i) {
-                    return ($i instanceof Fio ? $i->toArray() : ($i instanceof Phone ? $i->toArray() : null));
+                    return (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : null);
                 }, $i);
             }, $this->dataArrayNestedAnyOf);
         }
@@ -446,19 +446,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output->{'dataArrayAnyOf'} = array_map(function($i) {
-                return ($i instanceof Fio
-                    ? $i->toStdClass()
-                    : ($i instanceof Phone ? $i->toStdClass() : null)
-                );
+                return (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : null);
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output->{'dataArrayNestedAnyOf'} = array_map(function($i) {
                 return array_map(function($i) {
-                    return ($i instanceof Fio
-                        ? $i->toStdClass()
-                        : ($i instanceof Phone ? $i->toStdClass() : null)
-                    );
+                    return (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : null);
                 }, $i);
             }, $this->dataArrayNestedAnyOf);
         }
@@ -512,13 +506,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $this->dataArrayAnyOf = array_map(function($i) {
-                return ($i instanceof Fio ? $i : ($i instanceof Phone ? $i : $i));
+                return (($i instanceof Phone || $i instanceof Fio) ? $i : $i);
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $this->dataArrayNestedAnyOf = array_map(function($i) {
                 return array_map(function($i) {
-                    return ($i instanceof Fio ? $i : ($i instanceof Phone ? $i : $i));
+                    return (($i instanceof Phone || $i instanceof Fio) ? $i : $i);
                 }, $i);
             }, $this->dataArrayNestedAnyOf);
         }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-7.4/Record.php
@@ -324,16 +324,16 @@ class Record
             )
             : null;
         $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'})
-            ? array_map(fn ($i) => (Fio::validateInput($i, true)
-                ? Fio::fromInput($i, $validate)
-                : (Phone::validateInput($i, true) ? Phone::fromInput($i, $validate) : null)
+            ? array_map(fn ($i) => ((Phone::validateInput($i, true))
+                ? Phone::fromInput($i, $validate)
+                : ((Fio::validateInput($i, true)) ? Fio::fromInput($i, $validate) : null)
             ), $input->{'dataArrayAnyOf'})
             : null;
         $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'})
             ? array_map(
-                fn ($i) => array_map(fn ($i) => (Fio::validateInput($i, true)
-                    ? Fio::fromInput($i, $validate)
-                    : (Phone::validateInput($i, true) ? Phone::fromInput($i, $validate) : null)
+                fn ($i) => array_map(fn ($i) => ((Phone::validateInput($i, true))
+                    ? Phone::fromInput($i, $validate)
+                    : ((Fio::validateInput($i, true)) ? Fio::fromInput($i, $validate) : null)
                 ), $i),
                 $input->{'dataArrayNestedAnyOf'},
             )
@@ -366,15 +366,15 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output['dataArrayAnyOf'] = array_map(
-                fn ($i) => ($i instanceof Fio ? $i->toArray() : ($i instanceof Phone ? $i->toArray() : null)),
+                fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : null),
                 $this->dataArrayAnyOf,
             );
         }
         if (isset($this->dataArrayNestedAnyOf)) {
-            $output['dataArrayNestedAnyOf'] = array_map(fn ($i) => array_map(
-                fn ($i) => ($i instanceof Fio ? $i->toArray() : ($i instanceof Phone ? $i->toArray() : null)),
-                $i,
-            ), $this->dataArrayNestedAnyOf);
+            $output['dataArrayNestedAnyOf'] = array_map(
+                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : null), $i),
+                $this->dataArrayNestedAnyOf,
+            );
         }
 
         return $output;
@@ -399,17 +399,14 @@ class Record
             );
         }
         if (isset($this->dataArrayAnyOf)) {
-            $output->{'dataArrayAnyOf'} = array_map(fn ($i) => ($i instanceof Fio
-                ? $i->toStdClass()
-                : ($i instanceof Phone ? $i->toStdClass() : null)
-            ), $this->dataArrayAnyOf);
+            $output->{'dataArrayAnyOf'} = array_map(
+                fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : null),
+                $this->dataArrayAnyOf,
+            );
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output->{'dataArrayNestedAnyOf'} = array_map(
-                fn ($i) => array_map(fn ($i) => ($i instanceof Fio
-                    ? $i->toStdClass()
-                    : ($i instanceof Phone ? $i->toStdClass() : null)
-                ), $i),
+                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : null), $i),
                 $this->dataArrayNestedAnyOf,
             );
         }
@@ -460,14 +457,11 @@ class Record
             $this->dataArrayNested = array_map(fn ($i) => $i, $this->dataArrayNested);
         }
         if (isset($this->dataArrayAnyOf)) {
-            $this->dataArrayAnyOf = array_map(
-                fn ($i) => ($i instanceof Fio ? $i : ($i instanceof Phone ? $i : $i)),
-                $this->dataArrayAnyOf,
-            );
+            $this->dataArrayAnyOf = array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i : $i), $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $this->dataArrayNestedAnyOf = array_map(
-                fn ($i) => array_map(fn ($i) => ($i instanceof Fio ? $i : ($i instanceof Phone ? $i : $i)), $i),
+                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i : $i), $i),
                 $this->dataArrayNestedAnyOf,
             );
         }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-8.4/Record.php
@@ -361,17 +361,15 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output['dataArrayAnyOf'] = array_map(fn ($i) => match (true) {
+                $i instanceof Phone || $i instanceof Fio => $i->toArray(),
                 default => null,
-                $i instanceof Phone,
-                $i instanceof Fio => $i->toArray(),
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output['dataArrayNestedAnyOf'] = array_map(
                 fn ($i) => array_map(fn ($i) => match (true) {
+                    $i instanceof Phone || $i instanceof Fio => $i->toArray(),
                     default => null,
-                    $i instanceof Phone,
-                    $i instanceof Fio => $i->toArray(),
                 }, $i),
                 $this->dataArrayNestedAnyOf,
             );
@@ -400,17 +398,15 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output->{'dataArrayAnyOf'} = array_map(fn ($i) => match (true) {
+                $i instanceof Phone || $i instanceof Fio => $i->toStdClass(),
                 default => null,
-                $i instanceof Phone,
-                $i instanceof Fio => $i->toStdClass(),
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output->{'dataArrayNestedAnyOf'} = array_map(
                 fn ($i) => array_map(fn ($i) => match (true) {
+                    $i instanceof Phone || $i instanceof Fio => $i->toStdClass(),
                     default => null,
-                    $i instanceof Phone,
-                    $i instanceof Fio => $i->toStdClass(),
                 }, $i),
                 $this->dataArrayNestedAnyOf,
             );
@@ -463,15 +459,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $this->dataArrayAnyOf = array_map(fn ($i) => match (true) {
-                $i instanceof Phone,
-                $i instanceof Fio => $i,
+                $i instanceof Phone || $i instanceof Fio => $i,
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $this->dataArrayNestedAnyOf = array_map(
                 fn ($i) => array_map(fn ($i) => match (true) {
-                    $i instanceof Phone,
-                    $i instanceof Fio => $i,
+                    $i instanceof Phone || $i instanceof Fio => $i,
                 }, $i),
                 $this->dataArrayNestedAnyOf,
             );

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
@@ -180,9 +180,9 @@ class MyObject
 
     public function __clone()
     {
-        $this->foo = (in_array($this->foo, ['baz', 'quz'], true)
+        $this->foo = ((in_array($this->foo, ['foo', 'bar'], true) || in_array($this->foo, ['baz', 'quz'], true))
             ? $this->foo
-            : (in_array($this->foo, ['foo', 'bar'], true) ? $this->foo : $this->foo)
+            : $this->foo
         );
     }
 }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
@@ -179,9 +179,9 @@ class MyObject
 
     public function __clone()
     {
-        $this->foo = (in_array($this->foo, ['baz', 'quz'], true)
+        $this->foo = ((in_array($this->foo, ['foo', 'bar'], true) || in_array($this->foo, ['baz', 'quz'], true))
             ? $this->foo
-            : (in_array($this->foo, ['foo', 'bar'], true) ? $this->foo : $this->foo)
+            : $this->foo
         );
     }
 }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
@@ -103,8 +103,7 @@ class MyObject
     {
         $output = [];
         $output['foo'] = match (true) {
-            $this->foo instanceof A,
-            $this->foo instanceof B => $this->foo->value,
+            $this->foo instanceof A || $this->foo instanceof B => $this->foo->value,
         };
 
         return $output;
@@ -119,8 +118,7 @@ class MyObject
     {
         $output = new \stdClass();
         $output->{'foo'} = match (true) {
-            $this->foo instanceof A,
-            $this->foo instanceof B => $this->foo->value,
+            $this->foo instanceof A || $this->foo instanceof B => $this->foo->value,
         };
 
         return $output;
@@ -166,8 +164,7 @@ class MyObject
     public function __clone()
     {
         $this->foo = match (true) {
-            $this->foo instanceof A,
-            $this->foo instanceof B => $this->foo,
+            $this->foo instanceof A || $this->foo instanceof B => $this->foo,
         };
     }
 }

--- a/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
+++ b/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
@@ -223,8 +223,7 @@ class RefValidation
         $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
         $bar = isset($input->{'bar'})
             ? match (true) {
-                is_string($input->{'bar'}),
-                in_array($input->{'bar'}, [1, 2], true) => $input->{'bar'},
+                is_string($input->{'bar'}) || in_array($input->{'bar'}, [1, 2], true) => $input->{'bar'},
                 default => null,
             }
             : null;
@@ -256,8 +255,7 @@ class RefValidation
         }
         if (isset($this->bar)) {
             $output['bar'] = match (true) {
-                is_string($this->bar),
-                in_array($this->bar, [1, 2], true) => $this->bar,
+                is_string($this->bar) || in_array($this->bar, [1, 2], true) => $this->bar,
             };
         }
         if (isset($this->baz)) {
@@ -281,8 +279,7 @@ class RefValidation
         }
         if (isset($this->bar)) {
             $output->{'bar'} = match (true) {
-                is_string($this->bar),
-                in_array($this->bar, [1, 2], true) => $this->bar,
+                is_string($this->bar) || in_array($this->bar, [1, 2], true) => $this->bar,
             };
         }
         if (isset($this->baz)) {
@@ -333,8 +330,7 @@ class RefValidation
     {
         if (isset($this->bar)) {
             $this->bar = match (true) {
-                is_string($this->bar),
-                in_array($this->bar, [1, 2], true) => $this->bar,
+                is_string($this->bar) || in_array($this->bar, [1, 2], true) => $this->bar,
             };
         }
         if (isset($this->baz)) {

--- a/tests/Generator/Fixtures/SettersValidation/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-5.6/Foo.php
@@ -346,9 +346,9 @@ class Foo
 
         $_providedOptionals = [];
         $a = isset($input->{'a'})
-            ? (is_array($input->{'a'})
+            ? ((in_array($input->{'a'}, ['a', 'b'], true) || is_array($input->{'a'}))
                 ? $input->{'a'}
-                : (in_array($input->{'a'}, ['a', 'b'], true) ? $input->{'a'} : null)
+                : null
             )
             : null;
         $b = isset($input->{'b'}) ? $input->{'b'} : null;
@@ -463,10 +463,7 @@ class Foo
     public function __clone()
     {
         if (isset($this->a)) {
-            $this->a = (is_array($this->a)
-                ? $this->a
-                : (in_array($this->a, ['a', 'b'], true) ? $this->a : $this->a)
-            );
+            $this->a = ((in_array($this->a, ['a', 'b'], true) || is_array($this->a)) ? $this->a : $this->a);
         }
     }
 

--- a/tests/Generator/Fixtures/SettersValidation/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-7.4/Foo.php
@@ -307,9 +307,9 @@ class Foo
 
         $_providedOptionals = [];
         $a = isset($input->{'a'})
-            ? (is_array($input->{'a'})
+            ? ((in_array($input->{'a'}, ['a', 'b'], true) || is_array($input->{'a'}))
                 ? $input->{'a'}
-                : (in_array($input->{'a'}, ['a', 'b'], true) ? $input->{'a'} : null)
+                : null
             )
             : null;
         $b = isset($input->{'b'}) ? $input->{'b'} : null;
@@ -425,10 +425,7 @@ class Foo
     public function __clone()
     {
         if (isset($this->a)) {
-            $this->a = (is_array($this->a)
-                ? $this->a
-                : (in_array($this->a, ['a', 'b'], true) ? $this->a : $this->a)
-            );
+            $this->a = ((in_array($this->a, ['a', 'b'], true) || is_array($this->a)) ? $this->a : $this->a);
         }
     }
 

--- a/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
@@ -285,8 +285,7 @@ class Foo
         $_providedOptionals = [];
         $a = isset($input->{'a'})
             ? match (true) {
-                in_array($input->{'a'}, ['a', 'b'], true),
-                is_array($input->{'a'}) => $input->{'a'},
+                in_array($input->{'a'}, ['a', 'b'], true) || is_array($input->{'a'}) => $input->{'a'},
                 default => null,
             }
             : null;
@@ -320,8 +319,7 @@ class Foo
 
         if (isset($this->a)) {
             $output['a'] = match (true) {
-                in_array($this->a, ['a', 'b'], true),
-                is_array($this->a) => $this->a,
+                in_array($this->a, ['a', 'b'], true) || is_array($this->a) => $this->a,
             };
         }
         if (isset($this->b)) {
@@ -348,8 +346,7 @@ class Foo
 
         if (isset($this->a)) {
             $output->{'a'} = match (true) {
-                in_array($this->a, ['a', 'b'], true),
-                is_array($this->a) => $this->a,
+                in_array($this->a, ['a', 'b'], true) || is_array($this->a) => $this->a,
             };
         }
         if (isset($this->b)) {
@@ -406,8 +403,7 @@ class Foo
     {
         if (isset($this->a)) {
             $this->a = match (true) {
-                in_array($this->a, ['a', 'b'], true),
-                is_array($this->a) => $this->a,
+                in_array($this->a, ['a', 'b'], true) || is_array($this->a) => $this->a,
             };
         }
     }

--- a/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
@@ -155,12 +155,15 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'})
-            ? ((is_int($input->{'foo'}) || is_float($input->{'foo'}))
-                ? (str_contains((string)$input->{'foo'}, '.')
-                    ? (float)$input->{'foo'}
-                    : (int)$input->{'foo'}
+            ? ((is_string($input->{'foo'}))
+                ? $input->{'foo'}
+                : (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
+                    ? (str_contains((string)$input->{'foo'}, '.')
+                        ? (float)$input->{'foo'}
+                        : (int)$input->{'foo'}
+                    )
+                    : null
                 )
-                : (is_string($input->{'foo'}) ? $input->{'foo'} : null)
             )
             : null;
 
@@ -249,9 +252,9 @@ class MyClass
     public function __clone()
     {
         if (isset($this->foo)) {
-            $this->foo = ((is_int($this->foo) || is_float($this->foo))
+            $this->foo = ((is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)))
                 ? $this->foo
-                : (is_string($this->foo) ? $this->foo : $this->foo)
+                : $this->foo
             );
         }
     }

--- a/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
@@ -143,12 +143,15 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'})
-            ? ((is_int($input->{'foo'}) || is_float($input->{'foo'}))
-                ? (str_contains((string)$input->{'foo'}, '.')
-                    ? (float)$input->{'foo'}
-                    : (int)$input->{'foo'}
+            ? ((is_string($input->{'foo'}))
+                ? $input->{'foo'}
+                : (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
+                    ? (str_contains((string)$input->{'foo'}, '.')
+                        ? (float)$input->{'foo'}
+                        : (int)$input->{'foo'}
+                    )
+                    : null
                 )
-                : (is_string($input->{'foo'}) ? $input->{'foo'} : null)
             )
             : null;
 
@@ -238,9 +241,9 @@ class MyClass
     public function __clone()
     {
         if (isset($this->foo)) {
-            $this->foo = ((is_int($this->foo) || is_float($this->foo))
+            $this->foo = ((is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)))
                 ? $this->foo
-                : (is_string($this->foo) ? $this->foo : $this->foo)
+                : $this->foo
             );
         }
     }

--- a/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
@@ -148,8 +148,7 @@ class MyClass
 
         if (isset($this->foo)) {
             $output['foo'] = match (true) {
-                is_string($this->foo),
-                (is_int($this->foo) || is_float($this->foo)) => $this->foo,
+                is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) => $this->foo,
             };
         }
 
@@ -167,8 +166,7 @@ class MyClass
 
         if (isset($this->foo)) {
             $output->{'foo'} = match (true) {
-                is_string($this->foo),
-                (is_int($this->foo) || is_float($this->foo)) => $this->foo,
+                is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) => $this->foo,
             };
         }
 
@@ -216,8 +214,7 @@ class MyClass
     {
         if (isset($this->foo)) {
             $this->foo = match (true) {
-                is_string($this->foo),
-                (is_int($this->foo) || is_float($this->foo)) => $this->foo,
+                is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) => $this->foo,
             };
         }
     }

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
@@ -413,22 +413,24 @@ class MyClass
         }
 
         $arrayOfObjectsUnion = isset($input->{'arrayOfObjectsUnion'})
-            ? ((is_array($input->{'arrayOfObjectsUnion'})
+            ? (((is_array($input->{'arrayOfObjectsUnion'})
                 && count($input->{'arrayOfObjectsUnion'}) === count(array_filter(
                     $input->{'arrayOfObjectsUnion'},
-                    fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => MyClassArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
+                    fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => MyClassArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
                 )))
+            )
                 ? array_map(
-                    fn ($i): MyClassArrayOfObjectsUnionAlternative2Item => MyClassArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
+                    fn ($i): MyClassArrayOfObjectsUnionAlternative1Item => MyClassArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
                     $input->{'arrayOfObjectsUnion'},
                 )
-                : ((is_array($input->{'arrayOfObjectsUnion'})
+                : (((is_array($input->{'arrayOfObjectsUnion'})
                     && count($input->{'arrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'arrayOfObjectsUnion'},
-                        fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => MyClassArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
+                        fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => MyClassArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
                     )))
+                )
                     ? array_map(
-                        fn ($i): MyClassArrayOfObjectsUnionAlternative1Item => MyClassArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
+                        fn ($i): MyClassArrayOfObjectsUnionAlternative2Item => MyClassArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'arrayOfObjectsUnion'},
                     )
                     : null
@@ -436,22 +438,24 @@ class MyClass
             )
             : null;
         $refArrayOfObjectsUnion = isset($input->{'refArrayOfObjectsUnion'})
-            ? ((is_array($input->{'refArrayOfObjectsUnion'})
+            ? (((is_array($input->{'refArrayOfObjectsUnion'})
                 && count($input->{'refArrayOfObjectsUnion'}) === count(array_filter(
                     $input->{'refArrayOfObjectsUnion'},
-                    fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => MyClassRefArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
+                    fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => MyClassRefArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
                 )))
+            )
                 ? array_map(
-                    fn ($i): MyClassRefArrayOfObjectsUnionAlternative2Item => MyClassRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
+                    fn ($i): MyClassRefArrayOfObjectsUnionAlternative1Item => MyClassRefArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
                     $input->{'refArrayOfObjectsUnion'},
                 )
-                : ((is_array($input->{'refArrayOfObjectsUnion'})
+                : (((is_array($input->{'refArrayOfObjectsUnion'})
                     && count($input->{'refArrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'refArrayOfObjectsUnion'},
-                        fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => MyClassRefArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
+                        fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => MyClassRefArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
                     )))
+                )
                     ? array_map(
-                        fn ($i): MyClassRefArrayOfObjectsUnionAlternative1Item => MyClassRefArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
+                        fn ($i): MyClassRefArrayOfObjectsUnionAlternative2Item => MyClassRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'refArrayOfObjectsUnion'},
                     )
                     : null
@@ -459,40 +463,44 @@ class MyClass
             )
             : null;
         $refAndNotRefArrayOfObjectsUnion = isset($input->{'refAndNotRefArrayOfObjectsUnion'})
-            ? ((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+            ? (((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                 && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                     $input->{'refAndNotRefArrayOfObjectsUnion'},
-                    fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::validateInput($item, true),
+                    fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
                 )))
+            )
                 ? array_map(
-                    fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::fromInput($i, $validate),
+                    fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
                     $input->{'refAndNotRefArrayOfObjectsUnion'},
                 )
-                : ((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                : (((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                     && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
-                        fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item::validateInput($item, true),
+                        fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
                     )))
+                )
                     ? array_map(
-                        fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item::fromInput($i, $validate),
+                        fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                     )
-                    : ((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                    : (((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                         && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                             $input->{'refAndNotRefArrayOfObjectsUnion'},
-                            fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
+                            fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item::validateInput($item, true),
                         )))
+                    )
                         ? array_map(
-                            fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
+                            fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item::fromInput($i, $validate),
                             $input->{'refAndNotRefArrayOfObjectsUnion'},
                         )
-                        : ((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                        : (((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                             && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                                 $input->{'refAndNotRefArrayOfObjectsUnion'},
-                                fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
+                                fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::validateInput($item, true),
                             )))
+                        )
                             ? array_map(
-                                fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
+                                fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::fromInput($i, $validate),
                                 $input->{'refAndNotRefArrayOfObjectsUnion'},
                             )
                             : null
@@ -502,17 +510,18 @@ class MyClass
             )
             : null;
         $arrayOfObjAndStringUnion = isset($input->{'arrayOfObjAndStringUnion'})
-            ? (is_string($input->{'arrayOfObjAndStringUnion'})
-                ? $input->{'arrayOfObjAndStringUnion'}
-                : ((is_array($input->{'arrayOfObjAndStringUnion'})
-                    && count($input->{'arrayOfObjAndStringUnion'}) === count(array_filter(
-                        $input->{'arrayOfObjAndStringUnion'},
-                        fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => MyClassArrayOfObjAndStringUnionAlternative1Item::validateInput($item, true),
-                    )))
-                    ? array_map(
-                        fn ($i): MyClassArrayOfObjAndStringUnionAlternative1Item => MyClassArrayOfObjAndStringUnionAlternative1Item::fromInput($i, $validate),
-                        $input->{'arrayOfObjAndStringUnion'},
-                    )
+            ? (((is_array($input->{'arrayOfObjAndStringUnion'})
+                && count($input->{'arrayOfObjAndStringUnion'}) === count(array_filter(
+                    $input->{'arrayOfObjAndStringUnion'},
+                    fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => MyClassArrayOfObjAndStringUnionAlternative1Item::validateInput($item, true),
+                )))
+            )
+                ? array_map(
+                    fn ($i): MyClassArrayOfObjAndStringUnionAlternative1Item => MyClassArrayOfObjAndStringUnionAlternative1Item::fromInput($i, $validate),
+                    $input->{'arrayOfObjAndStringUnion'},
+                )
+                : ((is_string($input->{'arrayOfObjAndStringUnion'}))
+                    ? $input->{'arrayOfObjAndStringUnion'}
                     : null
                 )
             )
@@ -826,22 +835,24 @@ class MyClass
     public function __clone()
     {
         if (isset($this->arrayOfObjectsUnion)) {
-            $this->arrayOfObjectsUnion = ((is_array($this->arrayOfObjectsUnion)
+            $this->arrayOfObjectsUnion = (((is_array($this->arrayOfObjectsUnion)
                 && count($this->arrayOfObjectsUnion) === count(array_filter(
                     $this->arrayOfObjectsUnion,
-                    fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative2Item,
+                    fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative1Item,
                 )))
+            )
                 ? array_map(
-                    fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => clone $i,
+                    fn (MyClassArrayOfObjectsUnionAlternative1Item $i) => clone $i,
                     $this->arrayOfObjectsUnion,
                 )
-                : ((is_array($this->arrayOfObjectsUnion)
+                : (((is_array($this->arrayOfObjectsUnion)
                     && count($this->arrayOfObjectsUnion) === count(array_filter(
                         $this->arrayOfObjectsUnion,
-                        fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative1Item,
+                        fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative2Item,
                     )))
+                )
                     ? array_map(
-                        fn (MyClassArrayOfObjectsUnionAlternative1Item $i) => clone $i,
+                        fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => clone $i,
                         $this->arrayOfObjectsUnion,
                     )
                     : $this->arrayOfObjectsUnion
@@ -849,22 +860,24 @@ class MyClass
             );
         }
         if (isset($this->refArrayOfObjectsUnion)) {
-            $this->refArrayOfObjectsUnion = ((is_array($this->refArrayOfObjectsUnion)
+            $this->refArrayOfObjectsUnion = (((is_array($this->refArrayOfObjectsUnion)
                 && count($this->refArrayOfObjectsUnion) === count(array_filter(
                     $this->refArrayOfObjectsUnion,
-                    fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative2Item,
+                    fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative1Item,
                 )))
+            )
                 ? array_map(
-                    fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => clone $i,
+                    fn (MyClassRefArrayOfObjectsUnionAlternative1Item $i) => clone $i,
                     $this->refArrayOfObjectsUnion,
                 )
-                : ((is_array($this->refArrayOfObjectsUnion)
+                : (((is_array($this->refArrayOfObjectsUnion)
                     && count($this->refArrayOfObjectsUnion) === count(array_filter(
                         $this->refArrayOfObjectsUnion,
-                        fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative1Item,
+                        fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative2Item,
                     )))
+                )
                     ? array_map(
-                        fn (MyClassRefArrayOfObjectsUnionAlternative1Item $i) => clone $i,
+                        fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => clone $i,
                         $this->refArrayOfObjectsUnion,
                     )
                     : $this->refArrayOfObjectsUnion
@@ -872,40 +885,44 @@ class MyClass
             );
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
-            $this->refAndNotRefArrayOfObjectsUnion = ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+            $this->refAndNotRefArrayOfObjectsUnion = (((is_array($this->refAndNotRefArrayOfObjectsUnion)
                 && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                     $this->refAndNotRefArrayOfObjectsUnion,
-                    fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item,
+                    fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item,
                 )))
+            )
                 ? array_map(
-                    fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => clone $i,
+                    fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $i) => clone $i,
                     $this->refAndNotRefArrayOfObjectsUnion,
                 )
-                : ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+                : (((is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
-                        fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item,
+                        fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item,
                     )))
+                )
                     ? array_map(
-                        fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $i) => clone $i,
+                        fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $i) => clone $i,
                         $this->refAndNotRefArrayOfObjectsUnion,
                     )
-                    : ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+                    : (((is_array($this->refAndNotRefArrayOfObjectsUnion)
                         && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                             $this->refAndNotRefArrayOfObjectsUnion,
-                            fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item,
+                            fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item,
                         )))
+                    )
                         ? array_map(
-                            fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $i) => clone $i,
+                            fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $i) => clone $i,
                             $this->refAndNotRefArrayOfObjectsUnion,
                         )
-                        : ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+                        : (((is_array($this->refAndNotRefArrayOfObjectsUnion)
                             && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                                 $this->refAndNotRefArrayOfObjectsUnion,
-                                fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item,
+                                fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item,
                             )))
+                        )
                             ? array_map(
-                                fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $i) => clone $i,
+                                fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => clone $i,
                                 $this->refAndNotRefArrayOfObjectsUnion,
                             )
                             : $this->refAndNotRefArrayOfObjectsUnion
@@ -915,17 +932,18 @@ class MyClass
             );
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
-            $this->arrayOfObjAndStringUnion = (is_string($this->arrayOfObjAndStringUnion)
-                ? $this->arrayOfObjAndStringUnion
-                : ((is_array($this->arrayOfObjAndStringUnion)
-                    && count($this->arrayOfObjAndStringUnion) === count(array_filter(
-                        $this->arrayOfObjAndStringUnion,
-                        fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjAndStringUnionAlternative1Item,
-                    )))
-                    ? array_map(
-                        fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => clone $i,
-                        $this->arrayOfObjAndStringUnion,
-                    )
+            $this->arrayOfObjAndStringUnion = (((is_array($this->arrayOfObjAndStringUnion)
+                && count($this->arrayOfObjAndStringUnion) === count(array_filter(
+                    $this->arrayOfObjAndStringUnion,
+                    fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjAndStringUnionAlternative1Item,
+                )))
+            )
+                ? array_map(
+                    fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => clone $i,
+                    $this->arrayOfObjAndStringUnion,
+                )
+                : ((is_string($this->arrayOfObjAndStringUnion))
+                    ? $this->arrayOfObjAndStringUnion
                     : $this->arrayOfObjAndStringUnion
                 )
             );

--- a/tests/Generator/Fixtures/UnionArrayTyped/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayTyped/Output-7.4/MyClass.php
@@ -381,42 +381,26 @@ class MyClass
         }
 
         $unionOfTypedArrays = isset($input->{'unionOfTypedArrays'})
-            ? (is_array($input->{'unionOfTypedArrays'})
-                ? $input->{'unionOfTypedArrays'}
-                : (is_array($input->{'unionOfTypedArrays'}) ? $input->{'unionOfTypedArrays'} : null)
-            )
+            ? ((is_array($input->{'unionOfTypedArrays'})) ? $input->{'unionOfTypedArrays'} : null)
             : null;
         $refUnionOfTypedArrays = isset($input->{'refUnionOfTypedArrays'})
-            ? (is_array($input->{'refUnionOfTypedArrays'})
+            ? ((is_array($input->{'refUnionOfTypedArrays'}))
                 ? $input->{'refUnionOfTypedArrays'}
-                : (is_array($input->{'refUnionOfTypedArrays'})
-                    ? $input->{'refUnionOfTypedArrays'}
-                    : null
-                )
+                : null
             )
             : null;
         $refAndNotRefUnionOfTypedArrays = isset($input->{'refAndNotRefUnionOfTypedArrays'})
-            ? (is_array($input->{'refAndNotRefUnionOfTypedArrays'})
+            ? ((is_array($input->{'refAndNotRefUnionOfTypedArrays'}))
                 ? $input->{'refAndNotRefUnionOfTypedArrays'}
-                : (is_array($input->{'refAndNotRefUnionOfTypedArrays'})
-                    ? $input->{'refAndNotRefUnionOfTypedArrays'}
-                    : (is_array($input->{'refAndNotRefUnionOfTypedArrays'})
-                        ? $input->{'refAndNotRefUnionOfTypedArrays'}
-                        : (is_array($input->{'refAndNotRefUnionOfTypedArrays'})
-                            ? $input->{'refAndNotRefUnionOfTypedArrays'}
-                            : null
-                        )
-                    )
-                )
+                : null
             )
             : null;
         $unionOfTypedArrayAndString = isset($input->{'unionOfTypedArrayAndString'})
-            ? (is_string($input->{'unionOfTypedArrayAndString'})
+            ? ((is_array($input->{'unionOfTypedArrayAndString'})
+                || is_string($input->{'unionOfTypedArrayAndString'})
+            )
                 ? $input->{'unionOfTypedArrayAndString'}
-                : (is_array($input->{'unionOfTypedArrayAndString'})
-                    ? $input->{'unionOfTypedArrayAndString'}
-                    : null
-                )
+                : null
             )
             : null;
         $unionOfOneTypedArray = isset($input->{'unionOfOneTypedArray'}) ? $input->{'unionOfOneTypedArray'} : null;
@@ -447,21 +431,17 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->unionOfTypedArrays)) {
-            if (is_array($this->unionOfTypedArrays) || is_array($this->unionOfTypedArrays)) {
+            if (is_array($this->unionOfTypedArrays)) {
                 $output['unionOfTypedArrays'] = $this->unionOfTypedArrays;
             }
         }
         if (isset($this->refUnionOfTypedArrays)) {
-            if (is_array($this->refUnionOfTypedArrays) || is_array($this->refUnionOfTypedArrays)) {
+            if (is_array($this->refUnionOfTypedArrays)) {
                 $output['refUnionOfTypedArrays'] = $this->refUnionOfTypedArrays;
             }
         }
         if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            if (is_array($this->refAndNotRefUnionOfTypedArrays)
-                || is_array($this->refAndNotRefUnionOfTypedArrays)
-                || is_array($this->refAndNotRefUnionOfTypedArrays)
-                || is_array($this->refAndNotRefUnionOfTypedArrays)
-            ) {
+            if (is_array($this->refAndNotRefUnionOfTypedArrays)) {
                 $output['refAndNotRefUnionOfTypedArrays'] = $this->refAndNotRefUnionOfTypedArrays;
             }
         }
@@ -487,21 +467,17 @@ class MyClass
         $output = $this->_additionalProperties;
 
         if (isset($this->unionOfTypedArrays)) {
-            if (is_array($this->unionOfTypedArrays) || is_array($this->unionOfTypedArrays)) {
+            if (is_array($this->unionOfTypedArrays)) {
                 $output->{'unionOfTypedArrays'} = $this->unionOfTypedArrays;
             }
         }
         if (isset($this->refUnionOfTypedArrays)) {
-            if (is_array($this->refUnionOfTypedArrays) || is_array($this->refUnionOfTypedArrays)) {
+            if (is_array($this->refUnionOfTypedArrays)) {
                 $output->{'refUnionOfTypedArrays'} = $this->refUnionOfTypedArrays;
             }
         }
         if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            if (is_array($this->refAndNotRefUnionOfTypedArrays)
-                || is_array($this->refAndNotRefUnionOfTypedArrays)
-                || is_array($this->refAndNotRefUnionOfTypedArrays)
-                || is_array($this->refAndNotRefUnionOfTypedArrays)
-            ) {
+            if (is_array($this->refAndNotRefUnionOfTypedArrays)) {
                 $output->{'refAndNotRefUnionOfTypedArrays'} = $this->refAndNotRefUnionOfTypedArrays;
             }
         }
@@ -557,45 +533,27 @@ class MyClass
     public function __clone()
     {
         if (isset($this->unionOfTypedArrays)) {
-            $this->unionOfTypedArrays = (is_array($this->unionOfTypedArrays)
+            $this->unionOfTypedArrays = ((is_array($this->unionOfTypedArrays))
                 ? $this->unionOfTypedArrays
-                : (is_array($this->unionOfTypedArrays)
-                    ? $this->unionOfTypedArrays
-                    : $this->unionOfTypedArrays
-                )
+                : $this->unionOfTypedArrays
             );
         }
         if (isset($this->refUnionOfTypedArrays)) {
-            $this->refUnionOfTypedArrays = (is_array($this->refUnionOfTypedArrays)
+            $this->refUnionOfTypedArrays = ((is_array($this->refUnionOfTypedArrays))
                 ? $this->refUnionOfTypedArrays
-                : (is_array($this->refUnionOfTypedArrays)
-                    ? $this->refUnionOfTypedArrays
-                    : $this->refUnionOfTypedArrays
-                )
+                : $this->refUnionOfTypedArrays
             );
         }
         if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            $this->refAndNotRefUnionOfTypedArrays = (is_array($this->refAndNotRefUnionOfTypedArrays)
+            $this->refAndNotRefUnionOfTypedArrays = ((is_array($this->refAndNotRefUnionOfTypedArrays))
                 ? $this->refAndNotRefUnionOfTypedArrays
-                : (is_array($this->refAndNotRefUnionOfTypedArrays)
-                    ? $this->refAndNotRefUnionOfTypedArrays
-                    : (is_array($this->refAndNotRefUnionOfTypedArrays)
-                        ? $this->refAndNotRefUnionOfTypedArrays
-                        : (is_array($this->refAndNotRefUnionOfTypedArrays)
-                            ? $this->refAndNotRefUnionOfTypedArrays
-                            : $this->refAndNotRefUnionOfTypedArrays
-                        )
-                    )
-                )
+                : $this->refAndNotRefUnionOfTypedArrays
             );
         }
         if (isset($this->unionOfTypedArrayAndString)) {
-            $this->unionOfTypedArrayAndString = (is_string($this->unionOfTypedArrayAndString)
+            $this->unionOfTypedArrayAndString = ((is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString))
                 ? $this->unionOfTypedArrayAndString
-                : (is_array($this->unionOfTypedArrayAndString)
-                    ? $this->unionOfTypedArrayAndString
-                    : $this->unionOfTypedArrayAndString
-                )
+                : $this->unionOfTypedArrayAndString
             );
         }
     }

--- a/tests/Generator/Fixtures/UnionArrayTyped/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayTyped/Output-8.4/MyClass.php
@@ -393,8 +393,9 @@ class MyClass
             : null;
         $unionOfTypedArrayAndString = isset($input->{'unionOfTypedArrayAndString'})
             ? match (true) {
-                is_array($input->{'unionOfTypedArrayAndString'}),
-                is_string($input->{'unionOfTypedArrayAndString'}) => $input->{'unionOfTypedArrayAndString'},
+                is_array($input->{'unionOfTypedArrayAndString'})
+                    || is_string($input->{'unionOfTypedArrayAndString'}) =>
+                    $input->{'unionOfTypedArrayAndString'},
                 default => null,
             }
             : null;
@@ -442,8 +443,8 @@ class MyClass
         }
         if (isset($this->unionOfTypedArrayAndString)) {
             $output['unionOfTypedArrayAndString'] = match (true) {
-                is_array($this->unionOfTypedArrayAndString),
-                is_string($this->unionOfTypedArrayAndString) => $this->unionOfTypedArrayAndString,
+                is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString) =>
+                    $this->unionOfTypedArrayAndString,
             };
         }
         if (isset($this->unionOfOneTypedArray)) {
@@ -479,8 +480,8 @@ class MyClass
         }
         if (isset($this->unionOfTypedArrayAndString)) {
             $output->{'unionOfTypedArrayAndString'} = match (true) {
-                is_array($this->unionOfTypedArrayAndString),
-                is_string($this->unionOfTypedArrayAndString) => $this->unionOfTypedArrayAndString,
+                is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString) =>
+                    $this->unionOfTypedArrayAndString,
             };
         }
         if (isset($this->unionOfOneTypedArray)) {
@@ -546,8 +547,8 @@ class MyClass
         }
         if (isset($this->unionOfTypedArrayAndString)) {
             $this->unionOfTypedArrayAndString = match (true) {
-                is_array($this->unionOfTypedArrayAndString),
-                is_string($this->unionOfTypedArrayAndString) => $this->unionOfTypedArrayAndString,
+                is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString) =>
+                    $this->unionOfTypedArrayAndString,
             };
         }
     }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
@@ -311,16 +311,7 @@ class MyClass
         $bar = $input->{'bar'};
         $baz = $input->{'baz'};
         $qux = ($input->{'qux'} !== null
-            ? (is_string($input->{'qux'})
-                ? $input->{'qux'}
-                : (is_string($input->{'qux'})
-                    ? $input->{'qux'}
-                    : (is_string($input->{'qux'})
-                        ? $input->{'qux'}
-                        : (is_string($input->{'qux'}) ? $input->{'qux'} : null)
-                    )
-                )
-            )
+            ? ((is_string($input->{'qux'})) ? $input->{'qux'} : null)
             : null
         );
 
@@ -343,16 +334,16 @@ class MyClass
     {
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
-        if (is_string($this->foo) || is_string($this->foo)) {
+        if (is_string($this->foo)) {
             $output['foo'] = $this->foo;
         }
-        if (is_string($this->bar) || is_string($this->bar)) {
+        if (is_string($this->bar)) {
             $output['bar'] = $this->bar;
         }
-        if (is_string($this->baz) || is_string($this->baz)) {
+        if (is_string($this->baz)) {
             $output['baz'] = $this->baz;
         }
-        if (is_string($this->qux) || is_string($this->qux) || is_string($this->qux) || is_string($this->qux)) {
+        if (is_string($this->qux)) {
             $output['qux'] = $this->qux;
         }
 
@@ -368,16 +359,16 @@ class MyClass
     {
         $output = $this->_additionalProperties;
 
-        if (is_string($this->foo) || is_string($this->foo)) {
+        if (is_string($this->foo)) {
             $output->{'foo'} = $this->foo;
         }
-        if (is_string($this->bar) || is_string($this->bar)) {
+        if (is_string($this->bar)) {
             $output->{'bar'} = $this->bar;
         }
-        if (is_string($this->baz) || is_string($this->baz)) {
+        if (is_string($this->baz)) {
             $output->{'baz'} = $this->baz;
         }
-        if (is_string($this->qux) || is_string($this->qux) || is_string($this->qux) || is_string($this->qux)) {
+        if (is_string($this->qux)) {
             $output->{'qux'} = $this->qux;
         }
 
@@ -422,27 +413,9 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = (is_string($this->foo)
-            ? $this->foo
-            : (is_string($this->foo) ? $this->foo : $this->foo)
-        );
-        $this->bar = (is_string($this->bar)
-            ? $this->bar
-            : (is_string($this->bar) ? $this->bar : $this->bar)
-        );
-        $this->baz = (is_string($this->baz)
-            ? $this->baz
-            : (is_string($this->baz) ? $this->baz : $this->baz)
-        );
-        $this->qux = (is_string($this->qux)
-            ? $this->qux
-            : (is_string($this->qux)
-                ? $this->qux
-                : (is_string($this->qux)
-                    ? $this->qux
-                    : (is_string($this->qux) ? $this->qux : $this->qux)
-                )
-            )
-        );
+        $this->foo = ((is_string($this->foo)) ? $this->foo : $this->foo);
+        $this->bar = ((is_string($this->bar)) ? $this->bar : $this->bar);
+        $this->baz = ((is_string($this->baz)) ? $this->baz : $this->baz);
+        $this->qux = ((is_string($this->qux)) ? $this->qux : $this->qux);
     }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -254,16 +254,7 @@ class MyClass
         $bar = $input->{'bar'};
         $baz = $input->{'baz'};
         $qux = ($input->{'qux'} !== null
-            ? (is_string($input->{'qux'})
-                ? $input->{'qux'}
-                : (is_string($input->{'qux'})
-                    ? $input->{'qux'}
-                    : (is_string($input->{'qux'})
-                        ? $input->{'qux'}
-                        : (is_string($input->{'qux'}) ? $input->{'qux'} : null)
-                    )
-                )
-            )
+            ? ((is_string($input->{'qux'})) ? $input->{'qux'} : null)
             : null
         );
 
@@ -286,16 +277,16 @@ class MyClass
     {
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
-        if (is_string($this->foo) || is_string($this->foo)) {
+        if (is_string($this->foo)) {
             $output['foo'] = $this->foo;
         }
-        if (is_string($this->bar) || is_string($this->bar)) {
+        if (is_string($this->bar)) {
             $output['bar'] = $this->bar;
         }
-        if (is_string($this->baz) || is_string($this->baz)) {
+        if (is_string($this->baz)) {
             $output['baz'] = $this->baz;
         }
-        if (is_string($this->qux) || is_string($this->qux) || is_string($this->qux) || is_string($this->qux)) {
+        if (is_string($this->qux)) {
             $output['qux'] = $this->qux;
         }
 
@@ -311,16 +302,16 @@ class MyClass
     {
         $output = $this->_additionalProperties;
 
-        if (is_string($this->foo) || is_string($this->foo)) {
+        if (is_string($this->foo)) {
             $output->{'foo'} = $this->foo;
         }
-        if (is_string($this->bar) || is_string($this->bar)) {
+        if (is_string($this->bar)) {
             $output->{'bar'} = $this->bar;
         }
-        if (is_string($this->baz) || is_string($this->baz)) {
+        if (is_string($this->baz)) {
             $output->{'baz'} = $this->baz;
         }
-        if (is_string($this->qux) || is_string($this->qux) || is_string($this->qux) || is_string($this->qux)) {
+        if (is_string($this->qux)) {
             $output->{'qux'} = $this->qux;
         }
 
@@ -366,27 +357,9 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = (is_string($this->foo)
-            ? $this->foo
-            : (is_string($this->foo) ? $this->foo : $this->foo)
-        );
-        $this->bar = (is_string($this->bar)
-            ? $this->bar
-            : (is_string($this->bar) ? $this->bar : $this->bar)
-        );
-        $this->baz = (is_string($this->baz)
-            ? $this->baz
-            : (is_string($this->baz) ? $this->baz : $this->baz)
-        );
-        $this->qux = (is_string($this->qux)
-            ? $this->qux
-            : (is_string($this->qux)
-                ? $this->qux
-                : (is_string($this->qux)
-                    ? $this->qux
-                    : (is_string($this->qux) ? $this->qux : $this->qux)
-                )
-            )
-        );
+        $this->foo = ((is_string($this->foo)) ? $this->foo : $this->foo);
+        $this->bar = ((is_string($this->bar)) ? $this->bar : $this->bar);
+        $this->baz = ((is_string($this->baz)) ? $this->baz : $this->baz);
+        $this->qux = ((is_string($this->qux)) ? $this->qux : $this->qux);
     }
 }

--- a/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
@@ -434,32 +434,32 @@ class MyClass
 
         $_providedOptionals = [];
         $objectsUnion = isset($input->{'objectsUnion'})
-            ? (MyClassObjectsUnionAlternative2::validateInput($input->{'objectsUnion'}, true)
-                ? MyClassObjectsUnionAlternative2::fromInput($input->{'objectsUnion'}, $validate)
-                : (MyClassObjectsUnionAlternative1::validateInput($input->{'objectsUnion'}, true)
-                    ? MyClassObjectsUnionAlternative1::fromInput($input->{'objectsUnion'}, $validate)
+            ? ((MyClassObjectsUnionAlternative1::validateInput($input->{'objectsUnion'}, true))
+                ? MyClassObjectsUnionAlternative1::fromInput($input->{'objectsUnion'}, $validate)
+                : ((MyClassObjectsUnionAlternative2::validateInput($input->{'objectsUnion'}, true))
+                    ? MyClassObjectsUnionAlternative2::fromInput($input->{'objectsUnion'}, $validate)
                     : null
                 )
             )
             : null;
         $refObjectsUnion = isset($input->{'refObjectsUnion'})
-            ? (SomeObj2::validateInput($input->{'refObjectsUnion'}, true)
-                ? SomeObj2::fromInput($input->{'refObjectsUnion'}, $validate)
-                : (SomeObj1::validateInput($input->{'refObjectsUnion'}, true)
-                    ? SomeObj1::fromInput($input->{'refObjectsUnion'}, $validate)
+            ? ((SomeObj1::validateInput($input->{'refObjectsUnion'}, true))
+                ? SomeObj1::fromInput($input->{'refObjectsUnion'}, $validate)
+                : ((SomeObj2::validateInput($input->{'refObjectsUnion'}, true))
+                    ? SomeObj2::fromInput($input->{'refObjectsUnion'}, $validate)
                     : null
                 )
             )
             : null;
         $refAndNotRefObjectsUnion = isset($input->{'refAndNotRefObjectsUnion'})
-            ? (MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true)
-                ? MyClassRefAndNotRefObjectsUnionAlternative4::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                : (SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)
-                    ? SomeObj2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                    : (MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)
-                        ? MyClassRefAndNotRefObjectsUnionAlternative2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                        : (SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true)
-                            ? SomeObj1::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
+            ? ((SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
+                ? SomeObj1::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
+                : ((MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
+                    ? MyClassRefAndNotRefObjectsUnionAlternative2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
+                    : ((SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
+                        ? SomeObj2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
+                        : ((MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
+                            ? MyClassRefAndNotRefObjectsUnionAlternative4::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
                             : null
                         )
                     )
@@ -467,12 +467,9 @@ class MyClass
             )
             : null;
         $objAndStringUnion = isset($input->{'objAndStringUnion'})
-            ? (is_string($input->{'objAndStringUnion'})
-                ? $input->{'objAndStringUnion'}
-                : (MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true)
-                    ? MyClassObjAndStringUnionAlternative1::fromInput($input->{'objAndStringUnion'}, $validate)
-                    : null
-                )
+            ? ((MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true))
+                ? MyClassObjAndStringUnionAlternative1::fromInput($input->{'objAndStringUnion'}, $validate)
+                : ((is_string($input->{'objAndStringUnion'})) ? $input->{'objAndStringUnion'} : null)
             )
             : null;
         $unionOfOneObj = isset($input->{'unionOfOneObj'})
@@ -636,43 +633,37 @@ class MyClass
     public function __clone()
     {
         if (isset($this->objectsUnion)) {
-            $this->objectsUnion = ($this->objectsUnion instanceof MyClassObjectsUnionAlternative2
+            $this->objectsUnion = (($this->objectsUnion instanceof MyClassObjectsUnionAlternative1
+                || $this->objectsUnion instanceof MyClassObjectsUnionAlternative2
+            )
                 ? clone $this->objectsUnion
-                : ($this->objectsUnion instanceof MyClassObjectsUnionAlternative1
-                    ? clone $this->objectsUnion
-                    : $this->objectsUnion
-                )
+                : $this->objectsUnion
             );
         }
         if (isset($this->refObjectsUnion)) {
-            $this->refObjectsUnion = ($this->refObjectsUnion instanceof SomeObj2
+            $this->refObjectsUnion = (($this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2)
                 ? $this->refObjectsUnion
-                : ($this->refObjectsUnion instanceof SomeObj1
-                    ? $this->refObjectsUnion
-                    : $this->refObjectsUnion
-                )
+                : $this->refObjectsUnion
             );
         }
         if (isset($this->refAndNotRefObjectsUnion)) {
-            $this->refAndNotRefObjectsUnion = ($this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4
-                ? clone $this->refAndNotRefObjectsUnion
-                : ($this->refAndNotRefObjectsUnion instanceof SomeObj2
-                    ? $this->refAndNotRefObjectsUnion
-                    : ($this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
-                        ? clone $this->refAndNotRefObjectsUnion
-                        : ($this->refAndNotRefObjectsUnion instanceof SomeObj1
-                            ? $this->refAndNotRefObjectsUnion
-                            : $this->refAndNotRefObjectsUnion
-                        )
-                    )
+            $this->refAndNotRefObjectsUnion = (($this->refAndNotRefObjectsUnion instanceof SomeObj1
+                || $this->refAndNotRefObjectsUnion instanceof SomeObj2
+            )
+                ? $this->refAndNotRefObjectsUnion
+                : (($this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
+                    || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4
+                )
+                    ? clone $this->refAndNotRefObjectsUnion
+                    : $this->refAndNotRefObjectsUnion
                 )
             );
         }
         if (isset($this->objAndStringUnion)) {
-            $this->objAndStringUnion = (is_string($this->objAndStringUnion)
-                ? $this->objAndStringUnion
-                : ($this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1
-                    ? clone $this->objAndStringUnion
+            $this->objAndStringUnion = (($this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1)
+                ? clone $this->objAndStringUnion
+                : ((is_string($this->objAndStringUnion))
+                    ? $this->objAndStringUnion
                     : $this->objAndStringUnion
                 )
             );

--- a/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
@@ -441,22 +441,23 @@ class MyClass
 
         if (isset($this->objectsUnion)) {
             $output['objectsUnion'] = match (true) {
-                $this->objectsUnion instanceof MyClassObjectsUnionAlternative1,
-                $this->objectsUnion instanceof MyClassObjectsUnionAlternative2 => $this->objectsUnion->toArray(),
+                $this->objectsUnion instanceof MyClassObjectsUnionAlternative1
+                    || $this->objectsUnion instanceof MyClassObjectsUnionAlternative2 =>
+                    $this->objectsUnion->toArray(),
             };
         }
         if (isset($this->refObjectsUnion)) {
             $output['refObjectsUnion'] = match (true) {
-                $this->refObjectsUnion instanceof SomeObj1,
-                $this->refObjectsUnion instanceof SomeObj2 => $this->refObjectsUnion->toArray(),
+                $this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2 =>
+                    $this->refObjectsUnion->toArray(),
             };
         }
         if (isset($this->refAndNotRefObjectsUnion)) {
             $output['refAndNotRefObjectsUnion'] = match (true) {
-                $this->refAndNotRefObjectsUnion instanceof SomeObj1,
-                $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2,
-                $this->refAndNotRefObjectsUnion instanceof SomeObj2,
-                $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4 =>
+                $this->refAndNotRefObjectsUnion instanceof SomeObj1
+                    || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
+                    || $this->refAndNotRefObjectsUnion instanceof SomeObj2
+                    || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4 =>
                     $this->refAndNotRefObjectsUnion->toArray(),
             };
         }
@@ -487,22 +488,23 @@ class MyClass
 
         if (isset($this->objectsUnion)) {
             $output->{'objectsUnion'} = match (true) {
-                $this->objectsUnion instanceof MyClassObjectsUnionAlternative1,
-                $this->objectsUnion instanceof MyClassObjectsUnionAlternative2 => $this->objectsUnion->toStdClass(),
+                $this->objectsUnion instanceof MyClassObjectsUnionAlternative1
+                    || $this->objectsUnion instanceof MyClassObjectsUnionAlternative2 =>
+                    $this->objectsUnion->toStdClass(),
             };
         }
         if (isset($this->refObjectsUnion)) {
             $output->{'refObjectsUnion'} = match (true) {
-                $this->refObjectsUnion instanceof SomeObj1,
-                $this->refObjectsUnion instanceof SomeObj2 => $this->refObjectsUnion->toStdClass(),
+                $this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2 =>
+                    $this->refObjectsUnion->toStdClass(),
             };
         }
         if (isset($this->refAndNotRefObjectsUnion)) {
             $output->{'refAndNotRefObjectsUnion'} = match (true) {
-                $this->refAndNotRefObjectsUnion instanceof SomeObj1,
-                $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2,
-                $this->refAndNotRefObjectsUnion instanceof SomeObj2,
-                $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4 =>
+                $this->refAndNotRefObjectsUnion instanceof SomeObj1
+                    || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
+                    || $this->refAndNotRefObjectsUnion instanceof SomeObj2
+                    || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4 =>
                     $this->refAndNotRefObjectsUnion->toStdClass(),
             };
         }
@@ -563,22 +565,23 @@ class MyClass
     {
         if (isset($this->objectsUnion)) {
             $this->objectsUnion = match (true) {
-                $this->objectsUnion instanceof MyClassObjectsUnionAlternative1,
-                $this->objectsUnion instanceof MyClassObjectsUnionAlternative2 => clone $this->objectsUnion,
+                $this->objectsUnion instanceof MyClassObjectsUnionAlternative1
+                    || $this->objectsUnion instanceof MyClassObjectsUnionAlternative2 =>
+                    clone $this->objectsUnion,
             };
         }
         if (isset($this->refObjectsUnion)) {
             $this->refObjectsUnion = match (true) {
-                $this->refObjectsUnion instanceof SomeObj1,
-                $this->refObjectsUnion instanceof SomeObj2 => $this->refObjectsUnion,
+                $this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2 => $this->refObjectsUnion,
             };
         }
         if (isset($this->refAndNotRefObjectsUnion)) {
             $this->refAndNotRefObjectsUnion = match (true) {
-                $this->refAndNotRefObjectsUnion instanceof SomeObj1,
-                $this->refAndNotRefObjectsUnion instanceof SomeObj2 => $this->refAndNotRefObjectsUnion,
-                $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2,
-                $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4 =>
+                $this->refAndNotRefObjectsUnion instanceof SomeObj1
+                    || $this->refAndNotRefObjectsUnion instanceof SomeObj2 =>
+                    $this->refAndNotRefObjectsUnion,
+                $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
+                    || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4 =>
                     clone $this->refAndNotRefObjectsUnion,
             };
         }

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -222,16 +222,14 @@ class Cat
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
             $output['hasFur'] = ($this->hasFur !== null
                 ? match (true) {
-                    default => null,
                     ($this->hasFur === null || is_bool($this->hasFur)) => ($this->hasFur !== null ? $this->hasFur : null),
                     ($this->hasFur === null
                         || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
                     ) =>
                         ($this->hasFur !== null
                             ? match (true) {
+                                is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
                                 default => null,
-                                is_string($this->hasFur),
-                                (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
                             }
                             : null
                         ),
@@ -240,11 +238,13 @@ class Cat
                         || is_bool($this->hasFur)
                     ) =>
                         match (true) {
+                            is_string($this->hasFur)
+                                || (is_int($this->hasFur) || is_float($this->hasFur))
+                                || is_bool($this->hasFur) =>
+                                $this->hasFur,
                             default => null,
-                            is_string($this->hasFur),
-                            (is_int($this->hasFur) || is_float($this->hasFur)),
-                            is_bool($this->hasFur) => $this->hasFur,
                         },
+                    default => null,
                 }
                 : null
             );
@@ -265,16 +265,14 @@ class Cat
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
             $output->{'hasFur'} = ($this->hasFur !== null
                 ? match (true) {
-                    default => null,
                     ($this->hasFur === null || is_bool($this->hasFur)) => ($this->hasFur !== null ? $this->hasFur : null),
                     ($this->hasFur === null
                         || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
                     ) =>
                         ($this->hasFur !== null
                             ? match (true) {
+                                is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
                                 default => null,
-                                is_string($this->hasFur),
-                                (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
                             }
                             : null
                         ),
@@ -283,11 +281,13 @@ class Cat
                         || is_bool($this->hasFur)
                     ) =>
                         match (true) {
+                            is_string($this->hasFur)
+                                || (is_int($this->hasFur) || is_float($this->hasFur))
+                                || is_bool($this->hasFur) =>
+                                $this->hasFur,
                             default => null,
-                            is_string($this->hasFur),
-                            (is_int($this->hasFur) || is_float($this->hasFur)),
-                            is_bool($this->hasFur) => $this->hasFur,
                         },
+                    default => null,
                 }
                 : null
             );
@@ -337,19 +337,20 @@ class Cat
     {
         if (isset($this->hasFur)) {
             $this->hasFur = match (true) {
-                ($this->hasFur === null || is_bool($this->hasFur)),
-                ($this->hasFur === null
-                    || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                ) =>
+                ($this->hasFur === null || is_bool($this->hasFur))
+                    || ($this->hasFur === null
+                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
+                    ) =>
                     (isset($this->hasFur) ? clone $this->hasFur : null),
                 (is_string($this->hasFur)
                     || (is_int($this->hasFur) || is_float($this->hasFur))
                     || is_bool($this->hasFur)
                 ) =>
                     match (true) {
-                        is_string($this->hasFur),
-                        (is_int($this->hasFur) || is_float($this->hasFur)),
-                        is_bool($this->hasFur) => $this->hasFur,
+                        is_string($this->hasFur)
+                            || (is_int($this->hasFur) || is_float($this->hasFur))
+                            || is_bool($this->hasFur) =>
+                            $this->hasFur,
                     },
             };
         }

--- a/tests/Generator/Property/UnionPropertyTest.php
+++ b/tests/Generator/Property/UnionPropertyTest.php
@@ -73,8 +73,9 @@ EOCODE;
 
         $expected = <<<'EOCODE'
 $output['myPropertyName'] = match (true) {
-    $this->myPropertyName instanceof FooMyPropertyNameAlternative1,
-    $this->myPropertyName instanceof FooMyPropertyNameAlternative2 => $this->myPropertyName->toArray(),
+    $this->myPropertyName instanceof FooMyPropertyNameAlternative1
+        || $this->myPropertyName instanceof FooMyPropertyNameAlternative2 =>
+        $this->myPropertyName->toArray(),
 };
 EOCODE;
 
@@ -89,8 +90,9 @@ EOCODE;
 
         $expected = <<<'EOCODE'
 $output->{'myPropertyName'} = match (true) {
-    $this->myPropertyName instanceof FooMyPropertyNameAlternative1,
-    $this->myPropertyName instanceof FooMyPropertyNameAlternative2 => $this->myPropertyName->toStdClass(),
+    $this->myPropertyName instanceof FooMyPropertyNameAlternative1
+        || $this->myPropertyName instanceof FooMyPropertyNameAlternative2 =>
+        $this->myPropertyName->toStdClass(),
 };
 EOCODE;
 
@@ -101,8 +103,9 @@ EOCODE;
     {
         $expected = <<<'EOCODE'
 $this->myPropertyName = match (true) {
-    $this->myPropertyName instanceof FooMyPropertyNameAlternative1,
-    $this->myPropertyName instanceof FooMyPropertyNameAlternative2 => clone $this->myPropertyName,
+    $this->myPropertyName instanceof FooMyPropertyNameAlternative1
+        || $this->myPropertyName instanceof FooMyPropertyNameAlternative2 =>
+        clone $this->myPropertyName,
 };
 EOCODE;
         assertSame($expected, $this->property->cloneAssignment());


### PR DESCRIPTION
## Summary
- collapse duplicate union branch checks by grouping discriminators
- avoid redundant `is_array` guards when union arms already ensure arrays
- regenerate all snapshots and adjust tests

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_689fb369be0c832d8cc2764b197935db