### PR TITLE
Skip no-op conversions in union property

### DIFF
--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -447,11 +447,14 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->inputMappingExpr($expr);
+            if ($map === 'null') {
+                continue;
+            }
             $assert = $subProperty->inputAssertionExpr($expr);
             $conversions[$map][] = $assert;
         }
 
-        $out = "null";
+        $out = 'null';
         foreach (array_reverse($conversions) as $map => $asserts) {
             $conditions = array_values(array_unique($asserts));
             $cond = OrGenerator::make($conditions);
@@ -484,11 +487,14 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->outputMappingExpr($expr);
+            if ($map === 'null') {
+                continue;
+            }
             $assert = $subProperty->typeAssertionExpr($expr);
             $conversions[$map][] = $assert;
         }
 
-        $out = "null";
+        $out = 'null';
         foreach (array_reverse($conversions) as $map => $asserts) {
             $conditions = array_values(array_unique($asserts));
             $cond = OrGenerator::make($conditions);
@@ -521,11 +527,14 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->outputMappingExprStdClass($expr);
+            if ($map === 'null') {
+                continue;
+            }
             $assert = $subProperty->typeAssertionExpr($expr);
             $conversions[$map][] = $assert;
         }
 
-        $out = "null";
+        $out = 'null';
         foreach (array_reverse($conversions) as $map => $asserts) {
             $conditions = array_values(array_unique($asserts));
             $cond = OrGenerator::make($conditions);
@@ -557,6 +566,9 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->cloneExpr($expr);
+            if ($map === $expr) {
+                continue;
+            }
             $assert = $subProperty->typeAssertionExpr($expr);
             $conversions[$map][] = $assert;
         }

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
@@ -293,11 +293,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = ((is_string($this->foo) || is_int($this->foo)) ? $this->foo : $this->foo);
-        }
-    }
 }

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -652,24 +652,6 @@ class MyClass
         return $validator->isValid();
     }
 
-    public function __clone()
-    {
-        $this->b = ((is_array($this->b) || is_string($this->b)) ? $this->b : $this->b);
-        $this->d = ((is_array($this->d) || is_string($this->d)) ? $this->d : $this->d);
-        if (isset($this->f)) {
-            $this->f = ((is_array($this->f) || is_string($this->f)) ? $this->f : $this->f);
-        }
-        if (isset($this->h)) {
-            $this->h = ((is_array($this->h) || is_string($this->h)) ? $this->h : $this->h);
-        }
-        if (isset($this->i)) {
-            $this->i = ((is_array($this->i) || is_string($this->i) || is_array($this->i) || is_object($this->i))
-                ? $this->i
-                : $this->i
-            );
-        }
-    }
-
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
@@ -281,17 +281,4 @@ class BarTest
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->exampleProp)) {
-            $this->exampleProp = (($this->exampleProp instanceof FooTest
-                || $this->exampleProp instanceof MoiKlass
-                || $this->exampleProp instanceof FooTest_1
-            )
-                ? $this->exampleProp
-                : $this->exampleProp
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -270,17 +270,4 @@ class BarTest
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->exampleProp)) {
-            $this->exampleProp = (($this->exampleProp instanceof FooTest
-                || $this->exampleProp instanceof MoiKlass
-                || $this->exampleProp instanceof FooTest_1
-            )
-                ? $this->exampleProp
-                : $this->exampleProp
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -2672,7 +2672,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             )
                 ? clone $this->ensureArgs1
-                : ((is_string($this->ensureArgs1)) ? $this->ensureArgs1 : $this->ensureArgs1)
+                : $this->ensureArgs1
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -1696,7 +1696,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             )
                 ? clone $this->ensureArgs1
-                : ((is_string($this->ensureArgs1)) ? $this->ensureArgs1 : $this->ensureArgs1)
+                : $this->ensureArgs1
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -2672,7 +2672,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             )
                 ? clone $this->ensureArgs1
-                : ((is_string($this->ensureArgs1)) ? $this->ensureArgs1 : $this->ensureArgs1)
+                : $this->ensureArgs1
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -1696,7 +1696,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             )
                 ? clone $this->ensureArgs1
-                : ((is_string($this->ensureArgs1)) ? $this->ensureArgs1 : $this->ensureArgs1)
+                : $this->ensureArgs1
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
@@ -272,14 +272,4 @@ class Baz
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->grox)) {
-            $this->grox = (($this->grox instanceof Foo || $this->grox instanceof Bar)
-                ? $this->grox
-                : $this->grox
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -301,20 +301,4 @@ class Qux
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->grox)) {
-            $this->grox = ((is_string($this->grox) || is_array($this->grox))
-                ? $this->grox
-                : ((($this->grox instanceof Foo || $this->grox instanceof Bar))
-                    ? (($this->grox instanceof Foo || $this->grox instanceof Bar)
-                        ? $this->grox
-                        : $this->grox
-                    )
-                    : $this->grox
-                )
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -261,14 +261,4 @@ class Baz
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->grox)) {
-            $this->grox = (($this->grox instanceof Foo || $this->grox instanceof Bar)
-                ? $this->grox
-                : $this->grox
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -290,20 +290,4 @@ class Qux
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->grox)) {
-            $this->grox = ((is_string($this->grox) || is_array($this->grox))
-                ? $this->grox
-                : ((($this->grox instanceof Foo || $this->grox instanceof Bar))
-                    ? (($this->grox instanceof Foo || $this->grox instanceof Bar)
-                        ? $this->grox
-                        : $this->grox
-                    )
-                    : $this->grox
-                )
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -302,18 +302,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = ((is_string($this->foo) || is_array($this->foo) || is_object($this->foo))
-            ? $this->foo
-            : $this->foo
-        );
-        if (isset($this->bar)) {
-            $this->bar = ((is_string($this->bar) || is_array($this->bar) || is_object($this->bar))
-                ? $this->bar
-                : $this->bar
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -289,18 +289,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = ((is_string($this->foo) || is_array($this->foo) || is_object($this->foo))
-            ? $this->foo
-            : $this->foo
-        );
-        if (isset($this->bar)) {
-            $this->bar = ((is_string($this->bar) || is_array($this->bar) || is_object($this->bar))
-                ? $this->bar
-                : $this->bar
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-5.6/MyClass.php
@@ -243,9 +243,6 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = ((is_string($this->foo))
-            ? $this->foo
-            : (($this->foo instanceof MyClassFooAlternative2) ? clone $this->foo : $this->foo)
-        );
+        $this->foo = (($this->foo instanceof MyClassFooAlternative2) ? clone $this->foo : $this->foo);
     }
 }

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClass.php
@@ -235,9 +235,6 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = ((is_string($this->foo))
-            ? $this->foo
-            : (($this->foo instanceof MyClassFooAlternative2) ? clone $this->foo : $this->foo)
-        );
+        $this->foo = (($this->foo instanceof MyClassFooAlternative2) ? clone $this->foo : $this->foo);
     }
 }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-5.6/Record.php
@@ -505,15 +505,17 @@ class Record
             );
         }
         if (isset($this->dataArrayAnyOf)) {
-            $this->dataArrayAnyOf = array_map(function($i) {
-                return (($i instanceof Phone || $i instanceof Fio) ? $i : $i);
-            }, $this->dataArrayAnyOf);
+            $this->dataArrayAnyOf = array_map(
+                function($i) { return $i; },
+                $this->dataArrayAnyOf
+            );
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $this->dataArrayNestedAnyOf = array_map(function($i) {
-                return array_map(function($i) {
-                    return (($i instanceof Phone || $i instanceof Fio) ? $i : $i);
-                }, $i);
+                return array_map(
+                    function($i) { return $i; },
+                    $i
+                );
             }, $this->dataArrayNestedAnyOf);
         }
     }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-7.4/Record.php
@@ -457,13 +457,10 @@ class Record
             $this->dataArrayNested = array_map(fn ($i) => $i, $this->dataArrayNested);
         }
         if (isset($this->dataArrayAnyOf)) {
-            $this->dataArrayAnyOf = array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i : $i), $this->dataArrayAnyOf);
+            $this->dataArrayAnyOf = array_map(fn ($i) => $i, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
-            $this->dataArrayNestedAnyOf = array_map(
-                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i : $i), $i),
-                $this->dataArrayNestedAnyOf,
-            );
+            $this->dataArrayNestedAnyOf = array_map(fn ($i) => array_map(fn ($i) => $i, $i), $this->dataArrayNestedAnyOf);
         }
     }
 }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
@@ -177,12 +177,4 @@ class MyObject
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = ((in_array($this->foo, ['foo', 'bar'], true) || in_array($this->foo, ['baz', 'quz'], true))
-            ? $this->foo
-            : $this->foo
-        );
-    }
 }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
@@ -176,12 +176,4 @@ class MyObject
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = ((in_array($this->foo, ['foo', 'bar'], true) || in_array($this->foo, ['baz', 'quz'], true))
-            ? $this->foo
-            : $this->foo
-        );
-    }
 }

--- a/tests/Generator/Fixtures/SettersValidation/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-5.6/Foo.php
@@ -460,13 +460,6 @@ class Foo
         return $validator->isValid();
     }
 
-    public function __clone()
-    {
-        if (isset($this->a)) {
-            $this->a = ((in_array($this->a, ['a', 'b'], true) || is_array($this->a)) ? $this->a : $this->a);
-        }
-    }
-
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/SettersValidation/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-7.4/Foo.php
@@ -422,13 +422,6 @@ class Foo
         return $validator->isValid();
     }
 
-    public function __clone()
-    {
-        if (isset($this->a)) {
-            $this->a = ((in_array($this->a, ['a', 'b'], true) || is_array($this->a)) ? $this->a : $this->a);
-        }
-    }
-
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
@@ -248,14 +248,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = ((is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)))
-                ? $this->foo
-                : $this->foo
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
@@ -237,14 +237,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = ((is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)))
-                ? $this->foo
-                : $this->foo
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
@@ -654,24 +654,24 @@ class MyClass
             $this->arrayOfUnions = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : $i), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : $i) : $i)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $this->arrayOfRefUnions = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : $i), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : $i) : $i)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $this->arrayOfRefAndNotRefUnions = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : $i), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : $i) : $i)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
@@ -679,7 +679,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => is_array($i))))
             )
                 ? array_map(fn ($i) => $i, $i)
-                : ((is_string($i)) ? $i : $i)
+                : $i
             ), $this->arrayOfUnionOfStringAndArray);
         }
         if (isset($this->arrayOfUnionWithOneType)) {

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
@@ -942,10 +942,7 @@ class MyClass
                     fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => clone $i,
                     $this->arrayOfObjAndStringUnion,
                 )
-                : ((is_string($this->arrayOfObjAndStringUnion))
-                    ? $this->arrayOfObjAndStringUnion
-                    : $this->arrayOfObjAndStringUnion
-                )
+                : $this->arrayOfObjAndStringUnion
             );
         }
         if (isset($this->unionOfOneArrayOfObjects)) {

--- a/tests/Generator/Fixtures/UnionArrayTyped/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayTyped/Output-7.4/MyClass.php
@@ -529,32 +529,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->unionOfTypedArrays)) {
-            $this->unionOfTypedArrays = ((is_array($this->unionOfTypedArrays))
-                ? $this->unionOfTypedArrays
-                : $this->unionOfTypedArrays
-            );
-        }
-        if (isset($this->refUnionOfTypedArrays)) {
-            $this->refUnionOfTypedArrays = ((is_array($this->refUnionOfTypedArrays))
-                ? $this->refUnionOfTypedArrays
-                : $this->refUnionOfTypedArrays
-            );
-        }
-        if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            $this->refAndNotRefUnionOfTypedArrays = ((is_array($this->refAndNotRefUnionOfTypedArrays))
-                ? $this->refAndNotRefUnionOfTypedArrays
-                : $this->refAndNotRefUnionOfTypedArrays
-            );
-        }
-        if (isset($this->unionOfTypedArrayAndString)) {
-            $this->unionOfTypedArrayAndString = ((is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString))
-                ? $this->unionOfTypedArrayAndString
-                : $this->unionOfTypedArrayAndString
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
@@ -410,12 +410,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = ((is_string($this->foo)) ? $this->foo : $this->foo);
-        $this->bar = ((is_string($this->bar)) ? $this->bar : $this->bar);
-        $this->baz = ((is_string($this->baz)) ? $this->baz : $this->baz);
-        $this->qux = ((is_string($this->qux)) ? $this->qux : $this->qux);
-    }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -354,12 +354,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = ((is_string($this->foo)) ? $this->foo : $this->foo);
-        $this->bar = ((is_string($this->bar)) ? $this->bar : $this->bar);
-        $this->baz = ((is_string($this->baz)) ? $this->baz : $this->baz);
-        $this->qux = ((is_string($this->qux)) ? $this->qux : $this->qux);
-    }
 }

--- a/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
@@ -640,32 +640,18 @@ class MyClass
                 : $this->objectsUnion
             );
         }
-        if (isset($this->refObjectsUnion)) {
-            $this->refObjectsUnion = (($this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2)
-                ? $this->refObjectsUnion
-                : $this->refObjectsUnion
-            );
-        }
         if (isset($this->refAndNotRefObjectsUnion)) {
-            $this->refAndNotRefObjectsUnion = (($this->refAndNotRefObjectsUnion instanceof SomeObj1
-                || $this->refAndNotRefObjectsUnion instanceof SomeObj2
+            $this->refAndNotRefObjectsUnion = (($this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
+                || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4
             )
-                ? $this->refAndNotRefObjectsUnion
-                : (($this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
-                    || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4
-                )
-                    ? clone $this->refAndNotRefObjectsUnion
-                    : $this->refAndNotRefObjectsUnion
-                )
+                ? clone $this->refAndNotRefObjectsUnion
+                : $this->refAndNotRefObjectsUnion
             );
         }
         if (isset($this->objAndStringUnion)) {
             $this->objAndStringUnion = (($this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1)
                 ? clone $this->objAndStringUnion
-                : ((is_string($this->objAndStringUnion))
-                    ? $this->objAndStringUnion
-                    : $this->objAndStringUnion
-                )
+                : $this->objAndStringUnion
             );
         }
         if (isset($this->unionOfOneObj)) {


### PR DESCRIPTION
## Summary
- avoid passing identical branches to TernaryGenerator by skipping conversions that return the fallback value in union properties
- update generated fixture outputs to reflect new cloning logic

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68a051378c1c832db56c25040c4be84a