### PR TITLE
Fix duplicate type checks for unions mixing array and object

### DIFF
--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -17,6 +17,8 @@ use Helmich\Schema2Class\Generator\Property\Type\AbstractProperty;
 use Helmich\Schema2Class\Generator\Property\Type\Array\ObjectArrayProperty;
 use Helmich\Schema2Class\Generator\Property\Type\Array\PrimitiveArrayProperty;
 use Helmich\Schema2Class\Generator\Property\Type\Array\ReferenceArrayProperty;
+use Helmich\Schema2Class\Generator\Property\Type\Array\TypedArrayProperty;
+use Helmich\Schema2Class\Generator\Property\Type\Object\RawObjectProperty;
 use Helmich\Schema2Class\Generator\Property\Type\Object\NestedObjectProperty;
 use Helmich\Schema2Class\Generator\Property\Type\PropertyInterface;
 use Helmich\Schema2Class\Generator\Property\Type\ReferenceProperty;
@@ -37,6 +39,8 @@ class UnionProperty extends AbstractProperty
     /** @var PropertyInterface[] */
     private array $subProperties;
 
+    private bool $hasArrayProperty = false;
+
     public function __construct(string $key, array $schema, GeneratorRequest $generatorRequest)
     {
         if (isset($schema["anyOf"])) {
@@ -51,7 +55,43 @@ class UnionProperty extends AbstractProperty
             return PropertyBuilder::buildPropertyFromSchema($generatorRequest, "{$key}Alternative" . ($idx + 1), $subSchema, true);
         }, array_keys($schema["oneOf"]));
 
+        foreach ($this->subProperties as $prop) {
+            if (
+                $prop instanceof ReferenceArrayProperty
+                || $prop instanceof ObjectArrayProperty
+                || $prop instanceof PrimitiveArrayProperty
+                || $prop instanceof TypedArrayProperty
+            ) {
+                $this->hasArrayProperty = true;
+                break;
+            }
+        }
+
         parent::__construct($key, $schema, $generatorRequest);
+    }
+
+    private function inputAssertion(PropertyInterface $subProperty, string $expr): string
+    {
+        $assert = $subProperty->inputAssertionExpr($expr);
+        return $this->refineObjectAssertion($subProperty, $expr, $assert);
+    }
+
+    private function typeAssertion(PropertyInterface $subProperty, string $expr): string
+    {
+        $assert = $subProperty->typeAssertionExpr($expr);
+        return $this->refineObjectAssertion($subProperty, $expr, $assert);
+    }
+
+    private function refineObjectAssertion(PropertyInterface $subProperty, string $expr, string $assert): string
+    {
+        if ($this->hasArrayProperty && $subProperty instanceof RawObjectProperty) {
+            $prefix = 'is_array(' . $expr . ') || ';
+            if (str_starts_with($assert, $prefix)) {
+                $assert = substr($assert, strlen($prefix));
+            }
+        }
+
+        return $assert;
     }
 
     public static function canHandleSchema(array $schema): bool
@@ -66,12 +106,13 @@ class UnionProperty extends AbstractProperty
         $arms = [];
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->inputMappingExpr($accessor, asserted: true);
-            $discriminator = $subProperty->inputAssertionExpr($accessor);
+            $discriminator = $this->inputAssertion($subProperty, $accessor);
 
             if (
                 $subProperty instanceof ReferenceArrayProperty
                 || $subProperty instanceof ObjectArrayProperty
                 || $subProperty instanceof PrimitiveArrayProperty
+                || $subProperty instanceof TypedArrayProperty
             ) {
                 $isArrayCheck = "is_array({$accessor})";
                 if (!str_contains($discriminator, $isArrayCheck)) {
@@ -119,13 +160,14 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProp) {
             $mapping       = $subProp->inputMappingExpr($accessor, asserted: true);
             $assignment    = "\${$name} = {$mapping};";
-            $discriminator = $subProp->inputAssertionExpr($accessor);
+            $discriminator = $this->inputAssertion($subProp, $accessor);
     
             // If this arm is an "array" type, ensure its test guards against non-arrays
             if (
                 $subProp instanceof ReferenceArrayProperty
                 || $subProp instanceof ObjectArrayProperty
                 || $subProp instanceof PrimitiveArrayProperty
+                || $subProp instanceof TypedArrayProperty
             ) {
                 $isArrayCheck = "is_array({$accessor})";
                 if (!str_contains($discriminator, $isArrayCheck)) {
@@ -189,7 +231,7 @@ class UnionProperty extends AbstractProperty
 
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExpr("\$this->{$name}");
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+            $discriminator = $this->typeAssertion($subProperty, "\$this->{$name}");
             $arms[$mapping][] = $discriminator;
         }
 
@@ -210,7 +252,7 @@ class UnionProperty extends AbstractProperty
 
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExprStdClass("\$this->{$name}");
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+            $discriminator = $this->typeAssertion($subProperty, "\$this->{$name}");
             $arms[$mapping][] = $discriminator;
         }
 
@@ -238,7 +280,7 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExpr("\$this->{$name}");
             $assignment    = "\${$outputVarName}[{$keyStr}] = {$mapping};";
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+            $discriminator = $this->typeAssertion($subProperty, "\$this->{$name}");
 
             if (!isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => []];
@@ -279,7 +321,7 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExprStdClass("\$this->{$name}");
             $assignment    = "\${$outputVarName}->{{$keyStr}} = {$mapping};";
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+            $discriminator = $this->typeAssertion($subProperty, "\$this->{$name}");
 
             if (!isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => []];
@@ -407,7 +449,7 @@ class UnionProperty extends AbstractProperty
         $subAssertions = [];
 
         foreach ($this->subProperties as $prop) {
-            $subAssertions[] = $prop->typeAssertionExpr($expr);
+            $subAssertions[] = $this->typeAssertion($prop, $expr);
         }
 
         return OrGenerator::make($subAssertions);
@@ -418,7 +460,7 @@ class UnionProperty extends AbstractProperty
         $subAssertions = [];
 
         foreach ($this->subProperties as $prop) {
-            $subAssertions[] = $prop->inputAssertionExpr($expr);
+            $subAssertions[] = $this->inputAssertion($prop, $expr);
         }
 
         return OrGenerator::make($subAssertions);
@@ -430,7 +472,7 @@ class UnionProperty extends AbstractProperty
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->inputMappingExpr($expr);
-                $assert = $subProperty->inputAssertionExpr($expr);
+                $assert = $this->inputAssertion($subProperty, $expr);
                 $arms[$map][] = $assert;
             }
 
@@ -447,7 +489,7 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->inputMappingExpr($expr);
-            $assert = $subProperty->inputAssertionExpr($expr);
+            $assert = $this->inputAssertion($subProperty, $expr);
             $conversions[$map][] = $assert;
         }
 
@@ -467,7 +509,7 @@ class UnionProperty extends AbstractProperty
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->outputMappingExpr($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
+                $assert = $this->typeAssertion($subProperty, $expr);
                 $arms[$map][] = $assert;
             }
 
@@ -484,7 +526,7 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->outputMappingExpr($expr);
-            $assert = $subProperty->typeAssertionExpr($expr);
+            $assert = $this->typeAssertion($subProperty, $expr);
             $conversions[$map][] = $assert;
         }
 
@@ -504,7 +546,7 @@ class UnionProperty extends AbstractProperty
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->outputMappingExprStdClass($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
+                $assert = $this->typeAssertion($subProperty, $expr);
                 $arms[$map][] = $assert;
             }
 
@@ -521,7 +563,7 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->outputMappingExprStdClass($expr);
-            $assert = $subProperty->typeAssertionExpr($expr);
+            $assert = $this->typeAssertion($subProperty, $expr);
             $conversions[$map][] = $assert;
         }
 
@@ -541,7 +583,7 @@ class UnionProperty extends AbstractProperty
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->cloneExpr($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
+                $assert = $this->typeAssertion($subProperty, $expr);
                 $arms[$map][] = $assert;
             }
 
@@ -557,7 +599,7 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->cloneExpr($expr);
-            $assert = $subProperty->typeAssertionExpr($expr);
+            $assert = $this->typeAssertion($subProperty, $expr);
             $conversions[$map][] = $assert;
         }
 

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -492,10 +492,7 @@ class MyClass
         $i = null;
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
-                ? ((is_array($input->{'i'})
-                    || is_string($input->{'i'})
-                    || is_array($input->{'i'}) || is_object($input->{'i'})
-                )
+                ? ((is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}))
                     ? $input->{'i'}
                     : null
                 )
@@ -553,10 +550,7 @@ class MyClass
             $output['i'] = ($this->i !== null
                 ? ((is_array($this->i) || is_string($this->i))
                     ? $this->i
-                    : ((is_array($this->i) || is_object($this->i))
-                        ? json_decode(json_encode($this->i), true)
-                        : null
-                    )
+                    : ((is_object($this->i)) ? json_decode(json_encode($this->i), true) : null)
                 )
                 : null
             );
@@ -603,10 +597,7 @@ class MyClass
             $output->{'i'} = ($this->i !== null
                 ? ((is_array($this->i) || is_string($this->i))
                     ? $this->i
-                    : ((is_array($this->i) || is_object($this->i))
-                        ? json_decode(json_encode($this->i))
-                        : null
-                    )
+                    : ((is_object($this->i)) ? json_decode(json_encode($this->i)) : null)
                 )
                 : null
             );
@@ -663,7 +654,7 @@ class MyClass
             $this->h = ((is_array($this->h) || is_string($this->h)) ? $this->h : $this->h);
         }
         if (isset($this->i)) {
-            $this->i = ((is_array($this->i) || is_string($this->i) || is_array($this->i) || is_object($this->i))
+            $this->i = ((is_array($this->i) || is_string($this->i) || is_object($this->i))
                 ? $this->i
                 : $this->i
             );

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -406,10 +406,7 @@ class MyClass
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
                 ? match (true) {
-                    is_array($input->{'i'})
-                        || is_string($input->{'i'})
-                        || is_array($input->{'i'}) || is_object($input->{'i'}) =>
-                        $input->{'i'},
+                    is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}) => $input->{'i'},
                     default => null,
                 }
                 : null
@@ -469,7 +466,7 @@ class MyClass
             $output['i'] = ($this->i !== null
                 ? match (true) {
                     is_array($this->i) || is_string($this->i) => $this->i,
-                    is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), true),
+                    is_object($this->i) => json_decode(json_encode($this->i), true),
                     default => null,
                 }
                 : null
@@ -520,7 +517,7 @@ class MyClass
             $output->{'i'} = ($this->i !== null
                 ? match (true) {
                     is_array($this->i) || is_string($this->i) => $this->i,
-                    is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i)),
+                    is_object($this->i) => json_decode(json_encode($this->i)),
                     default => null,
                 }
                 : null
@@ -587,7 +584,7 @@ class MyClass
         }
         if (isset($this->i)) {
             $this->i = match (true) {
-                is_array($this->i) || is_string($this->i) || is_array($this->i) || is_object($this->i) => $this->i,
+                is_array($this->i) || is_string($this->i) || is_object($this->i) => $this->i,
             };
         }
     }

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -835,17 +835,13 @@ class MyClass
             : null;
         $arrObjUnion = isset($input->{'arrObjUnion'})
             ? match (true) {
-                is_array($input->{'arrObjUnion'})
-                    || is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) =>
-                    $input->{'arrObjUnion'},
+                is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) => $input->{'arrObjUnion'},
                 default => null,
             }
             : null;
         $objArrUnion = isset($input->{'objArrUnion'})
             ? match (true) {
-                is_array($input->{'objArrUnion'})
-                    || is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) =>
-                    $input->{'objArrUnion'},
+                is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) => $input->{'objArrUnion'},
                 default => null,
             }
             : null;
@@ -929,13 +925,13 @@ class MyClass
         if (isset($this->arrObjUnion)) {
             $output['arrObjUnion'] = match (true) {
                 is_array($this->arrObjUnion) => $this->arrObjUnion,
-                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion), true),
+                is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion), true),
             };
         }
         if (isset($this->objArrUnion)) {
             $output['objArrUnion'] = match (true) {
                 is_array($this->objArrUnion) => $this->objArrUnion,
-                is_array($this->objArrUnion) || is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion), true),
+                is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion), true),
             };
         }
         if (isset($this->numKeysDefaults)) {
@@ -1004,13 +1000,13 @@ class MyClass
         if (isset($this->arrObjUnion)) {
             $output->{'arrObjUnion'} = match (true) {
                 is_array($this->arrObjUnion) => $this->arrObjUnion,
-                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion)),
+                is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion)),
             };
         }
         if (isset($this->objArrUnion)) {
             $output->{'objArrUnion'} = match (true) {
                 is_array($this->objArrUnion) => $this->objArrUnion,
-                is_array($this->objArrUnion) || is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion)),
+                is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion)),
             };
         }
         if (isset($this->numKeysDefaults)) {
@@ -1104,12 +1100,12 @@ class MyClass
         }
         if (isset($this->arrObjUnion)) {
             $this->arrObjUnion = match (true) {
-                is_array($this->arrObjUnion) || is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => $this->arrObjUnion,
+                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => $this->arrObjUnion,
             };
         }
         if (isset($this->objArrUnion)) {
             $this->objArrUnion = match (true) {
-                is_array($this->objArrUnion) || is_array($this->objArrUnion) || is_object($this->objArrUnion) => $this->objArrUnion,
+                is_array($this->objArrUnion) || is_object($this->objArrUnion) => $this->objArrUnion,
             };
         }
         if (isset($this->numKeysDefaults)) {

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -426,16 +426,13 @@ class MyClass
                 || (is_int($input->{'qux'}) || is_float($input->{'qux'}))
                 || is_bool($input->{'qux'})
                 || is_array($input->{'qux'})
-                || is_array($input->{'qux'}) || is_object($input->{'qux'}) =>
+                || is_object($input->{'qux'}) =>
                 $input->{'qux'},
             default => throw new \InvalidArgumentException("could not build property 'qux' from JSON"),
         };
         $thud = ($input->{'thud'} !== null
             ? match (true) {
-                is_string($input->{'thud'})
-                    || is_array($input->{'thud'})
-                    || is_array($input->{'thud'}) || is_object($input->{'thud'}) =>
-                    $input->{'thud'},
+                is_string($input->{'thud'}) || is_array($input->{'thud'}) || is_object($input->{'thud'}) => $input->{'thud'},
                 (is_int($input->{'thud'}) || is_float($input->{'thud'})) =>
                     (str_contains((string)$input->{'thud'}, '.')
                         ? (float)$input->{'thud'}
@@ -484,10 +481,7 @@ class MyClass
             : null;
         $optQux = isset($input->{'optQux'})
             ? match (true) {
-                is_string($input->{'optQux'})
-                    || is_array($input->{'optQux'})
-                    || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) =>
-                    $input->{'optQux'},
+                is_string($input->{'optQux'}) || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) => $input->{'optQux'},
                 (is_int($input->{'optQux'}) || is_float($input->{'optQux'})) =>
                     (str_contains((string)$input->{'optQux'}, '.')
                         ? (float)$input->{'optQux'}
@@ -501,10 +495,7 @@ class MyClass
         if (property_exists($input, 'optThud')) {
             $optThud = ($input->{'optThud'} !== null
                 ? match (true) {
-                    is_string($input->{'optThud'})
-                        || is_array($input->{'optThud'})
-                        || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) =>
-                        $input->{'optThud'},
+                    is_string($input->{'optThud'}) || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) => $input->{'optThud'},
                     (is_int($input->{'optThud'}) || is_float($input->{'optThud'})) =>
                         (str_contains((string)$input->{'optThud'}, '.')
                             ? (float)$input->{'optThud'}
@@ -569,7 +560,7 @@ class MyClass
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
                 $this->qux,
-            is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux), true),
+            is_object($this->qux) => json_decode(json_encode($this->qux), true),
         };
         $output['thud'] = match (true) {
             is_string($this->thud)
@@ -577,7 +568,7 @@ class MyClass
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
                 $this->thud,
-            is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud), true),
+            is_object($this->thud) => json_decode(json_encode($this->thud), true),
         };
         if (isset($this->optFoo)) {
             $output['optFoo'] = match (true) {
@@ -612,7 +603,7 @@ class MyClass
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
                     $this->optQux,
-                is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux), true),
+                is_object($this->optQux) => json_decode(json_encode($this->optQux), true),
             };
         }
         if (isset($this->optThud) || array_key_exists('optThud', $this->_providedOptionals)) {
@@ -623,7 +614,7 @@ class MyClass
                         || is_bool($this->optThud)
                         || is_array($this->optThud) =>
                         $this->optThud,
-                    is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud), true),
+                    is_object($this->optThud) => json_decode(json_encode($this->optThud), true),
                     default => null,
                 }
                 : null
@@ -662,7 +653,7 @@ class MyClass
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
                 $this->qux,
-            is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux)),
+            is_object($this->qux) => json_decode(json_encode($this->qux)),
         };
         $output->{'thud'} = match (true) {
             is_string($this->thud)
@@ -670,7 +661,7 @@ class MyClass
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
                 $this->thud,
-            is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud)),
+            is_object($this->thud) => json_decode(json_encode($this->thud)),
         };
         if (isset($this->optFoo)) {
             $output->{'optFoo'} = match (true) {
@@ -705,7 +696,7 @@ class MyClass
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
                     $this->optQux,
-                is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux)),
+                is_object($this->optQux) => json_decode(json_encode($this->optQux)),
             };
         }
         if (isset($this->optThud) || array_key_exists('optThud', $this->_providedOptionals)) {
@@ -716,7 +707,7 @@ class MyClass
                         || is_bool($this->optThud)
                         || is_array($this->optThud) =>
                         $this->optThud,
-                    is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud)),
+                    is_object($this->optThud) => json_decode(json_encode($this->optThud)),
                     default => null,
                 }
                 : null
@@ -787,7 +778,7 @@ class MyClass
                 || (is_int($this->qux) || is_float($this->qux))
                 || is_bool($this->qux)
                 || is_array($this->qux)
-                || is_array($this->qux) || is_object($this->qux) =>
+                || is_object($this->qux) =>
                 $this->qux,
         };
         $this->thud = match (true) {
@@ -795,7 +786,7 @@ class MyClass
                 || (is_int($this->thud) || is_float($this->thud))
                 || is_bool($this->thud)
                 || is_array($this->thud)
-                || is_array($this->thud) || is_object($this->thud) =>
+                || is_object($this->thud) =>
                 $this->thud,
         };
         if (isset($this->optFoo)) {
@@ -830,7 +821,7 @@ class MyClass
                     || (is_int($this->optQux) || is_float($this->optQux))
                     || is_bool($this->optQux)
                     || is_array($this->optQux)
-                    || is_array($this->optQux) || is_object($this->optQux) =>
+                    || is_object($this->optQux) =>
                     $this->optQux,
             };
         }
@@ -840,7 +831,7 @@ class MyClass
                     || (is_int($this->optThud) || is_float($this->optThud))
                     || is_bool($this->optThud)
                     || is_array($this->optThud)
-                    || is_array($this->optThud) || is_object($this->optThud) =>
+                    || is_object($this->optThud) =>
                     $this->optThud,
             };
         }


### PR DESCRIPTION
## Summary
- avoid redundant `is_array` checks when unions include both array and object types
- update snapshots for fixtures affected by streamlined union assertions

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68a041c9172c832daff377cae90fbea8