### PR TITLE
Deduplicate union property type checks

### DIFF
--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -37,6 +37,64 @@ class UnionProperty extends AbstractProperty
     /** @var PropertyInterface[] */
     private array $subProperties;
 
+    /**
+     * Split an OR expression into individual conditions, removing surrounding
+     * parentheses from each part. Handles nested parentheses so we only split
+     * on top-level `||` operators.
+     *
+     * @return array<int,string>
+     */
+    private static function splitConditions(string $expr): array
+    {
+        $parts = [];
+        $buf   = '';
+        $depth = 0;
+        $len   = strlen($expr);
+
+        for ($i = 0; $i < $len; $i++) {
+            $ch = $expr[$i];
+            if ($ch === '(') {
+                $depth++;
+            } elseif ($ch === ')') {
+                $depth--;
+            } elseif ($ch === '|' && $depth === 0 && $i + 1 < $len && $expr[$i + 1] === '|') {
+                $parts[] = $buf;
+                $buf = '';
+                $i++; // skip second |
+                continue;
+            }
+            $buf .= $ch;
+        }
+
+        if (trim($buf) !== '') {
+            $parts[] = $buf;
+        }
+
+        $parts = array_filter(array_map('trim', $parts), static fn(string $p): bool => $p !== '');
+
+        return array_map(
+            static function (string $p): string {
+                if ($p[0] === '(' && substr($p, -1) === ')') {
+                    $p = trim(substr($p, 1, -1));
+                }
+                return $p;
+            },
+            $parts
+        );
+    }
+
+    /**
+     * Add assertion conditions from an expression to the given set.
+     *
+     * @param array<string,bool> $target
+     */
+    private static function addConditions(array &$target, string $expr): void
+    {
+        foreach (self::splitConditions($expr) as $cond) {
+            $target[$cond] = true;
+        }
+    }
+
     public function __construct(string $key, array $schema, GeneratorRequest $generatorRequest)
     {
         if (isset($schema["anyOf"])) {
@@ -79,13 +137,15 @@ class UnionProperty extends AbstractProperty
                 }
             }
 
-            $arms[$mapping][] = $discriminator;
+            if (!isset($arms[$mapping])) {
+                $arms[$mapping] = [];
+            }
+            self::addConditions($arms[$mapping], $discriminator);
         }
 
         $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
-            $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
+        foreach ($arms as $mapping => $conditions) {
+            $match->addArm(OrGenerator::make(array_keys($conditions), parens: false), $mapping);
         }
 
         $match->addArm(
@@ -136,7 +196,7 @@ class UnionProperty extends AbstractProperty
             if (! isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => [], "fallback" => false];
             }
-            $conversions[$assignment]["discriminators"][] = $discriminator;
+            self::addConditions($conversions[$assignment]["discriminators"], $discriminator);
         }
     
         // Turn those into an if/elseif/else chain
@@ -152,8 +212,7 @@ class UnionProperty extends AbstractProperty
             }
 
             $keyword = count($branches) ? "elseif" : "if";
-            $conditions = array_values(array_unique($info["discriminators"]));
-            $parenthesizedCondition = OrGenerator::make($conditions);
+            $parenthesizedCondition = OrGenerator::make(array_keys($info["discriminators"]));
 
             $branches[] = 
                 <<<PHP
@@ -190,13 +249,15 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExpr("\$this->{$name}");
             $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
-            $arms[$mapping][] = $discriminator;
+            if (!isset($arms[$mapping])) {
+                $arms[$mapping] = [];
+            }
+            self::addConditions($arms[$mapping], $discriminator);
         }
 
         $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
-            $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
+        foreach ($arms as $mapping => $conditions) {
+            $match->addArm(OrGenerator::make(array_keys($conditions), parens: false), $mapping);
         }
         $outputVarName = VariableNames::OUTPUT;
         return "\${$outputVarName}[{$keyStr}] = {$match->generate()};";
@@ -211,13 +272,15 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExprStdClass("\$this->{$name}");
             $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
-            $arms[$mapping][] = $discriminator;
+            if (!isset($arms[$mapping])) {
+                $arms[$mapping] = [];
+            }
+            self::addConditions($arms[$mapping], $discriminator);
         }
 
         $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
-            $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
+        foreach ($arms as $mapping => $conditions) {
+            $match->addArm(OrGenerator::make(array_keys($conditions), parens: false), $mapping);
         }
 
         $outputVarName = VariableNames::OUTPUT;
@@ -244,15 +307,14 @@ class UnionProperty extends AbstractProperty
                 $conversions[$assignment] = ["discriminators" => []];
             }
 
-            $conversions[$assignment]["discriminators"][] = $discriminator;
+            self::addConditions($conversions[$assignment]["discriminators"], $discriminator);
         }
 
         $indent = StringUtils::indentCode(...);
 
         $branches = [];
         foreach ($conversions as $assignment => $conversion) {
-            $conditions = array_values(array_unique($conversion["discriminators"]));
-            $parenthesizedCondition = OrGenerator::make($conditions);
+            $parenthesizedCondition = OrGenerator::make(array_keys($conversion["discriminators"]));
             $keyword = count($branches) ? "elseif" : "if";
             $branches[] =
                 <<<PHP
@@ -285,15 +347,14 @@ class UnionProperty extends AbstractProperty
                 $conversions[$assignment] = ["discriminators" => []];
             }
 
-            $conversions[$assignment]["discriminators"][] = $discriminator;
+            self::addConditions($conversions[$assignment]["discriminators"], $discriminator);
         }
 
         $indent = StringUtils::indentCode(...);
 
         $branches = [];
         foreach ($conversions as $assignment => $conversion) {
-            $conditions = array_values(array_unique($conversion["discriminators"]));
-            $parenthesizedCondition = OrGenerator::make($conditions);
+            $parenthesizedCondition = OrGenerator::make(array_keys($conversion["discriminators"]));
             $keyword = count($branches) ? "elseif" : "if";
             $branches[] =
                 <<<PHP
@@ -404,24 +465,24 @@ class UnionProperty extends AbstractProperty
 
     public function typeAssertionExpr(string $expr): string
     {
-        $subAssertions = [];
+        $conditions = [];
 
         foreach ($this->subProperties as $prop) {
-            $subAssertions[] = $prop->typeAssertionExpr($expr);
+            self::addConditions($conditions, $prop->typeAssertionExpr($expr));
         }
 
-        return OrGenerator::make($subAssertions);
+        return OrGenerator::make(array_keys($conditions));
     }
 
     public function inputAssertionExpr(string $expr): string
     {
-        $subAssertions = [];
+        $conditions = [];
 
         foreach ($this->subProperties as $prop) {
-            $subAssertions[] = $prop->inputAssertionExpr($expr);
+            self::addConditions($conditions, $prop->inputAssertionExpr($expr));
         }
 
-        return OrGenerator::make($subAssertions);
+        return OrGenerator::make(array_keys($conditions));
     }
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string
@@ -431,13 +492,15 @@ class UnionProperty extends AbstractProperty
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->inputMappingExpr($expr);
                 $assert = $subProperty->inputAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                if (!isset($arms[$map])) {
+                    $arms[$map] = [];
+                }
+                self::addConditions($arms[$map], $assert);
             }
 
             $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
-                $match->addArm(OrGenerator::make($conditions, parens: false), $map);
+            foreach ($arms as $map => $conditions) {
+                $match->addArm(OrGenerator::make(array_keys($conditions), parens: false), $map);
             }
             $match->addArm("default", "null");
 
@@ -448,13 +511,15 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->inputMappingExpr($expr);
             $assert = $subProperty->inputAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            if (!isset($conversions[$map])) {
+                $conversions[$map] = [];
+            }
+            self::addConditions($conversions[$map], $assert);
         }
 
         $out = "null";
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
-            $cond = OrGenerator::make($conditions);
+        foreach (array_reverse($conversions) as $map => $conditions) {
+            $cond = OrGenerator::make(array_keys($conditions));
             $out = TernaryGenerator::make($cond, $map, $out);
         }
 
@@ -468,13 +533,15 @@ class UnionProperty extends AbstractProperty
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->outputMappingExpr($expr);
                 $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                if (!isset($arms[$map])) {
+                    $arms[$map] = [];
+                }
+                self::addConditions($arms[$map], $assert);
             }
 
             $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
-                $match->addArm(OrGenerator::make($conditions, parens: false), $map);
+            foreach ($arms as $map => $conditions) {
+                $match->addArm(OrGenerator::make(array_keys($conditions), parens: false), $map);
             }
             $match->addArm("default", "null");
 
@@ -485,13 +552,15 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->outputMappingExpr($expr);
             $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            if (!isset($conversions[$map])) {
+                $conversions[$map] = [];
+            }
+            self::addConditions($conversions[$map], $assert);
         }
 
         $out = "null";
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
-            $cond = OrGenerator::make($conditions);
+        foreach (array_reverse($conversions) as $map => $conditions) {
+            $cond = OrGenerator::make(array_keys($conditions));
             $out = TernaryGenerator::make($cond, $map, $out);
         }
 
@@ -505,13 +574,15 @@ class UnionProperty extends AbstractProperty
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->outputMappingExprStdClass($expr);
                 $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                if (!isset($arms[$map])) {
+                    $arms[$map] = [];
+                }
+                self::addConditions($arms[$map], $assert);
             }
 
             $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
-                $match->addArm(OrGenerator::make($conditions, parens: false), $map);
+            foreach ($arms as $map => $conditions) {
+                $match->addArm(OrGenerator::make(array_keys($conditions), parens: false), $map);
             }
             $match->addArm("default", "null");
 
@@ -522,13 +593,15 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->outputMappingExprStdClass($expr);
             $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            if (!isset($conversions[$map])) {
+                $conversions[$map] = [];
+            }
+            self::addConditions($conversions[$map], $assert);
         }
 
         $out = "null";
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
-            $cond = OrGenerator::make($conditions);
+        foreach (array_reverse($conversions) as $map => $conditions) {
+            $cond = OrGenerator::make(array_keys($conditions));
             $out = TernaryGenerator::make($cond, $map, $out);
         }
 
@@ -542,13 +615,15 @@ class UnionProperty extends AbstractProperty
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->cloneExpr($expr);
                 $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                if (!isset($arms[$map])) {
+                    $arms[$map] = [];
+                }
+                self::addConditions($arms[$map], $assert);
             }
 
             $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
-                $match->addArm(OrGenerator::make($conditions, parens: false), $map);
+            foreach ($arms as $map => $conditions) {
+                $match->addArm(OrGenerator::make(array_keys($conditions), parens: false), $map);
             }
 
             return $match->generate();
@@ -558,13 +633,15 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->cloneExpr($expr);
             $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            if (!isset($conversions[$map])) {
+                $conversions[$map] = [];
+            }
+            self::addConditions($conversions[$map], $assert);
         }
 
         $out = $expr;
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
-            $cond = OrGenerator::make($conditions);
+        foreach (array_reverse($conversions) as $map => $conditions) {
+            $cond = OrGenerator::make(array_keys($conditions));
             $out = TernaryGenerator::make($cond, $map, $out);
         }
 

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -492,10 +492,7 @@ class MyClass
         $i = null;
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
-                ? ((is_array($input->{'i'})
-                    || is_string($input->{'i'})
-                    || is_array($input->{'i'}) || is_object($input->{'i'})
-                )
+                ? ((is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}))
                     ? $input->{'i'}
                     : null
                 )
@@ -663,7 +660,7 @@ class MyClass
             $this->h = ((is_array($this->h) || is_string($this->h)) ? $this->h : $this->h);
         }
         if (isset($this->i)) {
-            $this->i = ((is_array($this->i) || is_string($this->i) || is_array($this->i) || is_object($this->i))
+            $this->i = ((is_array($this->i) || is_string($this->i) || is_object($this->i))
                 ? $this->i
                 : $this->i
             );

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -406,10 +406,7 @@ class MyClass
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
                 ? match (true) {
-                    is_array($input->{'i'})
-                        || is_string($input->{'i'})
-                        || is_array($input->{'i'}) || is_object($input->{'i'}) =>
-                        $input->{'i'},
+                    is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}) => $input->{'i'},
                     default => null,
                 }
                 : null
@@ -587,7 +584,7 @@ class MyClass
         }
         if (isset($this->i)) {
             $this->i = match (true) {
-                is_array($this->i) || is_string($this->i) || is_array($this->i) || is_object($this->i) => $this->i,
+                is_array($this->i) || is_string($this->i) || is_object($this->i) => $this->i,
             };
         }
     }

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -438,7 +438,7 @@ class MyClass
         $qwert = isset($input->{'qwert'})
             ? match (true) {
                 is_string($input->{'qwert'}) => $input->{'qwert'},
-                (is_int($input->{'qwert'}) || is_float($input->{'qwert'})) =>
+                is_int($input->{'qwert'}) || is_float($input->{'qwert'}) =>
                     (str_contains((string)$input->{'qwert'}, '.')
                         ? (float)$input->{'qwert'}
                         : (int)$input->{'qwert'}
@@ -489,7 +489,7 @@ class MyClass
         }
         if (isset($this->qwert)) {
             $output['qwert'] = match (true) {
-                is_string($this->qwert) || (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
+                is_string($this->qwert) || is_int($this->qwert) || is_float($this->qwert) => $this->qwert,
             };
         }
         if (isset($this->zyx)) {
@@ -537,7 +537,7 @@ class MyClass
         }
         if (isset($this->qwert)) {
             $output->{'qwert'} = match (true) {
-                is_string($this->qwert) || (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
+                is_string($this->qwert) || is_int($this->qwert) || is_float($this->qwert) => $this->qwert,
             };
         }
         if (isset($this->zyx)) {
@@ -598,7 +598,7 @@ class MyClass
     {
         if (isset($this->qwert)) {
             $this->qwert = match (true) {
-                is_string($this->qwert) || (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
+                is_string($this->qwert) || is_int($this->qwert) || is_float($this->qwert) => $this->qwert,
             };
         }
     }

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -835,17 +835,13 @@ class MyClass
             : null;
         $arrObjUnion = isset($input->{'arrObjUnion'})
             ? match (true) {
-                is_array($input->{'arrObjUnion'})
-                    || is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) =>
-                    $input->{'arrObjUnion'},
+                is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) => $input->{'arrObjUnion'},
                 default => null,
             }
             : null;
         $objArrUnion = isset($input->{'objArrUnion'})
             ? match (true) {
-                is_array($input->{'objArrUnion'})
-                    || is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) =>
-                    $input->{'objArrUnion'},
+                is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) => $input->{'objArrUnion'},
                 default => null,
             }
             : null;
@@ -1104,12 +1100,12 @@ class MyClass
         }
         if (isset($this->arrObjUnion)) {
             $this->arrObjUnion = match (true) {
-                is_array($this->arrObjUnion) || is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => $this->arrObjUnion,
+                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => $this->arrObjUnion,
             };
         }
         if (isset($this->objArrUnion)) {
             $this->objArrUnion = match (true) {
-                is_array($this->objArrUnion) || is_array($this->objArrUnion) || is_object($this->objArrUnion) => $this->objArrUnion,
+                is_array($this->objArrUnion) || is_object($this->objArrUnion) => $this->objArrUnion,
             };
         }
         if (isset($this->numKeysDefaults)) {

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -197,7 +197,7 @@ class Qux
         $grox = isset($input->{'grox'})
             ? ((is_string($input->{'grox'}) || is_array($input->{'grox'}))
                 ? $input->{'grox'}
-                : (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
+                : ((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true))
                     ? ((Foo::validateInput($input->{'grox'}, true))
                         ? Foo::fromInput($input->{'grox'}, $validate)
                         : ((Bar::validateInput($input->{'grox'}, true))
@@ -232,7 +232,7 @@ class Qux
         if (isset($this->grox)) {
             if (is_string($this->grox) || is_array($this->grox)) {
                 $output['grox'] = $this->grox;
-            } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
+            } elseif ($this->grox instanceof Foo || $this->grox instanceof Bar) {
                 $output['grox'] = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toArray()
                     : null
@@ -255,7 +255,7 @@ class Qux
         if (isset($this->grox)) {
             if (is_string($this->grox) || is_array($this->grox)) {
                 $output->{'grox'} = $this->grox;
-            } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
+            } elseif ($this->grox instanceof Foo || $this->grox instanceof Bar) {
                 $output->{'grox'} = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toStdClass()
                     : null
@@ -307,7 +307,7 @@ class Qux
         if (isset($this->grox)) {
             $this->grox = ((is_string($this->grox) || is_array($this->grox))
                 ? $this->grox
-                : ((($this->grox instanceof Foo || $this->grox instanceof Bar))
+                : (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? (($this->grox instanceof Foo || $this->grox instanceof Bar)
                         ? $this->grox
                         : $this->grox

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -185,7 +185,7 @@ class Qux
         $grox = isset($input->{'grox'})
             ? ((is_string($input->{'grox'}) || is_array($input->{'grox'}))
                 ? $input->{'grox'}
-                : (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
+                : ((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true))
                     ? ((Foo::validateInput($input->{'grox'}, true))
                         ? Foo::fromInput($input->{'grox'}, $validate)
                         : ((Bar::validateInput($input->{'grox'}, true))
@@ -220,7 +220,7 @@ class Qux
         if (isset($this->grox)) {
             if (is_string($this->grox) || is_array($this->grox)) {
                 $output['grox'] = $this->grox;
-            } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
+            } elseif ($this->grox instanceof Foo || $this->grox instanceof Bar) {
                 $output['grox'] = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toArray()
                     : null
@@ -243,7 +243,7 @@ class Qux
         if (isset($this->grox)) {
             if (is_string($this->grox) || is_array($this->grox)) {
                 $output->{'grox'} = $this->grox;
-            } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
+            } elseif ($this->grox instanceof Foo || $this->grox instanceof Bar) {
                 $output->{'grox'} = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toStdClass()
                     : null
@@ -296,7 +296,7 @@ class Qux
         if (isset($this->grox)) {
             $this->grox = ((is_string($this->grox) || is_array($this->grox))
                 ? $this->grox
-                : ((($this->grox instanceof Foo || $this->grox instanceof Bar))
+                : (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? (($this->grox instanceof Foo || $this->grox instanceof Bar)
                         ? $this->grox
                         : $this->grox

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
@@ -178,7 +178,7 @@ class Qux
         $grox = isset($input->{'grox'})
             ? match (true) {
                 is_string($input->{'grox'}) || is_array($input->{'grox'}) => $input->{'grox'},
-                (Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)) =>
+                Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true) =>
                     match (true) {
                         Foo::validateInput($input->{'grox'}, true) => Foo::fromInput($input->{'grox'}, $validate),
                         Bar::validateInput($input->{'grox'}, true) => Bar::fromInput($input->{'grox'}, $validate),
@@ -210,7 +210,7 @@ class Qux
         if (isset($this->grox)) {
             $output['grox'] = match (true) {
                 is_string($this->grox) || is_array($this->grox) => $this->grox,
-                ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
+                $this->grox instanceof Foo || $this->grox instanceof Bar =>
                     match (true) {
                         $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toArray(),
                         default => null,
@@ -233,7 +233,7 @@ class Qux
         if (isset($this->grox)) {
             $output->{'grox'} = match (true) {
                 is_string($this->grox) || is_array($this->grox) => $this->grox,
-                ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
+                $this->grox instanceof Foo || $this->grox instanceof Bar =>
                     match (true) {
                         $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toStdClass(),
                         default => null,
@@ -286,7 +286,7 @@ class Qux
         if (isset($this->grox)) {
             $this->grox = match (true) {
                 is_string($this->grox) || is_array($this->grox) => $this->grox,
-                ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
+                $this->grox instanceof Foo || $this->grox instanceof Bar =>
                     match (true) {
                         $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox,
                     },

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -400,14 +400,14 @@ class MyClass
         $_providedOptionals = [];
         $foo = match (true) {
             is_string($input->{'foo'})
-                || (is_int($input->{'foo'}) || is_float($input->{'foo'}))
+                || is_int($input->{'foo'}) || is_float($input->{'foo'})
                 || is_bool($input->{'foo'}) =>
                 $input->{'foo'},
             default => throw new \InvalidArgumentException("could not build property 'foo' from JSON"),
         };
         $bar = match (true) {
             is_string($input->{'bar'})
-                || (is_int($input->{'bar'}) || is_float($input->{'bar'}))
+                || is_int($input->{'bar'}) || is_float($input->{'bar'})
                 || is_bool($input->{'bar'})
                 || is_array($input->{'bar'}) =>
                 $input->{'bar'},
@@ -415,28 +415,26 @@ class MyClass
         };
         $baz = match (true) {
             is_string($input->{'baz'})
-                || (is_int($input->{'baz'}) || is_float($input->{'baz'}))
+                || is_int($input->{'baz'}) || is_float($input->{'baz'})
                 || is_bool($input->{'baz'})
-                || is_array($input->{'baz'}) || is_object($input->{'baz'}) =>
+                || is_array($input->{'baz'})
+                || is_object($input->{'baz'}) =>
                 $input->{'baz'},
             default => throw new \InvalidArgumentException("could not build property 'baz' from JSON"),
         };
         $qux = match (true) {
             is_string($input->{'qux'})
-                || (is_int($input->{'qux'}) || is_float($input->{'qux'}))
+                || is_int($input->{'qux'}) || is_float($input->{'qux'})
                 || is_bool($input->{'qux'})
                 || is_array($input->{'qux'})
-                || is_array($input->{'qux'}) || is_object($input->{'qux'}) =>
+                || is_object($input->{'qux'}) =>
                 $input->{'qux'},
             default => throw new \InvalidArgumentException("could not build property 'qux' from JSON"),
         };
         $thud = ($input->{'thud'} !== null
             ? match (true) {
-                is_string($input->{'thud'})
-                    || is_array($input->{'thud'})
-                    || is_array($input->{'thud'}) || is_object($input->{'thud'}) =>
-                    $input->{'thud'},
-                (is_int($input->{'thud'}) || is_float($input->{'thud'})) =>
+                is_string($input->{'thud'}) || is_array($input->{'thud'}) || is_object($input->{'thud'}) => $input->{'thud'},
+                is_int($input->{'thud'}) || is_float($input->{'thud'}) =>
                     (str_contains((string)$input->{'thud'}, '.')
                         ? (float)$input->{'thud'}
                         : (int)$input->{'thud'}
@@ -449,7 +447,7 @@ class MyClass
         $optFoo = isset($input->{'optFoo'})
             ? match (true) {
                 is_string($input->{'optFoo'}) => $input->{'optFoo'},
-                (is_int($input->{'optFoo'}) || is_float($input->{'optFoo'})) =>
+                is_int($input->{'optFoo'}) || is_float($input->{'optFoo'}) =>
                     (str_contains((string)$input->{'optFoo'}, '.')
                         ? (float)$input->{'optFoo'}
                         : (int)$input->{'optFoo'}
@@ -461,7 +459,7 @@ class MyClass
         $optBar = isset($input->{'optBar'})
             ? match (true) {
                 is_string($input->{'optBar'}) || is_array($input->{'optBar'}) => $input->{'optBar'},
-                (is_int($input->{'optBar'}) || is_float($input->{'optBar'})) =>
+                is_int($input->{'optBar'}) || is_float($input->{'optBar'}) =>
                     (str_contains((string)$input->{'optBar'}, '.')
                         ? (float)$input->{'optBar'}
                         : (int)$input->{'optBar'}
@@ -473,7 +471,7 @@ class MyClass
         $optBaz = isset($input->{'optBaz'})
             ? match (true) {
                 is_string($input->{'optBaz'}) || is_array($input->{'optBaz'}) || is_object($input->{'optBaz'}) => $input->{'optBaz'},
-                (is_int($input->{'optBaz'}) || is_float($input->{'optBaz'})) =>
+                is_int($input->{'optBaz'}) || is_float($input->{'optBaz'}) =>
                     (str_contains((string)$input->{'optBaz'}, '.')
                         ? (float)$input->{'optBaz'}
                         : (int)$input->{'optBaz'}
@@ -484,11 +482,8 @@ class MyClass
             : null;
         $optQux = isset($input->{'optQux'})
             ? match (true) {
-                is_string($input->{'optQux'})
-                    || is_array($input->{'optQux'})
-                    || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) =>
-                    $input->{'optQux'},
-                (is_int($input->{'optQux'}) || is_float($input->{'optQux'})) =>
+                is_string($input->{'optQux'}) || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) => $input->{'optQux'},
+                is_int($input->{'optQux'}) || is_float($input->{'optQux'}) =>
                     (str_contains((string)$input->{'optQux'}, '.')
                         ? (float)$input->{'optQux'}
                         : (int)$input->{'optQux'}
@@ -501,11 +496,8 @@ class MyClass
         if (property_exists($input, 'optThud')) {
             $optThud = ($input->{'optThud'} !== null
                 ? match (true) {
-                    is_string($input->{'optThud'})
-                        || is_array($input->{'optThud'})
-                        || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) =>
-                        $input->{'optThud'},
-                    (is_int($input->{'optThud'}) || is_float($input->{'optThud'})) =>
+                    is_string($input->{'optThud'}) || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) => $input->{'optThud'},
+                    is_int($input->{'optThud'}) || is_float($input->{'optThud'}) =>
                         (str_contains((string)$input->{'optThud'}, '.')
                             ? (float)$input->{'optThud'}
                             : (int)$input->{'optThud'}
@@ -550,22 +542,22 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         $output['foo'] = match (true) {
-            is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) || is_bool($this->foo) => $this->foo,
+            is_string($this->foo) || is_int($this->foo) || is_float($this->foo) || is_bool($this->foo) => $this->foo,
         };
         $output['bar'] = match (true) {
             is_string($this->bar)
-                || (is_int($this->bar) || is_float($this->bar))
+                || is_int($this->bar) || is_float($this->bar)
                 || is_bool($this->bar)
                 || is_array($this->bar) =>
                 $this->bar,
         };
         $output['baz'] = match (true) {
-            is_string($this->baz) || (is_int($this->baz) || is_float($this->baz)) || is_bool($this->baz) => $this->baz,
+            is_string($this->baz) || is_int($this->baz) || is_float($this->baz) || is_bool($this->baz) => $this->baz,
             is_array($this->baz) || is_object($this->baz) => json_decode(json_encode($this->baz), true),
         };
         $output['qux'] = match (true) {
             is_string($this->qux)
-                || (is_int($this->qux) || is_float($this->qux))
+                || is_int($this->qux) || is_float($this->qux)
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
                 $this->qux,
@@ -573,7 +565,7 @@ class MyClass
         };
         $output['thud'] = match (true) {
             is_string($this->thud)
-                || (is_int($this->thud) || is_float($this->thud))
+                || is_int($this->thud) || is_float($this->thud)
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
                 $this->thud,
@@ -582,7 +574,7 @@ class MyClass
         if (isset($this->optFoo)) {
             $output['optFoo'] = match (true) {
                 is_string($this->optFoo)
-                    || (is_int($this->optFoo) || is_float($this->optFoo))
+                    || is_int($this->optFoo) || is_float($this->optFoo)
                     || is_bool($this->optFoo) =>
                     $this->optFoo,
             };
@@ -590,7 +582,7 @@ class MyClass
         if (isset($this->optBar)) {
             $output['optBar'] = match (true) {
                 is_string($this->optBar)
-                    || (is_int($this->optBar) || is_float($this->optBar))
+                    || is_int($this->optBar) || is_float($this->optBar)
                     || is_bool($this->optBar)
                     || is_array($this->optBar) =>
                     $this->optBar,
@@ -599,7 +591,7 @@ class MyClass
         if (isset($this->optBaz)) {
             $output['optBaz'] = match (true) {
                 is_string($this->optBaz)
-                    || (is_int($this->optBaz) || is_float($this->optBaz))
+                    || is_int($this->optBaz) || is_float($this->optBaz)
                     || is_bool($this->optBaz) =>
                     $this->optBaz,
                 is_array($this->optBaz) || is_object($this->optBaz) => json_decode(json_encode($this->optBaz), true),
@@ -608,7 +600,7 @@ class MyClass
         if (isset($this->optQux)) {
             $output['optQux'] = match (true) {
                 is_string($this->optQux)
-                    || (is_int($this->optQux) || is_float($this->optQux))
+                    || is_int($this->optQux) || is_float($this->optQux)
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
                     $this->optQux,
@@ -619,7 +611,7 @@ class MyClass
             $output['optThud'] = ($this->optThud !== null
                 ? match (true) {
                     is_string($this->optThud)
-                        || (is_int($this->optThud) || is_float($this->optThud))
+                        || is_int($this->optThud) || is_float($this->optThud)
                         || is_bool($this->optThud)
                         || is_array($this->optThud) =>
                         $this->optThud,
@@ -643,22 +635,22 @@ class MyClass
         $output = $this->_additionalProperties;
 
         $output->{'foo'} = match (true) {
-            is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) || is_bool($this->foo) => $this->foo,
+            is_string($this->foo) || is_int($this->foo) || is_float($this->foo) || is_bool($this->foo) => $this->foo,
         };
         $output->{'bar'} = match (true) {
             is_string($this->bar)
-                || (is_int($this->bar) || is_float($this->bar))
+                || is_int($this->bar) || is_float($this->bar)
                 || is_bool($this->bar)
                 || is_array($this->bar) =>
                 $this->bar,
         };
         $output->{'baz'} = match (true) {
-            is_string($this->baz) || (is_int($this->baz) || is_float($this->baz)) || is_bool($this->baz) => $this->baz,
+            is_string($this->baz) || is_int($this->baz) || is_float($this->baz) || is_bool($this->baz) => $this->baz,
             is_array($this->baz) || is_object($this->baz) => json_decode(json_encode($this->baz)),
         };
         $output->{'qux'} = match (true) {
             is_string($this->qux)
-                || (is_int($this->qux) || is_float($this->qux))
+                || is_int($this->qux) || is_float($this->qux)
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
                 $this->qux,
@@ -666,7 +658,7 @@ class MyClass
         };
         $output->{'thud'} = match (true) {
             is_string($this->thud)
-                || (is_int($this->thud) || is_float($this->thud))
+                || is_int($this->thud) || is_float($this->thud)
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
                 $this->thud,
@@ -675,7 +667,7 @@ class MyClass
         if (isset($this->optFoo)) {
             $output->{'optFoo'} = match (true) {
                 is_string($this->optFoo)
-                    || (is_int($this->optFoo) || is_float($this->optFoo))
+                    || is_int($this->optFoo) || is_float($this->optFoo)
                     || is_bool($this->optFoo) =>
                     $this->optFoo,
             };
@@ -683,7 +675,7 @@ class MyClass
         if (isset($this->optBar)) {
             $output->{'optBar'} = match (true) {
                 is_string($this->optBar)
-                    || (is_int($this->optBar) || is_float($this->optBar))
+                    || is_int($this->optBar) || is_float($this->optBar)
                     || is_bool($this->optBar)
                     || is_array($this->optBar) =>
                     $this->optBar,
@@ -692,7 +684,7 @@ class MyClass
         if (isset($this->optBaz)) {
             $output->{'optBaz'} = match (true) {
                 is_string($this->optBaz)
-                    || (is_int($this->optBaz) || is_float($this->optBaz))
+                    || is_int($this->optBaz) || is_float($this->optBaz)
                     || is_bool($this->optBaz) =>
                     $this->optBaz,
                 is_array($this->optBaz) || is_object($this->optBaz) => json_decode(json_encode($this->optBaz)),
@@ -701,7 +693,7 @@ class MyClass
         if (isset($this->optQux)) {
             $output->{'optQux'} = match (true) {
                 is_string($this->optQux)
-                    || (is_int($this->optQux) || is_float($this->optQux))
+                    || is_int($this->optQux) || is_float($this->optQux)
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
                     $this->optQux,
@@ -712,7 +704,7 @@ class MyClass
             $output->{'optThud'} = ($this->optThud !== null
                 ? match (true) {
                     is_string($this->optThud)
-                        || (is_int($this->optThud) || is_float($this->optThud))
+                        || is_int($this->optThud) || is_float($this->optThud)
                         || is_bool($this->optThud)
                         || is_array($this->optThud) =>
                         $this->optThud,
@@ -766,42 +758,43 @@ class MyClass
     public function __clone()
     {
         $this->foo = match (true) {
-            is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) || is_bool($this->foo) => $this->foo,
+            is_string($this->foo) || is_int($this->foo) || is_float($this->foo) || is_bool($this->foo) => $this->foo,
         };
         $this->bar = match (true) {
             is_string($this->bar)
-                || (is_int($this->bar) || is_float($this->bar))
+                || is_int($this->bar) || is_float($this->bar)
                 || is_bool($this->bar)
                 || is_array($this->bar) =>
                 $this->bar,
         };
         $this->baz = match (true) {
             is_string($this->baz)
-                || (is_int($this->baz) || is_float($this->baz))
+                || is_int($this->baz) || is_float($this->baz)
                 || is_bool($this->baz)
-                || is_array($this->baz) || is_object($this->baz) =>
+                || is_array($this->baz)
+                || is_object($this->baz) =>
                 $this->baz,
         };
         $this->qux = match (true) {
             is_string($this->qux)
-                || (is_int($this->qux) || is_float($this->qux))
+                || is_int($this->qux) || is_float($this->qux)
                 || is_bool($this->qux)
                 || is_array($this->qux)
-                || is_array($this->qux) || is_object($this->qux) =>
+                || is_object($this->qux) =>
                 $this->qux,
         };
         $this->thud = match (true) {
             is_string($this->thud)
-                || (is_int($this->thud) || is_float($this->thud))
+                || is_int($this->thud) || is_float($this->thud)
                 || is_bool($this->thud)
                 || is_array($this->thud)
-                || is_array($this->thud) || is_object($this->thud) =>
+                || is_object($this->thud) =>
                 $this->thud,
         };
         if (isset($this->optFoo)) {
             $this->optFoo = match (true) {
                 is_string($this->optFoo)
-                    || (is_int($this->optFoo) || is_float($this->optFoo))
+                    || is_int($this->optFoo) || is_float($this->optFoo)
                     || is_bool($this->optFoo) =>
                     $this->optFoo,
             };
@@ -809,7 +802,7 @@ class MyClass
         if (isset($this->optBar)) {
             $this->optBar = match (true) {
                 is_string($this->optBar)
-                    || (is_int($this->optBar) || is_float($this->optBar))
+                    || is_int($this->optBar) || is_float($this->optBar)
                     || is_bool($this->optBar)
                     || is_array($this->optBar) =>
                     $this->optBar,
@@ -818,29 +811,30 @@ class MyClass
         if (isset($this->optBaz)) {
             $this->optBaz = match (true) {
                 is_string($this->optBaz)
-                    || (is_int($this->optBaz) || is_float($this->optBaz))
+                    || is_int($this->optBaz) || is_float($this->optBaz)
                     || is_bool($this->optBaz)
-                    || is_array($this->optBaz) || is_object($this->optBaz) =>
+                    || is_array($this->optBaz)
+                    || is_object($this->optBaz) =>
                     $this->optBaz,
             };
         }
         if (isset($this->optQux)) {
             $this->optQux = match (true) {
                 is_string($this->optQux)
-                    || (is_int($this->optQux) || is_float($this->optQux))
+                    || is_int($this->optQux) || is_float($this->optQux)
                     || is_bool($this->optQux)
                     || is_array($this->optQux)
-                    || is_array($this->optQux) || is_object($this->optQux) =>
+                    || is_object($this->optQux) =>
                     $this->optQux,
             };
         }
         if (isset($this->optThud)) {
             $this->optThud = match (true) {
                 is_string($this->optThud)
-                    || (is_int($this->optThud) || is_float($this->optThud))
+                    || is_int($this->optThud) || is_float($this->optThud)
                     || is_bool($this->optThud)
                     || is_array($this->optThud)
-                    || is_array($this->optThud) || is_object($this->optThud) =>
+                    || is_object($this->optThud) =>
                     $this->optThud,
             };
         }

--- a/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
@@ -157,7 +157,7 @@ class MyClass
         $foo = isset($input->{'foo'})
             ? ((is_string($input->{'foo'}))
                 ? $input->{'foo'}
-                : (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
+                : ((is_int($input->{'foo'}) || is_float($input->{'foo'}))
                     ? (str_contains((string)$input->{'foo'}, '.')
                         ? (float)$input->{'foo'}
                         : (int)$input->{'foo'}
@@ -187,7 +187,7 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->foo)) {
-            if (is_string($this->foo) || (is_int($this->foo) || is_float($this->foo))) {
+            if (is_string($this->foo) || is_int($this->foo) || is_float($this->foo)) {
                 $output['foo'] = $this->foo;
             }
         }
@@ -205,7 +205,7 @@ class MyClass
         $output = $this->_additionalProperties;
 
         if (isset($this->foo)) {
-            if (is_string($this->foo) || (is_int($this->foo) || is_float($this->foo))) {
+            if (is_string($this->foo) || is_int($this->foo) || is_float($this->foo)) {
                 $output->{'foo'} = $this->foo;
             }
         }
@@ -252,7 +252,7 @@ class MyClass
     public function __clone()
     {
         if (isset($this->foo)) {
-            $this->foo = ((is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)))
+            $this->foo = ((is_string($this->foo) || is_int($this->foo) || is_float($this->foo))
                 ? $this->foo
                 : $this->foo
             );

--- a/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
@@ -145,7 +145,7 @@ class MyClass
         $foo = isset($input->{'foo'})
             ? ((is_string($input->{'foo'}))
                 ? $input->{'foo'}
-                : (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
+                : ((is_int($input->{'foo'}) || is_float($input->{'foo'}))
                     ? (str_contains((string)$input->{'foo'}, '.')
                         ? (float)$input->{'foo'}
                         : (int)$input->{'foo'}
@@ -175,7 +175,7 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->foo)) {
-            if (is_string($this->foo) || (is_int($this->foo) || is_float($this->foo))) {
+            if (is_string($this->foo) || is_int($this->foo) || is_float($this->foo)) {
                 $output['foo'] = $this->foo;
             }
         }
@@ -193,7 +193,7 @@ class MyClass
         $output = $this->_additionalProperties;
 
         if (isset($this->foo)) {
-            if (is_string($this->foo) || (is_int($this->foo) || is_float($this->foo))) {
+            if (is_string($this->foo) || is_int($this->foo) || is_float($this->foo)) {
                 $output->{'foo'} = $this->foo;
             }
         }
@@ -241,7 +241,7 @@ class MyClass
     public function __clone()
     {
         if (isset($this->foo)) {
-            $this->foo = ((is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)))
+            $this->foo = ((is_string($this->foo) || is_int($this->foo) || is_float($this->foo))
                 ? $this->foo
                 : $this->foo
             );

--- a/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
@@ -118,7 +118,7 @@ class MyClass
         $foo = isset($input->{'foo'})
             ? match (true) {
                 is_string($input->{'foo'}) => $input->{'foo'},
-                (is_int($input->{'foo'}) || is_float($input->{'foo'})) =>
+                is_int($input->{'foo'}) || is_float($input->{'foo'}) =>
                     (str_contains((string)$input->{'foo'}, '.')
                         ? (float)$input->{'foo'}
                         : (int)$input->{'foo'}
@@ -148,7 +148,7 @@ class MyClass
 
         if (isset($this->foo)) {
             $output['foo'] = match (true) {
-                is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) => $this->foo,
+                is_string($this->foo) || is_int($this->foo) || is_float($this->foo) => $this->foo,
             };
         }
 
@@ -166,7 +166,7 @@ class MyClass
 
         if (isset($this->foo)) {
             $output->{'foo'} = match (true) {
-                is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) => $this->foo,
+                is_string($this->foo) || is_int($this->foo) || is_float($this->foo) => $this->foo,
             };
         }
 
@@ -214,7 +214,7 @@ class MyClass
     {
         if (isset($this->foo)) {
             $this->foo = match (true) {
-                is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) => $this->foo,
+                is_string($this->foo) || is_int($this->foo) || is_float($this->foo) => $this->foo,
             };
         }
     }

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
@@ -446,50 +446,50 @@ class MyClass
         }
 
         $arrayOfUnions = isset($input->{'arrayOfUnions'})
-            ? array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
+            ? array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i))))
             )
                 ? array_map(fn ($i) => ((is_string($i))
                     ? $i
-                    : (((is_int($i) || is_float($i)))
+                    : ((is_int($i) || is_float($i))
                         ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
                         : null
                     )
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $input->{'arrayOfUnions'})
             : null;
         $arrayOfRefUnions = isset($input->{'arrayOfRefUnions'})
-            ? array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
+            ? array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i))))
             )
                 ? array_map(fn ($i) => ((is_string($i))
                     ? $i
-                    : (((is_int($i) || is_float($i)))
+                    : ((is_int($i) || is_float($i))
                         ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
                         : null
                     )
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $input->{'arrayOfRefUnions'})
             : null;
         $arrayOfRefAndNotRefUnions = isset($input->{'arrayOfRefAndNotRefUnions'})
-            ? array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
+            ? array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i))))
             )
                 ? array_map(fn ($i) => ((is_string($i))
                     ? $i
-                    : (((is_int($i) || is_float($i)))
+                    : ((is_int($i) || is_float($i))
                         ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
                         : null
                     )
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $input->{'arrayOfRefAndNotRefUnions'})
             : null;
         $arrayOfUnionOfStringAndArray = isset($input->{'arrayOfUnionOfStringAndArray'})
-            ? array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => is_array($i))))
+            ? array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => is_array($i)))
             )
                 ? array_map(fn ($i) => $i, $i)
                 : ((is_string($i)) ? $i : null)
@@ -525,32 +525,32 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->arrayOfUnions)) {
-            $output['arrayOfUnions'] = array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
+            $output['arrayOfUnions'] = array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => ((is_string($i) || is_int($i) || is_float($i)) ? $i : null), $i)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
-            $output['arrayOfRefUnions'] = array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
+            $output['arrayOfRefUnions'] = array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => ((is_string($i) || is_int($i) || is_float($i)) ? $i : null), $i)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
-            $output['arrayOfRefAndNotRefUnions'] = array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
+            $output['arrayOfRefAndNotRefUnions'] = array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => ((is_string($i) || is_int($i) || is_float($i)) ? $i : null), $i)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
-            $output['arrayOfUnionOfStringAndArray'] = array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => is_array($i))))
+            $output['arrayOfUnionOfStringAndArray'] = array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => is_array($i)))
             )
                 ? array_map(fn ($i) => $i, $i)
                 : ((is_string($i)) ? $i : null)
@@ -573,32 +573,32 @@ class MyClass
         $output = $this->_additionalProperties;
 
         if (isset($this->arrayOfUnions)) {
-            $output->{'arrayOfUnions'} = array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
+            $output->{'arrayOfUnions'} = array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => ((is_string($i) || is_int($i) || is_float($i)) ? $i : null), $i)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
-            $output->{'arrayOfRefUnions'} = array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
+            $output->{'arrayOfRefUnions'} = array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => ((is_string($i) || is_int($i) || is_float($i)) ? $i : null), $i)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
-            $output->{'arrayOfRefAndNotRefUnions'} = array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
+            $output->{'arrayOfRefAndNotRefUnions'} = array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => ((is_string($i) || is_int($i) || is_float($i)) ? $i : null), $i)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
-            $output->{'arrayOfUnionOfStringAndArray'} = array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => is_array($i))))
+            $output->{'arrayOfUnionOfStringAndArray'} = array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => is_array($i)))
             )
                 ? array_map(fn ($i) => $i, $i)
                 : ((is_string($i)) ? $i : null)
@@ -651,32 +651,32 @@ class MyClass
     public function __clone()
     {
         if (isset($this->arrayOfUnions)) {
-            $this->arrayOfUnions = array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
+            $this->arrayOfUnions = array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : $i), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : $i) : $i)
+                ? array_map(fn ($i) => ((is_string($i) || is_int($i) || is_float($i)) ? $i : $i), $i)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : $i) : $i)
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
-            $this->arrayOfRefUnions = array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
+            $this->arrayOfRefUnions = array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : $i), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : $i) : $i)
+                ? array_map(fn ($i) => ((is_string($i) || is_int($i) || is_float($i)) ? $i : $i), $i)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : $i) : $i)
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
-            $this->arrayOfRefAndNotRefUnions = array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
+            $this->arrayOfRefAndNotRefUnions = array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : $i), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : $i) : $i)
+                ? array_map(fn ($i) => ((is_string($i) || is_int($i) || is_float($i)) ? $i : $i), $i)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : $i) : $i)
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
-            $this->arrayOfUnionOfStringAndArray = array_map(fn ($i) => (((is_array($i)
-                && count($i) === count(array_filter($i, fn ($i) => is_array($i))))
+            $this->arrayOfUnionOfStringAndArray = array_map(fn ($i) => ((is_array($i)
+                && count($i) === count(array_filter($i, fn ($i) => is_array($i)))
             )
                 ? array_map(fn ($i) => $i, $i)
                 : ((is_string($i)) ? $i : $i)

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
@@ -440,14 +440,14 @@ class MyClass
 
         $arrayOfUnions = isset($input->{'arrayOfUnions'})
             ? array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i)))) =>
                     array_map(fn ($i) => match (true) {
                         is_string($i) => $i,
-                        (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
+                        is_int($i) || is_float($i) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -456,14 +456,14 @@ class MyClass
             : null;
         $arrayOfRefUnions = isset($input->{'arrayOfRefUnions'})
             ? array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i)))) =>
                     array_map(fn ($i) => match (true) {
                         is_string($i) => $i,
-                        (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
+                        is_int($i) || is_float($i) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -472,14 +472,14 @@ class MyClass
             : null;
         $arrayOfRefAndNotRefUnions = isset($input->{'arrayOfRefAndNotRefUnions'})
             ? array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i)))) =>
                     array_map(fn ($i) => match (true) {
                         is_string($i) => $i,
-                        (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
+                        is_int($i) || is_float($i) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -488,8 +488,8 @@ class MyClass
             : null;
         $arrayOfUnionOfStringAndArray = isset($input->{'arrayOfUnionOfStringAndArray'})
             ? array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => is_array($i)))) => array_map(fn ($i) => $i, $i),
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => is_array($i))) => array_map(fn ($i) => $i, $i),
                 is_string($i) => $i,
                 default => null,
             }, $input->{'arrayOfUnionOfStringAndArray'})
@@ -525,13 +525,13 @@ class MyClass
 
         if (isset($this->arrayOfUnions)) {
             $output['arrayOfUnions'] = array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i)))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
+                        is_string($i) || is_int($i) || is_float($i) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -540,13 +540,13 @@ class MyClass
         }
         if (isset($this->arrayOfRefUnions)) {
             $output['arrayOfRefUnions'] = array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i)))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
+                        is_string($i) || is_int($i) || is_float($i) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -555,13 +555,13 @@ class MyClass
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $output['arrayOfRefAndNotRefUnions'] = array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i)))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
+                        is_string($i) || is_int($i) || is_float($i) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -570,8 +570,8 @@ class MyClass
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
             $output['arrayOfUnionOfStringAndArray'] = array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => is_array($i)))) => array_map(fn ($i) => $i, $i),
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => is_array($i))) => array_map(fn ($i) => $i, $i),
                 is_string($i) => $i,
                 default => null,
             }, $this->arrayOfUnionOfStringAndArray);
@@ -594,13 +594,13 @@ class MyClass
 
         if (isset($this->arrayOfUnions)) {
             $output->{'arrayOfUnions'} = array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i)))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
+                        is_string($i) || is_int($i) || is_float($i) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -609,13 +609,13 @@ class MyClass
         }
         if (isset($this->arrayOfRefUnions)) {
             $output->{'arrayOfRefUnions'} = array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i)))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
+                        is_string($i) || is_int($i) || is_float($i) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -624,13 +624,13 @@ class MyClass
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $output->{'arrayOfRefAndNotRefUnions'} = array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i)))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
+                        is_string($i) || is_int($i) || is_float($i) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -639,8 +639,8 @@ class MyClass
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
             $output->{'arrayOfUnionOfStringAndArray'} = array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => is_array($i)))) => array_map(fn ($i) => $i, $i),
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => is_array($i))) => array_map(fn ($i) => $i, $i),
                 is_string($i) => $i,
                 default => null,
             }, $this->arrayOfUnionOfStringAndArray);
@@ -693,44 +693,44 @@ class MyClass
     {
         if (isset($this->arrayOfUnions)) {
             $this->arrayOfUnions = array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i)))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
+                        is_string($i) || is_int($i) || is_float($i) => $i,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                 },
             }, $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $this->arrayOfRefUnions = array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i)))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
+                        is_string($i) || is_int($i) || is_float($i) => $i,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                 },
             }, $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $this->arrayOfRefAndNotRefUnions = array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || is_int($i) || is_float($i)))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
+                        is_string($i) || is_int($i) || is_float($i) => $i,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                 },
             }, $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
             $this->arrayOfUnionOfStringAndArray = array_map(fn ($i) => match (true) {
-                (is_array($i)
-                    && count($i) === count(array_filter($i, fn ($i) => is_array($i)))) => array_map(fn ($i) => $i, $i),
+                is_array($i)
+                    && count($i) === count(array_filter($i, fn ($i) => is_array($i))) => array_map(fn ($i) => $i, $i),
                 is_string($i) => $i,
             }, $this->arrayOfUnionOfStringAndArray);
         }

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
@@ -413,21 +413,21 @@ class MyClass
         }
 
         $arrayOfObjectsUnion = isset($input->{'arrayOfObjectsUnion'})
-            ? (((is_array($input->{'arrayOfObjectsUnion'})
+            ? ((is_array($input->{'arrayOfObjectsUnion'})
                 && count($input->{'arrayOfObjectsUnion'}) === count(array_filter(
                     $input->{'arrayOfObjectsUnion'},
                     fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => MyClassArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
-                )))
+                ))
             )
                 ? array_map(
                     fn ($i): MyClassArrayOfObjectsUnionAlternative1Item => MyClassArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
                     $input->{'arrayOfObjectsUnion'},
                 )
-                : (((is_array($input->{'arrayOfObjectsUnion'})
+                : ((is_array($input->{'arrayOfObjectsUnion'})
                     && count($input->{'arrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'arrayOfObjectsUnion'},
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => MyClassArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
-                    )))
+                    ))
                 )
                     ? array_map(
                         fn ($i): MyClassArrayOfObjectsUnionAlternative2Item => MyClassArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
@@ -438,21 +438,21 @@ class MyClass
             )
             : null;
         $refArrayOfObjectsUnion = isset($input->{'refArrayOfObjectsUnion'})
-            ? (((is_array($input->{'refArrayOfObjectsUnion'})
+            ? ((is_array($input->{'refArrayOfObjectsUnion'})
                 && count($input->{'refArrayOfObjectsUnion'}) === count(array_filter(
                     $input->{'refArrayOfObjectsUnion'},
                     fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => MyClassRefArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
-                )))
+                ))
             )
                 ? array_map(
                     fn ($i): MyClassRefArrayOfObjectsUnionAlternative1Item => MyClassRefArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
                     $input->{'refArrayOfObjectsUnion'},
                 )
-                : (((is_array($input->{'refArrayOfObjectsUnion'})
+                : ((is_array($input->{'refArrayOfObjectsUnion'})
                     && count($input->{'refArrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'refArrayOfObjectsUnion'},
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => MyClassRefArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
-                    )))
+                    ))
                 )
                     ? array_map(
                         fn ($i): MyClassRefArrayOfObjectsUnionAlternative2Item => MyClassRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
@@ -463,41 +463,41 @@ class MyClass
             )
             : null;
         $refAndNotRefArrayOfObjectsUnion = isset($input->{'refAndNotRefArrayOfObjectsUnion'})
-            ? (((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+            ? ((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                 && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                     $input->{'refAndNotRefArrayOfObjectsUnion'},
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
-                )))
+                ))
             )
                 ? array_map(
                     fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
                     $input->{'refAndNotRefArrayOfObjectsUnion'},
                 )
-                : (((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                : ((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                     && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
-                    )))
+                    ))
                 )
                     ? array_map(
                         fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                     )
-                    : (((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                    : ((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                         && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                             $input->{'refAndNotRefArrayOfObjectsUnion'},
                             fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item::validateInput($item, true),
-                        )))
+                        ))
                     )
                         ? array_map(
                             fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item::fromInput($i, $validate),
                             $input->{'refAndNotRefArrayOfObjectsUnion'},
                         )
-                        : (((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                        : ((is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                             && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                                 $input->{'refAndNotRefArrayOfObjectsUnion'},
                                 fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::validateInput($item, true),
-                            )))
+                            ))
                         )
                             ? array_map(
                                 fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::fromInput($i, $validate),
@@ -510,11 +510,11 @@ class MyClass
             )
             : null;
         $arrayOfObjAndStringUnion = isset($input->{'arrayOfObjAndStringUnion'})
-            ? (((is_array($input->{'arrayOfObjAndStringUnion'})
+            ? ((is_array($input->{'arrayOfObjAndStringUnion'})
                 && count($input->{'arrayOfObjAndStringUnion'}) === count(array_filter(
                     $input->{'arrayOfObjAndStringUnion'},
                     fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => MyClassArrayOfObjAndStringUnionAlternative1Item::validateInput($item, true),
-                )))
+                ))
             )
                 ? array_map(
                     fn ($i): MyClassArrayOfObjAndStringUnionAlternative1Item => MyClassArrayOfObjAndStringUnionAlternative1Item::fromInput($i, $validate),
@@ -559,21 +559,21 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->arrayOfObjectsUnion)) {
-            if ((is_array($this->arrayOfObjectsUnion)
+            if (is_array($this->arrayOfObjectsUnion)
                 && count($this->arrayOfObjectsUnion) === count(array_filter(
                     $this->arrayOfObjectsUnion,
                     fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative1Item,
-                )))
+                ))
             ) {
                 $output['arrayOfObjectsUnion'] = array_map(
                     fn (MyClassArrayOfObjectsUnionAlternative1Item $i) => $i->toArray(),
                     $this->arrayOfObjectsUnion,
                 );
-            } elseif ((is_array($this->arrayOfObjectsUnion)
+            } elseif (is_array($this->arrayOfObjectsUnion)
                 && count($this->arrayOfObjectsUnion) === count(array_filter(
                     $this->arrayOfObjectsUnion,
                     fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative2Item,
-                )))
+                ))
             ) {
                 $output['arrayOfObjectsUnion'] = array_map(
                     fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => $i->toArray(),
@@ -582,21 +582,21 @@ class MyClass
             }
         }
         if (isset($this->refArrayOfObjectsUnion)) {
-            if ((is_array($this->refArrayOfObjectsUnion)
+            if (is_array($this->refArrayOfObjectsUnion)
                 && count($this->refArrayOfObjectsUnion) === count(array_filter(
                     $this->refArrayOfObjectsUnion,
                     fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative1Item,
-                )))
+                ))
             ) {
                 $output['refArrayOfObjectsUnion'] = array_map(
                     fn (MyClassRefArrayOfObjectsUnionAlternative1Item $i) => $i->toArray(),
                     $this->refArrayOfObjectsUnion,
                 );
-            } elseif ((is_array($this->refArrayOfObjectsUnion)
+            } elseif (is_array($this->refArrayOfObjectsUnion)
                 && count($this->refArrayOfObjectsUnion) === count(array_filter(
                     $this->refArrayOfObjectsUnion,
                     fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative2Item,
-                )))
+                ))
             ) {
                 $output['refArrayOfObjectsUnion'] = array_map(
                     fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => $i->toArray(),
@@ -605,41 +605,41 @@ class MyClass
             }
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
-            if ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+            if (is_array($this->refAndNotRefArrayOfObjectsUnion)
                 && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                     $this->refAndNotRefArrayOfObjectsUnion,
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item,
-                )))
+                ))
             ) {
                 $output['refAndNotRefArrayOfObjectsUnion'] = array_map(
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $i) => $i->toArray(),
                     $this->refAndNotRefArrayOfObjectsUnion,
                 );
-            } elseif ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+            } elseif (is_array($this->refAndNotRefArrayOfObjectsUnion)
                 && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                     $this->refAndNotRefArrayOfObjectsUnion,
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item,
-                )))
+                ))
             ) {
                 $output['refAndNotRefArrayOfObjectsUnion'] = array_map(
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $i) => $i->toArray(),
                     $this->refAndNotRefArrayOfObjectsUnion,
                 );
-            } elseif ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+            } elseif (is_array($this->refAndNotRefArrayOfObjectsUnion)
                 && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                     $this->refAndNotRefArrayOfObjectsUnion,
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item,
-                )))
+                ))
             ) {
                 $output['refAndNotRefArrayOfObjectsUnion'] = array_map(
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $i) => $i->toArray(),
                     $this->refAndNotRefArrayOfObjectsUnion,
                 );
-            } elseif ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+            } elseif (is_array($this->refAndNotRefArrayOfObjectsUnion)
                 && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                     $this->refAndNotRefArrayOfObjectsUnion,
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item,
-                )))
+                ))
             ) {
                 $output['refAndNotRefArrayOfObjectsUnion'] = array_map(
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => $i->toArray(),
@@ -648,11 +648,11 @@ class MyClass
             }
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
-            if ((is_array($this->arrayOfObjAndStringUnion)
+            if (is_array($this->arrayOfObjAndStringUnion)
                 && count($this->arrayOfObjAndStringUnion) === count(array_filter(
                     $this->arrayOfObjAndStringUnion,
                     fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjAndStringUnionAlternative1Item,
-                )))
+                ))
             ) {
                 $output['arrayOfObjAndStringUnion'] = array_map(
                     fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => $i->toArray(),
@@ -682,21 +682,21 @@ class MyClass
         $output = $this->_additionalProperties;
 
         if (isset($this->arrayOfObjectsUnion)) {
-            if ((is_array($this->arrayOfObjectsUnion)
+            if (is_array($this->arrayOfObjectsUnion)
                 && count($this->arrayOfObjectsUnion) === count(array_filter(
                     $this->arrayOfObjectsUnion,
                     fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative1Item,
-                )))
+                ))
             ) {
                 $output->{'arrayOfObjectsUnion'} = array_map(
                     fn (MyClassArrayOfObjectsUnionAlternative1Item $i) => $i->toStdClass(),
                     $this->arrayOfObjectsUnion,
                 );
-            } elseif ((is_array($this->arrayOfObjectsUnion)
+            } elseif (is_array($this->arrayOfObjectsUnion)
                 && count($this->arrayOfObjectsUnion) === count(array_filter(
                     $this->arrayOfObjectsUnion,
                     fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative2Item,
-                )))
+                ))
             ) {
                 $output->{'arrayOfObjectsUnion'} = array_map(
                     fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => $i->toStdClass(),
@@ -705,21 +705,21 @@ class MyClass
             }
         }
         if (isset($this->refArrayOfObjectsUnion)) {
-            if ((is_array($this->refArrayOfObjectsUnion)
+            if (is_array($this->refArrayOfObjectsUnion)
                 && count($this->refArrayOfObjectsUnion) === count(array_filter(
                     $this->refArrayOfObjectsUnion,
                     fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative1Item,
-                )))
+                ))
             ) {
                 $output->{'refArrayOfObjectsUnion'} = array_map(
                     fn (MyClassRefArrayOfObjectsUnionAlternative1Item $i) => $i->toStdClass(),
                     $this->refArrayOfObjectsUnion,
                 );
-            } elseif ((is_array($this->refArrayOfObjectsUnion)
+            } elseif (is_array($this->refArrayOfObjectsUnion)
                 && count($this->refArrayOfObjectsUnion) === count(array_filter(
                     $this->refArrayOfObjectsUnion,
                     fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative2Item,
-                )))
+                ))
             ) {
                 $output->{'refArrayOfObjectsUnion'} = array_map(
                     fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => $i->toStdClass(),
@@ -728,41 +728,41 @@ class MyClass
             }
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
-            if ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+            if (is_array($this->refAndNotRefArrayOfObjectsUnion)
                 && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                     $this->refAndNotRefArrayOfObjectsUnion,
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item,
-                )))
+                ))
             ) {
                 $output->{'refAndNotRefArrayOfObjectsUnion'} = array_map(
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $i) => $i->toStdClass(),
                     $this->refAndNotRefArrayOfObjectsUnion,
                 );
-            } elseif ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+            } elseif (is_array($this->refAndNotRefArrayOfObjectsUnion)
                 && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                     $this->refAndNotRefArrayOfObjectsUnion,
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item,
-                )))
+                ))
             ) {
                 $output->{'refAndNotRefArrayOfObjectsUnion'} = array_map(
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $i) => $i->toStdClass(),
                     $this->refAndNotRefArrayOfObjectsUnion,
                 );
-            } elseif ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+            } elseif (is_array($this->refAndNotRefArrayOfObjectsUnion)
                 && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                     $this->refAndNotRefArrayOfObjectsUnion,
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item,
-                )))
+                ))
             ) {
                 $output->{'refAndNotRefArrayOfObjectsUnion'} = array_map(
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $i) => $i->toStdClass(),
                     $this->refAndNotRefArrayOfObjectsUnion,
                 );
-            } elseif ((is_array($this->refAndNotRefArrayOfObjectsUnion)
+            } elseif (is_array($this->refAndNotRefArrayOfObjectsUnion)
                 && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                     $this->refAndNotRefArrayOfObjectsUnion,
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item,
-                )))
+                ))
             ) {
                 $output->{'refAndNotRefArrayOfObjectsUnion'} = array_map(
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => $i->toStdClass(),
@@ -771,11 +771,11 @@ class MyClass
             }
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
-            if ((is_array($this->arrayOfObjAndStringUnion)
+            if (is_array($this->arrayOfObjAndStringUnion)
                 && count($this->arrayOfObjAndStringUnion) === count(array_filter(
                     $this->arrayOfObjAndStringUnion,
                     fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjAndStringUnionAlternative1Item,
-                )))
+                ))
             ) {
                 $output->{'arrayOfObjAndStringUnion'} = array_map(
                     fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => $i->toStdClass(),
@@ -835,21 +835,21 @@ class MyClass
     public function __clone()
     {
         if (isset($this->arrayOfObjectsUnion)) {
-            $this->arrayOfObjectsUnion = (((is_array($this->arrayOfObjectsUnion)
+            $this->arrayOfObjectsUnion = ((is_array($this->arrayOfObjectsUnion)
                 && count($this->arrayOfObjectsUnion) === count(array_filter(
                     $this->arrayOfObjectsUnion,
                     fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative1Item,
-                )))
+                ))
             )
                 ? array_map(
                     fn (MyClassArrayOfObjectsUnionAlternative1Item $i) => clone $i,
                     $this->arrayOfObjectsUnion,
                 )
-                : (((is_array($this->arrayOfObjectsUnion)
+                : ((is_array($this->arrayOfObjectsUnion)
                     && count($this->arrayOfObjectsUnion) === count(array_filter(
                         $this->arrayOfObjectsUnion,
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative2Item,
-                    )))
+                    ))
                 )
                     ? array_map(
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => clone $i,
@@ -860,21 +860,21 @@ class MyClass
             );
         }
         if (isset($this->refArrayOfObjectsUnion)) {
-            $this->refArrayOfObjectsUnion = (((is_array($this->refArrayOfObjectsUnion)
+            $this->refArrayOfObjectsUnion = ((is_array($this->refArrayOfObjectsUnion)
                 && count($this->refArrayOfObjectsUnion) === count(array_filter(
                     $this->refArrayOfObjectsUnion,
                     fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative1Item,
-                )))
+                ))
             )
                 ? array_map(
                     fn (MyClassRefArrayOfObjectsUnionAlternative1Item $i) => clone $i,
                     $this->refArrayOfObjectsUnion,
                 )
-                : (((is_array($this->refArrayOfObjectsUnion)
+                : ((is_array($this->refArrayOfObjectsUnion)
                     && count($this->refArrayOfObjectsUnion) === count(array_filter(
                         $this->refArrayOfObjectsUnion,
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative2Item,
-                    )))
+                    ))
                 )
                     ? array_map(
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => clone $i,
@@ -885,41 +885,41 @@ class MyClass
             );
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
-            $this->refAndNotRefArrayOfObjectsUnion = (((is_array($this->refAndNotRefArrayOfObjectsUnion)
+            $this->refAndNotRefArrayOfObjectsUnion = ((is_array($this->refAndNotRefArrayOfObjectsUnion)
                 && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                     $this->refAndNotRefArrayOfObjectsUnion,
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item,
-                )))
+                ))
             )
                 ? array_map(
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $i) => clone $i,
                     $this->refAndNotRefArrayOfObjectsUnion,
                 )
-                : (((is_array($this->refAndNotRefArrayOfObjectsUnion)
+                : ((is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item,
-                    )))
+                    ))
                 )
                     ? array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $i) => clone $i,
                         $this->refAndNotRefArrayOfObjectsUnion,
                     )
-                    : (((is_array($this->refAndNotRefArrayOfObjectsUnion)
+                    : ((is_array($this->refAndNotRefArrayOfObjectsUnion)
                         && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                             $this->refAndNotRefArrayOfObjectsUnion,
                             fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item,
-                        )))
+                        ))
                     )
                         ? array_map(
                             fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $i) => clone $i,
                             $this->refAndNotRefArrayOfObjectsUnion,
                         )
-                        : (((is_array($this->refAndNotRefArrayOfObjectsUnion)
+                        : ((is_array($this->refAndNotRefArrayOfObjectsUnion)
                             && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                                 $this->refAndNotRefArrayOfObjectsUnion,
                                 fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item,
-                            )))
+                            ))
                         )
                             ? array_map(
                                 fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => clone $i,
@@ -932,11 +932,11 @@ class MyClass
             );
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
-            $this->arrayOfObjAndStringUnion = (((is_array($this->arrayOfObjAndStringUnion)
+            $this->arrayOfObjAndStringUnion = ((is_array($this->arrayOfObjAndStringUnion)
                 && count($this->arrayOfObjAndStringUnion) === count(array_filter(
                     $this->arrayOfObjAndStringUnion,
                     fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjAndStringUnionAlternative1Item,
-                )))
+                ))
             )
                 ? array_map(
                     fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => clone $i,

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClass.php
@@ -407,20 +407,20 @@ class MyClass
 
         $arrayOfObjectsUnion = isset($input->{'arrayOfObjectsUnion'})
             ? match (true) {
-                (is_array($input->{'arrayOfObjectsUnion'})
+                is_array($input->{'arrayOfObjectsUnion'})
                     && count($input->{'arrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'arrayOfObjectsUnion'},
                         fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => MyClassArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (object|array $i): MyClassArrayOfObjectsUnionAlternative1Item => MyClassArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
                         $input->{'arrayOfObjectsUnion'},
                     ),
-                (is_array($input->{'arrayOfObjectsUnion'})
+                is_array($input->{'arrayOfObjectsUnion'})
                     && count($input->{'arrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'arrayOfObjectsUnion'},
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => MyClassArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (object|array $i): MyClassArrayOfObjectsUnionAlternative2Item => MyClassArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'arrayOfObjectsUnion'},
@@ -430,20 +430,20 @@ class MyClass
             : null;
         $refArrayOfObjectsUnion = isset($input->{'refArrayOfObjectsUnion'})
             ? match (true) {
-                (is_array($input->{'refArrayOfObjectsUnion'})
+                is_array($input->{'refArrayOfObjectsUnion'})
                     && count($input->{'refArrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'refArrayOfObjectsUnion'},
                         fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => MyClassRefArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (object|array $i): MyClassRefArrayOfObjectsUnionAlternative1Item => MyClassRefArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
                         $input->{'refArrayOfObjectsUnion'},
                     ),
-                (is_array($input->{'refArrayOfObjectsUnion'})
+                is_array($input->{'refArrayOfObjectsUnion'})
                     && count($input->{'refArrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'refArrayOfObjectsUnion'},
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => MyClassRefArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (object|array $i): MyClassRefArrayOfObjectsUnionAlternative2Item => MyClassRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'refArrayOfObjectsUnion'},
@@ -453,38 +453,38 @@ class MyClass
             : null;
         $refAndNotRefArrayOfObjectsUnion = isset($input->{'refAndNotRefArrayOfObjectsUnion'})
             ? match (true) {
-                (is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                     && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item::validateInput($item, true),
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (object|array $i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item::fromInput($i, $validate),
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                     ),
-                (is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                     && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item::validateInput($item, true),
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (object|array $i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                     ),
-                (is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                     && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item::validateInput($item, true),
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (object|array $i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item::fromInput($i, $validate),
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                     ),
-                (is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
+                is_array($input->{'refAndNotRefArrayOfObjectsUnion'})
                     && count($input->{'refAndNotRefArrayOfObjectsUnion'}) === count(array_filter(
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::validateInput($item, true),
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (object|array $i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::fromInput($i, $validate),
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
@@ -494,11 +494,11 @@ class MyClass
             : null;
         $arrayOfObjAndStringUnion = isset($input->{'arrayOfObjAndStringUnion'})
             ? match (true) {
-                (is_array($input->{'arrayOfObjAndStringUnion'})
+                is_array($input->{'arrayOfObjAndStringUnion'})
                     && count($input->{'arrayOfObjAndStringUnion'}) === count(array_filter(
                         $input->{'arrayOfObjAndStringUnion'},
                         fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => MyClassArrayOfObjAndStringUnionAlternative1Item::validateInput($item, true),
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (object|array $i): MyClassArrayOfObjAndStringUnionAlternative1Item => MyClassArrayOfObjAndStringUnionAlternative1Item::fromInput($i, $validate),
                         $input->{'arrayOfObjAndStringUnion'},
@@ -541,20 +541,20 @@ class MyClass
 
         if (isset($this->arrayOfObjectsUnion)) {
             $output['arrayOfObjectsUnion'] = match (true) {
-                (is_array($this->arrayOfObjectsUnion)
+                is_array($this->arrayOfObjectsUnion)
                     && count($this->arrayOfObjectsUnion) === count(array_filter(
                         $this->arrayOfObjectsUnion,
                         fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative1Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassArrayOfObjectsUnionAlternative1Item $i) => $i->toArray(),
                         $this->arrayOfObjectsUnion,
                     ),
-                (is_array($this->arrayOfObjectsUnion)
+                is_array($this->arrayOfObjectsUnion)
                     && count($this->arrayOfObjectsUnion) === count(array_filter(
                         $this->arrayOfObjectsUnion,
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative2Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => $i->toArray(),
                         $this->arrayOfObjectsUnion,
@@ -563,20 +563,20 @@ class MyClass
         }
         if (isset($this->refArrayOfObjectsUnion)) {
             $output['refArrayOfObjectsUnion'] = match (true) {
-                (is_array($this->refArrayOfObjectsUnion)
+                is_array($this->refArrayOfObjectsUnion)
                     && count($this->refArrayOfObjectsUnion) === count(array_filter(
                         $this->refArrayOfObjectsUnion,
                         fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative1Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefArrayOfObjectsUnionAlternative1Item $i) => $i->toArray(),
                         $this->refArrayOfObjectsUnion,
                     ),
-                (is_array($this->refArrayOfObjectsUnion)
+                is_array($this->refArrayOfObjectsUnion)
                     && count($this->refArrayOfObjectsUnion) === count(array_filter(
                         $this->refArrayOfObjectsUnion,
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative2Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => $i->toArray(),
                         $this->refArrayOfObjectsUnion,
@@ -585,38 +585,38 @@ class MyClass
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
             $output['refAndNotRefArrayOfObjectsUnion'] = match (true) {
-                (is_array($this->refAndNotRefArrayOfObjectsUnion)
+                is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $i) => $i->toArray(),
                         $this->refAndNotRefArrayOfObjectsUnion,
                     ),
-                (is_array($this->refAndNotRefArrayOfObjectsUnion)
+                is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $i) => $i->toArray(),
                         $this->refAndNotRefArrayOfObjectsUnion,
                     ),
-                (is_array($this->refAndNotRefArrayOfObjectsUnion)
+                is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $i) => $i->toArray(),
                         $this->refAndNotRefArrayOfObjectsUnion,
                     ),
-                (is_array($this->refAndNotRefArrayOfObjectsUnion)
+                is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => $i->toArray(),
                         $this->refAndNotRefArrayOfObjectsUnion,
@@ -625,11 +625,11 @@ class MyClass
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
             $output['arrayOfObjAndStringUnion'] = match (true) {
-                (is_array($this->arrayOfObjAndStringUnion)
+                is_array($this->arrayOfObjAndStringUnion)
                     && count($this->arrayOfObjAndStringUnion) === count(array_filter(
                         $this->arrayOfObjAndStringUnion,
                         fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjAndStringUnionAlternative1Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => $i->toArray(),
                         $this->arrayOfObjAndStringUnion,
@@ -658,20 +658,20 @@ class MyClass
 
         if (isset($this->arrayOfObjectsUnion)) {
             $output->{'arrayOfObjectsUnion'} = match (true) {
-                (is_array($this->arrayOfObjectsUnion)
+                is_array($this->arrayOfObjectsUnion)
                     && count($this->arrayOfObjectsUnion) === count(array_filter(
                         $this->arrayOfObjectsUnion,
                         fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative1Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassArrayOfObjectsUnionAlternative1Item $i) => $i->toStdClass(),
                         $this->arrayOfObjectsUnion,
                     ),
-                (is_array($this->arrayOfObjectsUnion)
+                is_array($this->arrayOfObjectsUnion)
                     && count($this->arrayOfObjectsUnion) === count(array_filter(
                         $this->arrayOfObjectsUnion,
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative2Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => $i->toStdClass(),
                         $this->arrayOfObjectsUnion,
@@ -680,20 +680,20 @@ class MyClass
         }
         if (isset($this->refArrayOfObjectsUnion)) {
             $output->{'refArrayOfObjectsUnion'} = match (true) {
-                (is_array($this->refArrayOfObjectsUnion)
+                is_array($this->refArrayOfObjectsUnion)
                     && count($this->refArrayOfObjectsUnion) === count(array_filter(
                         $this->refArrayOfObjectsUnion,
                         fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative1Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefArrayOfObjectsUnionAlternative1Item $i) => $i->toStdClass(),
                         $this->refArrayOfObjectsUnion,
                     ),
-                (is_array($this->refArrayOfObjectsUnion)
+                is_array($this->refArrayOfObjectsUnion)
                     && count($this->refArrayOfObjectsUnion) === count(array_filter(
                         $this->refArrayOfObjectsUnion,
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative2Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => $i->toStdClass(),
                         $this->refArrayOfObjectsUnion,
@@ -702,38 +702,38 @@ class MyClass
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
             $output->{'refAndNotRefArrayOfObjectsUnion'} = match (true) {
-                (is_array($this->refAndNotRefArrayOfObjectsUnion)
+                is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $i) => $i->toStdClass(),
                         $this->refAndNotRefArrayOfObjectsUnion,
                     ),
-                (is_array($this->refAndNotRefArrayOfObjectsUnion)
+                is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $i) => $i->toStdClass(),
                         $this->refAndNotRefArrayOfObjectsUnion,
                     ),
-                (is_array($this->refAndNotRefArrayOfObjectsUnion)
+                is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $i) => $i->toStdClass(),
                         $this->refAndNotRefArrayOfObjectsUnion,
                     ),
-                (is_array($this->refAndNotRefArrayOfObjectsUnion)
+                is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => $i->toStdClass(),
                         $this->refAndNotRefArrayOfObjectsUnion,
@@ -742,11 +742,11 @@ class MyClass
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
             $output->{'arrayOfObjAndStringUnion'} = match (true) {
-                (is_array($this->arrayOfObjAndStringUnion)
+                is_array($this->arrayOfObjAndStringUnion)
                     && count($this->arrayOfObjAndStringUnion) === count(array_filter(
                         $this->arrayOfObjAndStringUnion,
                         fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjAndStringUnionAlternative1Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => $i->toStdClass(),
                         $this->arrayOfObjAndStringUnion,
@@ -805,20 +805,20 @@ class MyClass
     {
         if (isset($this->arrayOfObjectsUnion)) {
             $this->arrayOfObjectsUnion = match (true) {
-                (is_array($this->arrayOfObjectsUnion)
+                is_array($this->arrayOfObjectsUnion)
                     && count($this->arrayOfObjectsUnion) === count(array_filter(
                         $this->arrayOfObjectsUnion,
                         fn (MyClassArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative1Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassArrayOfObjectsUnionAlternative1Item $i) => clone $i,
                         $this->arrayOfObjectsUnion,
                     ),
-                (is_array($this->arrayOfObjectsUnion)
+                is_array($this->arrayOfObjectsUnion)
                     && count($this->arrayOfObjectsUnion) === count(array_filter(
                         $this->arrayOfObjectsUnion,
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassArrayOfObjectsUnionAlternative2Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => clone $i,
                         $this->arrayOfObjectsUnion,
@@ -827,20 +827,20 @@ class MyClass
         }
         if (isset($this->refArrayOfObjectsUnion)) {
             $this->refArrayOfObjectsUnion = match (true) {
-                (is_array($this->refArrayOfObjectsUnion)
+                is_array($this->refArrayOfObjectsUnion)
                     && count($this->refArrayOfObjectsUnion) === count(array_filter(
                         $this->refArrayOfObjectsUnion,
                         fn (MyClassRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative1Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefArrayOfObjectsUnionAlternative1Item $i) => clone $i,
                         $this->refArrayOfObjectsUnion,
                     ),
-                (is_array($this->refArrayOfObjectsUnion)
+                is_array($this->refArrayOfObjectsUnion)
                     && count($this->refArrayOfObjectsUnion) === count(array_filter(
                         $this->refArrayOfObjectsUnion,
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefArrayOfObjectsUnionAlternative2Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => clone $i,
                         $this->refArrayOfObjectsUnion,
@@ -849,38 +849,38 @@ class MyClass
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
             $this->refAndNotRefArrayOfObjectsUnion = match (true) {
-                (is_array($this->refAndNotRefArrayOfObjectsUnion)
+                is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative1Item $i) => clone $i,
                         $this->refAndNotRefArrayOfObjectsUnion,
                     ),
-                (is_array($this->refAndNotRefArrayOfObjectsUnion)
+                is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative2Item $i) => clone $i,
                         $this->refAndNotRefArrayOfObjectsUnion,
                     ),
-                (is_array($this->refAndNotRefArrayOfObjectsUnion)
+                is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative3Item $i) => clone $i,
                         $this->refAndNotRefArrayOfObjectsUnion,
                     ),
-                (is_array($this->refAndNotRefArrayOfObjectsUnion)
+                is_array($this->refAndNotRefArrayOfObjectsUnion)
                     && count($this->refAndNotRefArrayOfObjectsUnion) === count(array_filter(
                         $this->refAndNotRefArrayOfObjectsUnion,
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $item): bool => $item instanceof MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => clone $i,
                         $this->refAndNotRefArrayOfObjectsUnion,
@@ -889,11 +889,11 @@ class MyClass
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
             $this->arrayOfObjAndStringUnion = match (true) {
-                (is_array($this->arrayOfObjAndStringUnion)
+                is_array($this->arrayOfObjAndStringUnion)
                     && count($this->arrayOfObjAndStringUnion) === count(array_filter(
                         $this->arrayOfObjAndStringUnion,
                         fn (MyClassArrayOfObjAndStringUnionAlternative1Item $item): bool => $item instanceof MyClassArrayOfObjAndStringUnionAlternative1Item,
-                    ))) =>
+                    )) =>
                     array_map(
                         fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => clone $i,
                         $this->arrayOfObjAndStringUnion,

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -161,15 +161,14 @@ class Cat
         if (property_exists($input, 'hasFur')) {
             $hasFur = ($input->{'hasFur'} !== null
                 ? match (true) {
-                    ($input->{'hasFur'} === null || is_bool($input->{'hasFur'})) =>
+                    $input->{'hasFur'} === null || is_bool($input->{'hasFur'}) =>
                         ($input->{'hasFur'} !== null ? (bool)$input->{'hasFur'} : null),
-                    ($input->{'hasFur'} === null
-                        || (is_string($input->{'hasFur'}) || (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})))
-                    ) =>
+                    $input->{'hasFur'} === null
+                        || (is_string($input->{'hasFur'}) || is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})) =>
                         ($input->{'hasFur'} !== null
                             ? match (true) {
                                 is_string($input->{'hasFur'}) => $input->{'hasFur'},
-                                (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})) =>
+                                is_int($input->{'hasFur'}) || is_float($input->{'hasFur'}) =>
                                     (str_contains((string)$input->{'hasFur'}, '.')
                                         ? (float)$input->{'hasFur'}
                                         : (int)$input->{'hasFur'}
@@ -178,13 +177,12 @@ class Cat
                             }
                             : null
                         ),
-                    (is_string($input->{'hasFur'})
-                        || (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'}))
-                        || is_bool($input->{'hasFur'})
-                    ) =>
+                    is_string($input->{'hasFur'})
+                        || is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})
+                        || is_bool($input->{'hasFur'}) =>
                         match (true) {
                             is_string($input->{'hasFur'}) => $input->{'hasFur'},
-                            (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})) =>
+                            is_int($input->{'hasFur'}) || is_float($input->{'hasFur'}) =>
                                 (str_contains((string)$input->{'hasFur'}, '.')
                                     ? (float)$input->{'hasFur'}
                                     : (int)$input->{'hasFur'}
@@ -222,24 +220,22 @@ class Cat
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
             $output['hasFur'] = ($this->hasFur !== null
                 ? match (true) {
-                    ($this->hasFur === null || is_bool($this->hasFur)) => ($this->hasFur !== null ? $this->hasFur : null),
-                    ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
+                    $this->hasFur === null || is_bool($this->hasFur) => ($this->hasFur !== null ? $this->hasFur : null),
+                    $this->hasFur === null
+                        || (is_string($this->hasFur) || is_int($this->hasFur) || is_float($this->hasFur)) =>
                         ($this->hasFur !== null
                             ? match (true) {
-                                is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
+                                is_string($this->hasFur) || is_int($this->hasFur) || is_float($this->hasFur) => $this->hasFur,
                                 default => null,
                             }
                             : null
                         ),
-                    (is_string($this->hasFur)
-                        || (is_int($this->hasFur) || is_float($this->hasFur))
-                        || is_bool($this->hasFur)
-                    ) =>
+                    is_string($this->hasFur)
+                        || is_int($this->hasFur) || is_float($this->hasFur)
+                        || is_bool($this->hasFur) =>
                         match (true) {
                             is_string($this->hasFur)
-                                || (is_int($this->hasFur) || is_float($this->hasFur))
+                                || is_int($this->hasFur) || is_float($this->hasFur)
                                 || is_bool($this->hasFur) =>
                                 $this->hasFur,
                             default => null,
@@ -265,24 +261,22 @@ class Cat
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
             $output->{'hasFur'} = ($this->hasFur !== null
                 ? match (true) {
-                    ($this->hasFur === null || is_bool($this->hasFur)) => ($this->hasFur !== null ? $this->hasFur : null),
-                    ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
+                    $this->hasFur === null || is_bool($this->hasFur) => ($this->hasFur !== null ? $this->hasFur : null),
+                    $this->hasFur === null
+                        || (is_string($this->hasFur) || is_int($this->hasFur) || is_float($this->hasFur)) =>
                         ($this->hasFur !== null
                             ? match (true) {
-                                is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
+                                is_string($this->hasFur) || is_int($this->hasFur) || is_float($this->hasFur) => $this->hasFur,
                                 default => null,
                             }
                             : null
                         ),
-                    (is_string($this->hasFur)
-                        || (is_int($this->hasFur) || is_float($this->hasFur))
-                        || is_bool($this->hasFur)
-                    ) =>
+                    is_string($this->hasFur)
+                        || is_int($this->hasFur) || is_float($this->hasFur)
+                        || is_bool($this->hasFur) =>
                         match (true) {
                             is_string($this->hasFur)
-                                || (is_int($this->hasFur) || is_float($this->hasFur))
+                                || is_int($this->hasFur) || is_float($this->hasFur)
                                 || is_bool($this->hasFur) =>
                                 $this->hasFur,
                             default => null,
@@ -337,18 +331,16 @@ class Cat
     {
         if (isset($this->hasFur)) {
             $this->hasFur = match (true) {
-                ($this->hasFur === null || is_bool($this->hasFur))
-                    || ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
+                $this->hasFur === null || is_bool($this->hasFur)
+                    || $this->hasFur === null
+                        || (is_string($this->hasFur) || is_int($this->hasFur) || is_float($this->hasFur)) =>
                     (isset($this->hasFur) ? clone $this->hasFur : null),
-                (is_string($this->hasFur)
-                    || (is_int($this->hasFur) || is_float($this->hasFur))
-                    || is_bool($this->hasFur)
-                ) =>
+                is_string($this->hasFur)
+                    || is_int($this->hasFur) || is_float($this->hasFur)
+                    || is_bool($this->hasFur) =>
                     match (true) {
                         is_string($this->hasFur)
-                            || (is_int($this->hasFur) || is_float($this->hasFur))
+                            || is_int($this->hasFur) || is_float($this->hasFur)
                             || is_bool($this->hasFur) =>
                             $this->hasFur,
                     },


### PR DESCRIPTION
## Summary
- avoid duplicate runtime checks when handling `oneOf`/`anyOf` unions
- regenerate test fixtures

## Testing
- `SKIP_EVAL=1 UPDATE_SNAPSHOTS=1 vendor/bin/phpunit --exclude-filter SchemaToClassTest`
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68a041c9172c832daff377cae90fbea8