### PR TITLE
Deduplicate union type checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Now it:
 - Handles URL-encoded references
 - Handles definition descriptions and/or top-level schema description and adds it to a class' PHPDoc
 - Generates a `toStdClass()` method returning an object representation of the instance
+- Deduplicates repeated type checks in generated unions
 
 ### Better support for older PHP versions:
 

--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -59,6 +59,97 @@ class UnionProperty extends AbstractProperty
         return isset($schema["oneOf"]) || isset($schema["anyOf"]);
     }
 
+    /**
+     * Deduplicates OR conditions across mapping arms.
+     *
+     * @param array<string, array<int, string>> $arms
+     * @return array<string, array<int, string>>
+     */
+    private static function dedupeArms(array $arms): array
+    {
+        $used    = [];
+        $deduped = [];
+
+        foreach ($arms as $map => $asserts) {
+            $conditions = [];
+            foreach ($asserts as $assert) {
+                foreach (self::splitOr($assert) as $part) {
+                    if ($part === '' || isset($used[$part])) {
+                        continue;
+                    }
+                    $used[$part] = true;
+                    $conditions[] = $part;
+                }
+            }
+
+            if ($conditions !== []) {
+                $deduped[$map] = $conditions;
+            }
+        }
+
+        return $deduped;
+    }
+
+    /**
+     * Split an expression by top-level OR operators.
+     *
+     * @return array<int,string>
+     */
+    private static function splitOr(string $expr): array
+    {
+        $parts = [];
+        $buf   = '';
+        $depth = 0;
+        $len   = strlen($expr);
+
+        for ($i = 0; $i < $len; $i++) {
+            $ch = $expr[$i];
+            if ($ch === '(') {
+                $depth++;
+            } elseif ($ch === ')') {
+                if ($depth > 0) {
+                    $depth--;
+                }
+            }
+
+            if ($depth === 0 && $ch === '|' && $i + 1 < $len && $expr[$i + 1] === '|') {
+                $parts[] = trim($buf);
+                $buf = '';
+                $i++; // Skip next '|'
+                continue;
+            }
+
+            $buf .= $ch;
+        }
+
+        if (trim($buf) !== '') {
+            $parts[] = trim($buf);
+        }
+
+        return $parts;
+    }
+
+    /**
+     * @param array<string, array{discriminators: array<int, string>, fallback?: bool}> $conversions
+     * @return array<string, array{discriminators: array<int, string>, fallback?: bool}>
+     */
+    private static function dedupeConversions(array $conversions): array
+    {
+        $arms = [];
+        foreach ($conversions as $assignment => $info) {
+            $arms[$assignment] = $info['discriminators'];
+        }
+
+        $dedupedArms = self::dedupeArms($arms);
+
+        foreach ($conversions as $assignment => &$info) {
+            $info['discriminators'] = $dedupedArms[$assignment] ?? [];
+        }
+        unset($info);
+
+        return $conversions;
+    }
+
     public function convertInputToTypeMatch(): string
     {
         $inputVarName = ArgumentNames::INPUT;
@@ -82,9 +173,10 @@ class UnionProperty extends AbstractProperty
             $arms[$mapping][] = $discriminator;
         }
 
+        $arms = self::dedupeArms($arms);
+
         $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
+        foreach ($arms as $mapping => $conditions) {
             $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
         }
 
@@ -138,7 +230,9 @@ class UnionProperty extends AbstractProperty
             }
             $conversions[$assignment]["discriminators"][] = $discriminator;
         }
-    
+
+        $conversions = self::dedupeConversions($conversions);
+
         // Turn those into an if/elseif/else chain
         $branches = [];
         $fallback = null;
@@ -152,8 +246,7 @@ class UnionProperty extends AbstractProperty
             }
 
             $keyword = count($branches) ? "elseif" : "if";
-            $conditions = array_values(array_unique($info["discriminators"]));
-            $parenthesizedCondition = OrGenerator::make($conditions);
+            $parenthesizedCondition = OrGenerator::make($info["discriminators"]);
 
             $branches[] = 
                 <<<PHP
@@ -193,9 +286,10 @@ class UnionProperty extends AbstractProperty
             $arms[$mapping][] = $discriminator;
         }
 
+        $arms = self::dedupeArms($arms);
+
         $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
+        foreach ($arms as $mapping => $conditions) {
             $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
         }
         $outputVarName = VariableNames::OUTPUT;
@@ -214,9 +308,10 @@ class UnionProperty extends AbstractProperty
             $arms[$mapping][] = $discriminator;
         }
 
+        $arms = self::dedupeArms($arms);
+
         $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
+        foreach ($arms as $mapping => $conditions) {
             $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
         }
 
@@ -247,12 +342,13 @@ class UnionProperty extends AbstractProperty
             $conversions[$assignment]["discriminators"][] = $discriminator;
         }
 
+        $conversions = self::dedupeConversions($conversions);
+
         $indent = StringUtils::indentCode(...);
 
         $branches = [];
         foreach ($conversions as $assignment => $conversion) {
-            $conditions = array_values(array_unique($conversion["discriminators"]));
-            $parenthesizedCondition = OrGenerator::make($conditions);
+            $parenthesizedCondition = OrGenerator::make($conversion["discriminators"]);
             $keyword = count($branches) ? "elseif" : "if";
             $branches[] =
                 <<<PHP
@@ -288,12 +384,13 @@ class UnionProperty extends AbstractProperty
             $conversions[$assignment]["discriminators"][] = $discriminator;
         }
 
+        $conversions = self::dedupeConversions($conversions);
+
         $indent = StringUtils::indentCode(...);
 
         $branches = [];
         foreach ($conversions as $assignment => $conversion) {
-            $conditions = array_values(array_unique($conversion["discriminators"]));
-            $parenthesizedCondition = OrGenerator::make($conditions);
+            $parenthesizedCondition = OrGenerator::make($conversion["discriminators"]);
             $keyword = count($branches) ? "elseif" : "if";
             $branches[] =
                 <<<PHP
@@ -434,9 +531,10 @@ class UnionProperty extends AbstractProperty
                 $arms[$map][] = $assert;
             }
 
+            $arms = self::dedupeArms($arms);
+
             $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
+            foreach ($arms as $map => $conditions) {
                 $match->addArm(OrGenerator::make($conditions, parens: false), $map);
             }
             $match->addArm("default", "null");
@@ -451,9 +549,10 @@ class UnionProperty extends AbstractProperty
             $conversions[$map][] = $assert;
         }
 
+        $conversions = self::dedupeArms($conversions);
+
         $out = "null";
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
+        foreach (array_reverse($conversions) as $map => $conditions) {
             $cond = OrGenerator::make($conditions);
             $out = TernaryGenerator::make($cond, $map, $out);
         }
@@ -471,9 +570,10 @@ class UnionProperty extends AbstractProperty
                 $arms[$map][] = $assert;
             }
 
+            $arms = self::dedupeArms($arms);
+
             $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
+            foreach ($arms as $map => $conditions) {
                 $match->addArm(OrGenerator::make($conditions, parens: false), $map);
             }
             $match->addArm("default", "null");
@@ -488,9 +588,10 @@ class UnionProperty extends AbstractProperty
             $conversions[$map][] = $assert;
         }
 
+        $conversions = self::dedupeArms($conversions);
+
         $out = "null";
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
+        foreach (array_reverse($conversions) as $map => $conditions) {
             $cond = OrGenerator::make($conditions);
             $out = TernaryGenerator::make($cond, $map, $out);
         }
@@ -508,9 +609,10 @@ class UnionProperty extends AbstractProperty
                 $arms[$map][] = $assert;
             }
 
+            $arms = self::dedupeArms($arms);
+
             $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
+            foreach ($arms as $map => $conditions) {
                 $match->addArm(OrGenerator::make($conditions, parens: false), $map);
             }
             $match->addArm("default", "null");
@@ -525,9 +627,10 @@ class UnionProperty extends AbstractProperty
             $conversions[$map][] = $assert;
         }
 
+        $conversions = self::dedupeArms($conversions);
+
         $out = "null";
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
+        foreach (array_reverse($conversions) as $map => $conditions) {
             $cond = OrGenerator::make($conditions);
             $out = TernaryGenerator::make($cond, $map, $out);
         }
@@ -545,9 +648,10 @@ class UnionProperty extends AbstractProperty
                 $arms[$map][] = $assert;
             }
 
+            $arms = self::dedupeArms($arms);
+
             $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
+            foreach ($arms as $map => $conditions) {
                 $match->addArm(OrGenerator::make($conditions, parens: false), $map);
             }
 
@@ -561,9 +665,10 @@ class UnionProperty extends AbstractProperty
             $conversions[$map][] = $assert;
         }
 
+        $conversions = self::dedupeArms($conversions);
+
         $out = $expr;
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
+        foreach (array_reverse($conversions) as $map => $conditions) {
             $cond = OrGenerator::make($conditions);
             $out = TernaryGenerator::make($cond, $map, $out);
         }

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -492,10 +492,7 @@ class MyClass
         $i = null;
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
-                ? ((is_array($input->{'i'})
-                    || is_string($input->{'i'})
-                    || is_array($input->{'i'}) || is_object($input->{'i'})
-                )
+                ? ((is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}))
                     ? $input->{'i'}
                     : null
                 )
@@ -553,10 +550,7 @@ class MyClass
             $output['i'] = ($this->i !== null
                 ? ((is_array($this->i) || is_string($this->i))
                     ? $this->i
-                    : ((is_array($this->i) || is_object($this->i))
-                        ? json_decode(json_encode($this->i), true)
-                        : null
-                    )
+                    : ((is_object($this->i)) ? json_decode(json_encode($this->i), true) : null)
                 )
                 : null
             );
@@ -603,10 +597,7 @@ class MyClass
             $output->{'i'} = ($this->i !== null
                 ? ((is_array($this->i) || is_string($this->i))
                     ? $this->i
-                    : ((is_array($this->i) || is_object($this->i))
-                        ? json_decode(json_encode($this->i))
-                        : null
-                    )
+                    : ((is_object($this->i)) ? json_decode(json_encode($this->i)) : null)
                 )
                 : null
             );
@@ -663,7 +654,7 @@ class MyClass
             $this->h = ((is_array($this->h) || is_string($this->h)) ? $this->h : $this->h);
         }
         if (isset($this->i)) {
-            $this->i = ((is_array($this->i) || is_string($this->i) || is_array($this->i) || is_object($this->i))
+            $this->i = ((is_array($this->i) || is_string($this->i) || is_object($this->i))
                 ? $this->i
                 : $this->i
             );

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -406,10 +406,7 @@ class MyClass
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
                 ? match (true) {
-                    is_array($input->{'i'})
-                        || is_string($input->{'i'})
-                        || is_array($input->{'i'}) || is_object($input->{'i'}) =>
-                        $input->{'i'},
+                    is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}) => $input->{'i'},
                     default => null,
                 }
                 : null
@@ -469,7 +466,7 @@ class MyClass
             $output['i'] = ($this->i !== null
                 ? match (true) {
                     is_array($this->i) || is_string($this->i) => $this->i,
-                    is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), true),
+                    is_object($this->i) => json_decode(json_encode($this->i), true),
                     default => null,
                 }
                 : null
@@ -520,7 +517,7 @@ class MyClass
             $output->{'i'} = ($this->i !== null
                 ? match (true) {
                     is_array($this->i) || is_string($this->i) => $this->i,
-                    is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i)),
+                    is_object($this->i) => json_decode(json_encode($this->i)),
                     default => null,
                 }
                 : null
@@ -587,7 +584,7 @@ class MyClass
         }
         if (isset($this->i)) {
             $this->i = match (true) {
-                is_array($this->i) || is_string($this->i) || is_array($this->i) || is_object($this->i) => $this->i,
+                is_array($this->i) || is_string($this->i) || is_object($this->i) => $this->i,
             };
         }
     }

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -835,17 +835,13 @@ class MyClass
             : null;
         $arrObjUnion = isset($input->{'arrObjUnion'})
             ? match (true) {
-                is_array($input->{'arrObjUnion'})
-                    || is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) =>
-                    $input->{'arrObjUnion'},
+                is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) => $input->{'arrObjUnion'},
                 default => null,
             }
             : null;
         $objArrUnion = isset($input->{'objArrUnion'})
             ? match (true) {
-                is_array($input->{'objArrUnion'})
-                    || is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) =>
-                    $input->{'objArrUnion'},
+                is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) => $input->{'objArrUnion'},
                 default => null,
             }
             : null;
@@ -929,13 +925,13 @@ class MyClass
         if (isset($this->arrObjUnion)) {
             $output['arrObjUnion'] = match (true) {
                 is_array($this->arrObjUnion) => $this->arrObjUnion,
-                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion), true),
+                is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion), true),
             };
         }
         if (isset($this->objArrUnion)) {
             $output['objArrUnion'] = match (true) {
                 is_array($this->objArrUnion) => $this->objArrUnion,
-                is_array($this->objArrUnion) || is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion), true),
+                is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion), true),
             };
         }
         if (isset($this->numKeysDefaults)) {
@@ -1004,13 +1000,13 @@ class MyClass
         if (isset($this->arrObjUnion)) {
             $output->{'arrObjUnion'} = match (true) {
                 is_array($this->arrObjUnion) => $this->arrObjUnion,
-                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion)),
+                is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion)),
             };
         }
         if (isset($this->objArrUnion)) {
             $output->{'objArrUnion'} = match (true) {
                 is_array($this->objArrUnion) => $this->objArrUnion,
-                is_array($this->objArrUnion) || is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion)),
+                is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion)),
             };
         }
         if (isset($this->numKeysDefaults)) {
@@ -1104,12 +1100,12 @@ class MyClass
         }
         if (isset($this->arrObjUnion)) {
             $this->arrObjUnion = match (true) {
-                is_array($this->arrObjUnion) || is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => $this->arrObjUnion,
+                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => $this->arrObjUnion,
             };
         }
         if (isset($this->objArrUnion)) {
             $this->objArrUnion = match (true) {
-                is_array($this->objArrUnion) || is_array($this->objArrUnion) || is_object($this->objArrUnion) => $this->objArrUnion,
+                is_array($this->objArrUnion) || is_object($this->objArrUnion) => $this->objArrUnion,
             };
         }
         if (isset($this->numKeysDefaults)) {

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -417,7 +417,8 @@ class MyClass
             is_string($input->{'baz'})
                 || (is_int($input->{'baz'}) || is_float($input->{'baz'}))
                 || is_bool($input->{'baz'})
-                || is_array($input->{'baz'}) || is_object($input->{'baz'}) =>
+                || is_array($input->{'baz'})
+                || is_object($input->{'baz'}) =>
                 $input->{'baz'},
             default => throw new \InvalidArgumentException("could not build property 'baz' from JSON"),
         };
@@ -426,16 +427,13 @@ class MyClass
                 || (is_int($input->{'qux'}) || is_float($input->{'qux'}))
                 || is_bool($input->{'qux'})
                 || is_array($input->{'qux'})
-                || is_array($input->{'qux'}) || is_object($input->{'qux'}) =>
+                || is_object($input->{'qux'}) =>
                 $input->{'qux'},
             default => throw new \InvalidArgumentException("could not build property 'qux' from JSON"),
         };
         $thud = ($input->{'thud'} !== null
             ? match (true) {
-                is_string($input->{'thud'})
-                    || is_array($input->{'thud'})
-                    || is_array($input->{'thud'}) || is_object($input->{'thud'}) =>
-                    $input->{'thud'},
+                is_string($input->{'thud'}) || is_array($input->{'thud'}) || is_object($input->{'thud'}) => $input->{'thud'},
                 (is_int($input->{'thud'}) || is_float($input->{'thud'})) =>
                     (str_contains((string)$input->{'thud'}, '.')
                         ? (float)$input->{'thud'}
@@ -484,10 +482,7 @@ class MyClass
             : null;
         $optQux = isset($input->{'optQux'})
             ? match (true) {
-                is_string($input->{'optQux'})
-                    || is_array($input->{'optQux'})
-                    || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) =>
-                    $input->{'optQux'},
+                is_string($input->{'optQux'}) || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) => $input->{'optQux'},
                 (is_int($input->{'optQux'}) || is_float($input->{'optQux'})) =>
                     (str_contains((string)$input->{'optQux'}, '.')
                         ? (float)$input->{'optQux'}
@@ -501,10 +496,7 @@ class MyClass
         if (property_exists($input, 'optThud')) {
             $optThud = ($input->{'optThud'} !== null
                 ? match (true) {
-                    is_string($input->{'optThud'})
-                        || is_array($input->{'optThud'})
-                        || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) =>
-                        $input->{'optThud'},
+                    is_string($input->{'optThud'}) || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) => $input->{'optThud'},
                     (is_int($input->{'optThud'}) || is_float($input->{'optThud'})) =>
                         (str_contains((string)$input->{'optThud'}, '.')
                             ? (float)$input->{'optThud'}
@@ -569,7 +561,7 @@ class MyClass
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
                 $this->qux,
-            is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux), true),
+            is_object($this->qux) => json_decode(json_encode($this->qux), true),
         };
         $output['thud'] = match (true) {
             is_string($this->thud)
@@ -577,7 +569,7 @@ class MyClass
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
                 $this->thud,
-            is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud), true),
+            is_object($this->thud) => json_decode(json_encode($this->thud), true),
         };
         if (isset($this->optFoo)) {
             $output['optFoo'] = match (true) {
@@ -612,7 +604,7 @@ class MyClass
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
                     $this->optQux,
-                is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux), true),
+                is_object($this->optQux) => json_decode(json_encode($this->optQux), true),
             };
         }
         if (isset($this->optThud) || array_key_exists('optThud', $this->_providedOptionals)) {
@@ -623,7 +615,7 @@ class MyClass
                         || is_bool($this->optThud)
                         || is_array($this->optThud) =>
                         $this->optThud,
-                    is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud), true),
+                    is_object($this->optThud) => json_decode(json_encode($this->optThud), true),
                     default => null,
                 }
                 : null
@@ -662,7 +654,7 @@ class MyClass
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
                 $this->qux,
-            is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux)),
+            is_object($this->qux) => json_decode(json_encode($this->qux)),
         };
         $output->{'thud'} = match (true) {
             is_string($this->thud)
@@ -670,7 +662,7 @@ class MyClass
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
                 $this->thud,
-            is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud)),
+            is_object($this->thud) => json_decode(json_encode($this->thud)),
         };
         if (isset($this->optFoo)) {
             $output->{'optFoo'} = match (true) {
@@ -705,7 +697,7 @@ class MyClass
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
                     $this->optQux,
-                is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux)),
+                is_object($this->optQux) => json_decode(json_encode($this->optQux)),
             };
         }
         if (isset($this->optThud) || array_key_exists('optThud', $this->_providedOptionals)) {
@@ -716,7 +708,7 @@ class MyClass
                         || is_bool($this->optThud)
                         || is_array($this->optThud) =>
                         $this->optThud,
-                    is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud)),
+                    is_object($this->optThud) => json_decode(json_encode($this->optThud)),
                     default => null,
                 }
                 : null
@@ -779,7 +771,8 @@ class MyClass
             is_string($this->baz)
                 || (is_int($this->baz) || is_float($this->baz))
                 || is_bool($this->baz)
-                || is_array($this->baz) || is_object($this->baz) =>
+                || is_array($this->baz)
+                || is_object($this->baz) =>
                 $this->baz,
         };
         $this->qux = match (true) {
@@ -787,7 +780,7 @@ class MyClass
                 || (is_int($this->qux) || is_float($this->qux))
                 || is_bool($this->qux)
                 || is_array($this->qux)
-                || is_array($this->qux) || is_object($this->qux) =>
+                || is_object($this->qux) =>
                 $this->qux,
         };
         $this->thud = match (true) {
@@ -795,7 +788,7 @@ class MyClass
                 || (is_int($this->thud) || is_float($this->thud))
                 || is_bool($this->thud)
                 || is_array($this->thud)
-                || is_array($this->thud) || is_object($this->thud) =>
+                || is_object($this->thud) =>
                 $this->thud,
         };
         if (isset($this->optFoo)) {
@@ -820,7 +813,8 @@ class MyClass
                 is_string($this->optBaz)
                     || (is_int($this->optBaz) || is_float($this->optBaz))
                     || is_bool($this->optBaz)
-                    || is_array($this->optBaz) || is_object($this->optBaz) =>
+                    || is_array($this->optBaz)
+                    || is_object($this->optBaz) =>
                     $this->optBaz,
             };
         }
@@ -830,7 +824,7 @@ class MyClass
                     || (is_int($this->optQux) || is_float($this->optQux))
                     || is_bool($this->optQux)
                     || is_array($this->optQux)
-                    || is_array($this->optQux) || is_object($this->optQux) =>
+                    || is_object($this->optQux) =>
                     $this->optQux,
             };
         }
@@ -840,7 +834,7 @@ class MyClass
                     || (is_int($this->optThud) || is_float($this->optThud))
                     || is_bool($this->optThud)
                     || is_array($this->optThud)
-                    || is_array($this->optThud) || is_object($this->optThud) =>
+                    || is_object($this->optThud) =>
                     $this->optThud,
             };
         }


### PR DESCRIPTION
## Summary
- avoid duplicated OR checks when generating union properties
- regenerate affected fixtures
- document deduplication improvement in CHANGELOG

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` (3 expected `match.unhandled` warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a041c9172c832daff377cae90fbea8