### PR TITLE
Fix union property cloning with identical branches

### DIFF
--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -453,6 +453,9 @@ class UnionProperty extends AbstractProperty
 
         $out = "null";
         foreach (array_reverse($conversions) as $map => $asserts) {
+            if ($map === $out) {
+                continue;
+            }
             $conditions = array_values(array_unique($asserts));
             $cond = OrGenerator::make($conditions);
             $out = TernaryGenerator::make($cond, $map, $out);
@@ -490,6 +493,9 @@ class UnionProperty extends AbstractProperty
 
         $out = "null";
         foreach (array_reverse($conversions) as $map => $asserts) {
+            if ($map === $out) {
+                continue;
+            }
             $conditions = array_values(array_unique($asserts));
             $cond = OrGenerator::make($conditions);
             $out = TernaryGenerator::make($cond, $map, $out);
@@ -527,6 +533,9 @@ class UnionProperty extends AbstractProperty
 
         $out = "null";
         foreach (array_reverse($conversions) as $map => $asserts) {
+            if ($map === $out) {
+                continue;
+            }
             $conditions = array_values(array_unique($asserts));
             $cond = OrGenerator::make($conditions);
             $out = TernaryGenerator::make($cond, $map, $out);
@@ -563,6 +572,9 @@ class UnionProperty extends AbstractProperty
 
         $out = $expr;
         foreach (array_reverse($conversions) as $map => $asserts) {
+            if ($map === $out) {
+                continue;
+            }
             $conditions = array_values(array_unique($asserts));
             $cond = OrGenerator::make($conditions);
             $out = TernaryGenerator::make($cond, $map, $out);

--- a/src/Generator/Property/Type/ReferenceProperty.php
+++ b/src/Generator/Property/Type/ReferenceProperty.php
@@ -6,6 +6,7 @@ namespace Helmich\Schema2Class\Generator\Property\Type;
 use Helmich\Schema2Class\Generator\GeneratorRequest;
 use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeInterface;
 use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeEnum;
+use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeClass;
 
 /**
  * Property that refers to a generated PHP artifact (class, Enum) via `$ref`.
@@ -58,6 +59,13 @@ class ReferenceProperty extends AbstractProperty
     public function outputMappingExprStdClass(string $expr): string
     {
         return $this->refType->outputMappingExprStdClass($expr);
+    }
+
+    public function cloneExpr(string $expr): string
+    {
+        return $this->refType instanceof ReferencedTypeClass
+            ? "clone {$expr}"
+            : $expr;
     }
 
     public function needsValidation(): bool

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
@@ -293,11 +293,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = ((is_string($this->foo) || is_int($this->foo)) ? $this->foo : $this->foo);
-        }
-    }
 }

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -652,24 +652,6 @@ class MyClass
         return $validator->isValid();
     }
 
-    public function __clone()
-    {
-        $this->b = ((is_array($this->b) || is_string($this->b)) ? $this->b : $this->b);
-        $this->d = ((is_array($this->d) || is_string($this->d)) ? $this->d : $this->d);
-        if (isset($this->f)) {
-            $this->f = ((is_array($this->f) || is_string($this->f)) ? $this->f : $this->f);
-        }
-        if (isset($this->h)) {
-            $this->h = ((is_array($this->h) || is_string($this->h)) ? $this->h : $this->h);
-        }
-        if (isset($this->i)) {
-            $this->i = ((is_array($this->i) || is_string($this->i) || is_array($this->i) || is_object($this->i))
-                ? $this->i
-                : $this->i
-            );
-        }
-    }
-
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/Definitions/Output-5.6/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-5.6/Address.php
@@ -278,4 +278,11 @@ class Address
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->name)) {
+            $this->name = clone $this->name;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/Definitions/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-5.6/MyClass.php
@@ -231,4 +231,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->address)) {
+            $this->address = clone $this->address;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/Address.php
@@ -237,4 +237,11 @@ class Address
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->name)) {
+            $this->name = clone $this->name;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/Definitions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-7.4/MyClass.php
@@ -197,4 +197,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->address)) {
+            $this->address = clone $this->address;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/Address.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/Address.php
@@ -230,4 +230,11 @@ class Address
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->name)) {
+            $this->name = clone $this->name;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/Definitions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Definitions/Output-8.4/MyClass.php
@@ -191,4 +191,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->address)) {
+            $this->address = clone $this->address;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-5.6/Bar.php
@@ -230,4 +230,11 @@ class Bar
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->a)) {
+            $this->a = clone $this->a;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-7.4/Bar.php
@@ -209,4 +209,11 @@ class Bar
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->a)) {
+            $this->a = clone $this->a;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Bar.php
+++ b/tests/Generator/Fixtures/DefinitionsPropertyRef/Output-8.4/Bar.php
@@ -202,4 +202,11 @@ class Bar
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->a)) {
+            $this->a = clone $this->a;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/Descriptions/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-5.6/MyClass.php
@@ -299,4 +299,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->bar)) {
+            $this->bar = clone $this->bar;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/Descriptions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-7.4/MyClass.php
@@ -257,4 +257,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->bar)) {
+            $this->bar = clone $this->bar;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/Descriptions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/Descriptions/Output-8.4/MyClass.php
@@ -250,4 +250,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->bar)) {
+            $this->bar = clone $this->bar;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/EncodedRef/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-5.6/Baz.php
@@ -334,4 +334,17 @@ class Baz
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->a)) {
+            $this->a = clone $this->a;
+        }
+        if (isset($this->b)) {
+            $this->b = clone $this->b;
+        }
+        if (isset($this->c)) {
+            $this->c = clone $this->c;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/EncodedRef/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-7.4/Baz.php
@@ -287,4 +287,17 @@ class Baz
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->a)) {
+            $this->a = clone $this->a;
+        }
+        if (isset($this->b)) {
+            $this->b = clone $this->b;
+        }
+        if (isset($this->c)) {
+            $this->c = clone $this->c;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/EncodedRef/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/EncodedRef/Output-8.4/Baz.php
@@ -280,4 +280,17 @@ class Baz
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->a)) {
+            $this->a = clone $this->a;
+        }
+        if (isset($this->b)) {
+            $this->b = clone $this->b;
+        }
+        if (isset($this->c)) {
+            $this->c = clone $this->c;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
@@ -289,7 +289,7 @@ class BarTest
                 || $this->exampleProp instanceof MoiKlass
                 || $this->exampleProp instanceof FooTest_1
             )
-                ? $this->exampleProp
+                ? clone $this->exampleProp
                 : $this->exampleProp
             );
         }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -278,7 +278,7 @@ class BarTest
                 || $this->exampleProp instanceof MoiKlass
                 || $this->exampleProp instanceof FooTest_1
             )
-                ? $this->exampleProp
+                ? clone $this->exampleProp
                 : $this->exampleProp
             );
         }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
@@ -253,7 +253,7 @@ class BarTest
                 $this->exampleProp instanceof FooTest
                     || $this->exampleProp instanceof MoiKlass
                     || $this->exampleProp instanceof FooTest_1 =>
-                    $this->exampleProp,
+                    clone $this->exampleProp,
             };
         }
     }

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -2672,7 +2672,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             )
                 ? clone $this->ensureArgs1
-                : ((is_string($this->ensureArgs1)) ? $this->ensureArgs1 : $this->ensureArgs1)
+                : $this->ensureArgs1
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -1696,7 +1696,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             )
                 ? clone $this->ensureArgs1
-                : ((is_string($this->ensureArgs1)) ? $this->ensureArgs1 : $this->ensureArgs1)
+                : $this->ensureArgs1
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -2672,7 +2672,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             )
                 ? clone $this->ensureArgs1
-                : ((is_string($this->ensureArgs1)) ? $this->ensureArgs1 : $this->ensureArgs1)
+                : $this->ensureArgs1
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -1696,7 +1696,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             )
                 ? clone $this->ensureArgs1
-                : ((is_string($this->ensureArgs1)) ? $this->ensureArgs1 : $this->ensureArgs1)
+                : $this->ensureArgs1
             );
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -1084,22 +1084,26 @@ class MyClass
         }
         if (isset($this->xyyz)) {
             $this->xyyz = match (true) {
-                is_string($this->xyyz) || $this->xyyz instanceof ObjDef || is_array($this->xyyz) => $this->xyyz,
+                is_string($this->xyyz) || is_array($this->xyyz) => $this->xyyz,
+                $this->xyyz instanceof ObjDef => clone $this->xyyz,
             };
         }
         if (isset($this->buux)) {
             $this->buux = match (true) {
-                is_string($this->buux) || is_array($this->buux) || $this->buux instanceof ObjDef => $this->buux,
+                is_string($this->buux) || is_array($this->buux) => $this->buux,
+                $this->buux instanceof ObjDef => clone $this->buux,
             };
         }
         if (isset($this->boic)) {
             $this->boic = match (true) {
-                is_string($this->boic) || is_array($this->boic) || $this->boic instanceof ObjDef => $this->boic,
+                is_string($this->boic) || is_array($this->boic) => $this->boic,
+                $this->boic instanceof ObjDef => clone $this->boic,
             };
         }
         if (isset($this->poox)) {
             $this->poox = match (true) {
-                is_string($this->poox) || $this->poox instanceof NumericKeysObj => $this->poox,
+                is_string($this->poox) => $this->poox,
+                $this->poox instanceof NumericKeysObj => clone $this->poox,
             };
         }
         if (isset($this->arrObjUnion)) {

--- a/tests/Generator/Fixtures/MutableSetters/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-5.6/MyClass.php
@@ -314,6 +314,11 @@ class MyClass
         return $validator->isValid();
     }
 
+    public function __clone()
+    {
+        $this->bar = clone $this->bar;
+    }
+
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-7.4/MyClass.php
@@ -271,6 +271,11 @@ class MyClass
         return $validator->isValid();
     }
 
+    public function __clone()
+    {
+        $this->bar = clone $this->bar;
+    }
+
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSetters/Output-8.4/MyClass.php
@@ -264,6 +264,11 @@ class MyClass
         return $validator->isValid();
     }
 
+    public function __clone()
+    {
+        $this->bar = clone $this->bar;
+    }
+
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-5.6/MyClass.php
@@ -341,6 +341,11 @@ class MyClass
         return $validator->isValid();
     }
 
+    public function __clone()
+    {
+        $this->bar = clone $this->bar;
+    }
+
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-7.4/MyClass.php
@@ -284,6 +284,11 @@ class MyClass
         return $validator->isValid();
     }
 
+    public function __clone()
+    {
+        $this->bar = clone $this->bar;
+    }
+
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MutableSettersChainable/Output-8.4/MyClass.php
@@ -277,6 +277,11 @@ class MyClass
         return $validator->isValid();
     }
 
+    public function __clone()
+    {
+        $this->bar = clone $this->bar;
+    }
+
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClass.php
@@ -311,5 +311,8 @@ class MyClass
                 $this->files
             );
         }
+        if (isset($this->options)) {
+            $this->options = clone $this->options;
+        }
     }
 }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-5.6/MyClassFilesItem.php
@@ -288,4 +288,11 @@ class MyClassFilesItem
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->options)) {
+            $this->options = clone $this->options;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClass.php
@@ -279,5 +279,8 @@ class MyClass
         if (isset($this->files)) {
             $this->files = array_map(fn (MyClassFilesItem $i) => clone $i, $this->files);
         }
+        if (isset($this->options)) {
+            $this->options = clone $this->options;
+        }
     }
 }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-7.4/MyClassFilesItem.php
@@ -244,4 +244,11 @@ class MyClassFilesItem
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->options)) {
+            $this->options = clone $this->options;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClass.php
@@ -272,5 +272,8 @@ class MyClass
         if (isset($this->files)) {
             $this->files = array_map(fn (MyClassFilesItem $i) => clone $i, $this->files);
         }
+        if (isset($this->options)) {
+            $this->options = clone $this->options;
+        }
     }
 }

--- a/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
+++ b/tests/Generator/Fixtures/NestedSchemaRefs/Output-8.4/MyClassFilesItem.php
@@ -237,4 +237,11 @@ class MyClassFilesItem
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->options)) {
+            $this->options = clone $this->options;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
@@ -277,7 +277,7 @@ class Baz
     {
         if (isset($this->grox)) {
             $this->grox = (($this->grox instanceof Foo || $this->grox instanceof Bar)
-                ? $this->grox
+                ? clone $this->grox
                 : $this->grox
             );
         }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -309,7 +309,7 @@ class Qux
                 ? $this->grox
                 : ((($this->grox instanceof Foo || $this->grox instanceof Bar))
                     ? (($this->grox instanceof Foo || $this->grox instanceof Bar)
-                        ? $this->grox
+                        ? clone $this->grox
                         : $this->grox
                     )
                     : $this->grox

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -266,7 +266,7 @@ class Baz
     {
         if (isset($this->grox)) {
             $this->grox = (($this->grox instanceof Foo || $this->grox instanceof Bar)
-                ? $this->grox
+                ? clone $this->grox
                 : $this->grox
             );
         }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -298,7 +298,7 @@ class Qux
                 ? $this->grox
                 : ((($this->grox instanceof Foo || $this->grox instanceof Bar))
                     ? (($this->grox instanceof Foo || $this->grox instanceof Bar)
-                        ? $this->grox
+                        ? clone $this->grox
                         : $this->grox
                     )
                     : $this->grox

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
@@ -243,7 +243,7 @@ class Baz
     {
         if (isset($this->grox)) {
             $this->grox = match (true) {
-                $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox,
+                $this->grox instanceof Foo || $this->grox instanceof Bar => clone $this->grox,
             };
         }
     }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
@@ -288,7 +288,7 @@ class Qux
                 is_string($this->grox) || is_array($this->grox) => $this->grox,
                 ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
                     match (true) {
-                        $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox,
+                        $this->grox instanceof Foo || $this->grox instanceof Bar => clone $this->grox,
                     },
             };
         }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -302,18 +302,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = ((is_string($this->foo) || is_array($this->foo) || is_object($this->foo))
-            ? $this->foo
-            : $this->foo
-        );
-        if (isset($this->bar)) {
-            $this->bar = ((is_string($this->bar) || is_array($this->bar) || is_object($this->bar))
-                ? $this->bar
-                : $this->bar
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -289,18 +289,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = ((is_string($this->foo) || is_array($this->foo) || is_object($this->foo))
-            ? $this->foo
-            : $this->foo
-        );
-        if (isset($this->bar)) {
-            $this->bar = ((is_string($this->bar) || is_array($this->bar) || is_object($this->bar))
-                ? $this->bar
-                : $this->bar
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyClass.php
@@ -175,4 +175,9 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        $this->value = clone $this->value;
+    }
 }

--- a/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumberField.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyGenericStringNumberField.php
@@ -177,4 +177,11 @@ class MyGenericStringNumberField
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->field)) {
+            $this->field = clone $this->field;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyRecursiveObject.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-5.6/MyRecursiveObject.php
@@ -168,4 +168,11 @@ class MyRecursiveObject
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->MyRecursiveObject)) {
+            $this->MyRecursiveObject = clone $this->MyRecursiveObject;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyClass.php
@@ -173,4 +173,9 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        $this->value = clone $this->value;
+    }
 }

--- a/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumberField.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyGenericStringNumberField.php
@@ -163,4 +163,11 @@ class MyGenericStringNumberField
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->field)) {
+            $this->field = clone $this->field;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyRecursiveObject.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-7.4/MyRecursiveObject.php
@@ -154,4 +154,11 @@ class MyRecursiveObject
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->MyRecursiveObject)) {
+            $this->MyRecursiveObject = clone $this->MyRecursiveObject;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyClass.php
@@ -167,4 +167,9 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        $this->value = clone $this->value;
+    }
 }

--- a/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumberField.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyGenericStringNumberField.php
@@ -157,4 +157,11 @@ class MyGenericStringNumberField
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->field)) {
+            $this->field = clone $this->field;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyRecursiveObject.php
+++ b/tests/Generator/Fixtures/RecursiveField/Output-8.4/MyRecursiveObject.php
@@ -148,4 +148,11 @@ class MyRecursiveObject
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->MyRecursiveObject)) {
+            $this->MyRecursiveObject = clone $this->MyRecursiveObject;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Pets.php
+++ b/tests/Generator/Fixtures/RefAnnotations/Output-8.4/Pets.php
@@ -255,4 +255,14 @@ class Pets
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->pet)) {
+            $this->pet = clone $this->pet;
+        }
+        if (isset($this->cat)) {
+            $this->cat = clone $this->cat;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-5.6/Record.php
@@ -506,13 +506,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $this->dataArrayAnyOf = array_map(function($i) {
-                return (($i instanceof Phone || $i instanceof Fio) ? $i : $i);
+                return (($i instanceof Phone || $i instanceof Fio) ? clone $i : $i);
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $this->dataArrayNestedAnyOf = array_map(function($i) {
                 return array_map(function($i) {
-                    return (($i instanceof Phone || $i instanceof Fio) ? $i : $i);
+                    return (($i instanceof Phone || $i instanceof Fio) ? clone $i : $i);
                 }, $i);
             }, $this->dataArrayNestedAnyOf);
         }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-7.4/Record.php
@@ -457,11 +457,14 @@ class Record
             $this->dataArrayNested = array_map(fn ($i) => $i, $this->dataArrayNested);
         }
         if (isset($this->dataArrayAnyOf)) {
-            $this->dataArrayAnyOf = array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i : $i), $this->dataArrayAnyOf);
+            $this->dataArrayAnyOf = array_map(
+                fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? clone $i : $i),
+                $this->dataArrayAnyOf,
+            );
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $this->dataArrayNestedAnyOf = array_map(
-                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i : $i), $i),
+                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? clone $i : $i), $i),
                 $this->dataArrayNestedAnyOf,
             );
         }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-8.4/Record.php
@@ -459,13 +459,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $this->dataArrayAnyOf = array_map(fn ($i) => match (true) {
-                $i instanceof Phone || $i instanceof Fio => $i,
+                $i instanceof Phone || $i instanceof Fio => clone $i,
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $this->dataArrayNestedAnyOf = array_map(
                 fn ($i) => array_map(fn ($i) => match (true) {
-                    $i instanceof Phone || $i instanceof Fio => $i,
+                    $i instanceof Phone || $i instanceof Fio => clone $i,
                 }, $i),
                 $this->dataArrayNestedAnyOf,
             );

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
@@ -177,12 +177,4 @@ class MyObject
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = ((in_array($this->foo, ['foo', 'bar'], true) || in_array($this->foo, ['baz', 'quz'], true))
-            ? $this->foo
-            : $this->foo
-        );
-    }
 }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
@@ -176,12 +176,4 @@ class MyObject
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = ((in_array($this->foo, ['foo', 'bar'], true) || in_array($this->foo, ['baz', 'quz'], true))
-            ? $this->foo
-            : $this->foo
-        );
-    }
 }

--- a/tests/Generator/Fixtures/SettersValidation/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-5.6/Foo.php
@@ -462,8 +462,8 @@ class Foo
 
     public function __clone()
     {
-        if (isset($this->a)) {
-            $this->a = ((in_array($this->a, ['a', 'b'], true) || is_array($this->a)) ? $this->a : $this->a);
+        if (isset($this->d)) {
+            $this->d = clone $this->d;
         }
     }
 

--- a/tests/Generator/Fixtures/SettersValidation/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-7.4/Foo.php
@@ -424,8 +424,8 @@ class Foo
 
     public function __clone()
     {
-        if (isset($this->a)) {
-            $this->a = ((in_array($this->a, ['a', 'b'], true) || is_array($this->a)) ? $this->a : $this->a);
+        if (isset($this->d)) {
+            $this->d = clone $this->d;
         }
     }
 

--- a/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
@@ -406,6 +406,9 @@ class Foo
                 in_array($this->a, ['a', 'b'], true) || is_array($this->a) => $this->a,
             };
         }
+        if (isset($this->d)) {
+            $this->d = clone $this->d;
+        }
     }
 
     /**

--- a/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
@@ -248,14 +248,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = ((is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)))
-                ? $this->foo
-                : $this->foo
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
@@ -237,14 +237,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = ((is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)))
-                ? $this->foo
-                : $this->foo
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
@@ -654,24 +654,24 @@ class MyClass
             $this->arrayOfUnions = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : $i), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : $i) : $i)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $this->arrayOfRefUnions = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : $i), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : $i) : $i)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $this->arrayOfRefAndNotRefUnions = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : $i), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : $i) : $i)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
@@ -679,7 +679,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => is_array($i))))
             )
                 ? array_map(fn ($i) => $i, $i)
-                : ((is_string($i)) ? $i : $i)
+                : $i
             ), $this->arrayOfUnionOfStringAndArray);
         }
         if (isset($this->arrayOfUnionWithOneType)) {

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
@@ -942,10 +942,7 @@ class MyClass
                     fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => clone $i,
                     $this->arrayOfObjAndStringUnion,
                 )
-                : ((is_string($this->arrayOfObjAndStringUnion))
-                    ? $this->arrayOfObjAndStringUnion
-                    : $this->arrayOfObjAndStringUnion
-                )
+                : $this->arrayOfObjAndStringUnion
             );
         }
         if (isset($this->unionOfOneArrayOfObjects)) {

--- a/tests/Generator/Fixtures/UnionArrayTyped/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayTyped/Output-7.4/MyClass.php
@@ -529,32 +529,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->unionOfTypedArrays)) {
-            $this->unionOfTypedArrays = ((is_array($this->unionOfTypedArrays))
-                ? $this->unionOfTypedArrays
-                : $this->unionOfTypedArrays
-            );
-        }
-        if (isset($this->refUnionOfTypedArrays)) {
-            $this->refUnionOfTypedArrays = ((is_array($this->refUnionOfTypedArrays))
-                ? $this->refUnionOfTypedArrays
-                : $this->refUnionOfTypedArrays
-            );
-        }
-        if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            $this->refAndNotRefUnionOfTypedArrays = ((is_array($this->refAndNotRefUnionOfTypedArrays))
-                ? $this->refAndNotRefUnionOfTypedArrays
-                : $this->refAndNotRefUnionOfTypedArrays
-            );
-        }
-        if (isset($this->unionOfTypedArrayAndString)) {
-            $this->unionOfTypedArrayAndString = ((is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString))
-                ? $this->unionOfTypedArrayAndString
-                : $this->unionOfTypedArrayAndString
-            );
-        }
-    }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
@@ -410,12 +410,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = ((is_string($this->foo)) ? $this->foo : $this->foo);
-        $this->bar = ((is_string($this->bar)) ? $this->bar : $this->bar);
-        $this->baz = ((is_string($this->baz)) ? $this->baz : $this->baz);
-        $this->qux = ((is_string($this->qux)) ? $this->qux : $this->qux);
-    }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -354,12 +354,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = ((is_string($this->foo)) ? $this->foo : $this->foo);
-        $this->bar = ((is_string($this->bar)) ? $this->bar : $this->bar);
-        $this->baz = ((is_string($this->baz)) ? $this->baz : $this->baz);
-        $this->qux = ((is_string($this->qux)) ? $this->qux : $this->qux);
-    }
 }

--- a/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
@@ -642,30 +642,24 @@ class MyClass
         }
         if (isset($this->refObjectsUnion)) {
             $this->refObjectsUnion = (($this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2)
-                ? $this->refObjectsUnion
+                ? clone $this->refObjectsUnion
                 : $this->refObjectsUnion
             );
         }
         if (isset($this->refAndNotRefObjectsUnion)) {
             $this->refAndNotRefObjectsUnion = (($this->refAndNotRefObjectsUnion instanceof SomeObj1
+                || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
                 || $this->refAndNotRefObjectsUnion instanceof SomeObj2
+                || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4
             )
-                ? $this->refAndNotRefObjectsUnion
-                : (($this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
-                    || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4
-                )
-                    ? clone $this->refAndNotRefObjectsUnion
-                    : $this->refAndNotRefObjectsUnion
-                )
+                ? clone $this->refAndNotRefObjectsUnion
+                : $this->refAndNotRefObjectsUnion
             );
         }
         if (isset($this->objAndStringUnion)) {
             $this->objAndStringUnion = (($this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1)
                 ? clone $this->objAndStringUnion
-                : ((is_string($this->objAndStringUnion))
-                    ? $this->objAndStringUnion
-                    : $this->objAndStringUnion
-                )
+                : $this->objAndStringUnion
             );
         }
         if (isset($this->unionOfOneObj)) {

--- a/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
@@ -572,15 +572,14 @@ class MyClass
         }
         if (isset($this->refObjectsUnion)) {
             $this->refObjectsUnion = match (true) {
-                $this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2 => $this->refObjectsUnion,
+                $this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2 => clone $this->refObjectsUnion,
             };
         }
         if (isset($this->refAndNotRefObjectsUnion)) {
             $this->refAndNotRefObjectsUnion = match (true) {
                 $this->refAndNotRefObjectsUnion instanceof SomeObj1
-                    || $this->refAndNotRefObjectsUnion instanceof SomeObj2 =>
-                    $this->refAndNotRefObjectsUnion,
-                $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
+                    || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
+                    || $this->refAndNotRefObjectsUnion instanceof SomeObj2
                     || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4 =>
                     clone $this->refAndNotRefObjectsUnion,
             };


### PR DESCRIPTION
## Summary
- avoid building redundant ternaries in union property expressions
- clone referenced class instances when generating clone methods
- update fixtures

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68a051378c1c832db56c25040c4be84a