### PR TITLE
Fix cloning for raw object unions

### DIFF
--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -557,6 +557,10 @@ class UnionProperty extends AbstractProperty
                 $arms[$map][] = $assert;
             }
 
+            if (count($arms) === 1) {
+                return array_key_first($arms);
+            }
+
             $match = new MatchGenerator("true");
             foreach ($arms as $map => $asserts) {
                 $conditions = array_values(array_unique($asserts));

--- a/src/Generator/Property/Type/Object/RawObjectProperty.php
+++ b/src/Generator/Property/Type/Object/RawObjectProperty.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator\Property\Type\Object;
 
 use Composer\Semver\Semver;
+use Helmich\Schema2Class\Generator\Expression\MatchGenerator;
 use Helmich\Schema2Class\Generator\Property\Type\AbstractProperty;
 
 /**
@@ -46,6 +47,19 @@ class RawObjectProperty extends AbstractProperty
     public function outputMappingExprStdClass(string $expr): string
     {
         return 'json_decode(json_encode(' . $expr . '))';
+    }
+
+    public function cloneExpr(string $expr): string
+    {
+        if ($this->request->isAtLeastPHP('8.0')) {
+            $match = new MatchGenerator('true');
+            $match->addArm('is_object(' . $expr . ')', 'clone ' . $expr);
+            $match->addArm('default', $expr);
+
+            return $match->generate();
+        }
+
+        return 'is_object(' . $expr . ') ? clone ' . $expr . ' : ' . $expr;
     }
 
     public function needsValidation(): bool

--- a/tests/Generator/Fixtures/AdditionalPropertiesNested/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesNested/Output-8.4/MyClass.php
@@ -226,4 +226,14 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->bar)) {
+            $this->bar = match (true) {
+                is_object($this->bar) => clone $this->bar,
+                default => $this->bar,
+            };
+        }
+    }
 }

--- a/tests/Generator/Fixtures/AdditionalPropertiesNestedArr/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesNestedArr/Output-8.4/MyClass.php
@@ -253,7 +253,10 @@ class MyClass
     public function __clone()
     {
         if (isset($this->bar)) {
-            $this->bar = array_map(fn ($i) => $i, $this->bar);
+            $this->bar = array_map(fn ($i) => match (true) {
+                is_object($i) => clone $i,
+                default => $i,
+            }, $this->bar);
         }
     }
 }

--- a/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-5.6/MyClass.php
@@ -282,4 +282,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->params)) {
+            $this->params = is_object($this->params) ? clone $this->params : $this->params;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-7.4/MyClass.php
@@ -249,4 +249,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->params)) {
+            $this->params = is_object($this->params) ? clone $this->params : $this->params;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-8.4/MyClass.php
@@ -230,4 +230,14 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->params)) {
+            $this->params = match (true) {
+                is_object($this->params) => clone $this->params,
+                default => $this->params,
+            };
+        }
+    }
 }

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
@@ -254,13 +254,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = match (true) {
-                is_string($this->foo) || is_int($this->foo) => $this->foo,
-            };
-        }
-    }
 }

--- a/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
@@ -236,13 +236,4 @@ class Cat
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->hasFur)) {
-            $this->hasFur = match (true) {
-                in_array($this->hasFur, ['a', 'b'], true) || is_array($this->hasFur) => $this->hasFur,
-            };
-        }
-    }
 }

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -652,6 +652,16 @@ class MyClass
         return $validator->isValid();
     }
 
+    public function __clone()
+    {
+        if (isset($this->i)) {
+            $this->i = ((is_array($this->i) || is_object($this->i))
+                ? is_object($this->i) ? clone $this->i : $this->i
+                : $this->i
+            );
+        }
+    }
+
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -569,25 +569,14 @@ class MyClass
 
     public function __clone()
     {
-        $this->b = match (true) {
-            is_array($this->b) || is_string($this->b) => $this->b,
-        };
-        $this->d = match (true) {
-            is_array($this->d) || is_string($this->d) => $this->d,
-        };
-        if (isset($this->f)) {
-            $this->f = match (true) {
-                is_array($this->f) || is_string($this->f) => $this->f,
-            };
-        }
-        if (isset($this->h)) {
-            $this->h = match (true) {
-                is_array($this->h) || is_string($this->h) => $this->h,
-            };
-        }
         if (isset($this->i)) {
             $this->i = match (true) {
-                is_array($this->i) || is_string($this->i) || is_array($this->i) || is_object($this->i) => $this->i,
+                is_array($this->i) || is_string($this->i) => $this->i,
+                is_array($this->i) || is_object($this->i) =>
+                    match (true) {
+                        is_object($this->i) => clone $this->i,
+                        default => $this->i,
+                    },
             };
         }
     }

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -594,15 +594,6 @@ class MyClass
         return $validator->isValid();
     }
 
-    public function __clone()
-    {
-        if (isset($this->qwert)) {
-            $this->qwert = match (true) {
-                is_string($this->qwert) || (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
-            };
-        }
-    }
-
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/EmptyObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/EmptyObject/Output-8.4/MyClass.php
@@ -253,4 +253,14 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->b)) {
+            $this->b = match (true) {
+                is_object($this->b) => clone $this->b,
+                default => $this->b,
+            };
+        }
+    }
 }

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
@@ -249,12 +249,7 @@ class BarTest
     public function __clone()
     {
         if (isset($this->exampleProp)) {
-            $this->exampleProp = match (true) {
-                $this->exampleProp instanceof FooTest
-                    || $this->exampleProp instanceof MoiKlass
-                    || $this->exampleProp instanceof FooTest_1 =>
-                    clone $this->exampleProp,
-            };
+            $this->exampleProp = clone $this->exampleProp;
         }
     }
 }

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -1108,12 +1108,22 @@ class MyClass
         }
         if (isset($this->arrObjUnion)) {
             $this->arrObjUnion = match (true) {
-                is_array($this->arrObjUnion) || is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => $this->arrObjUnion,
+                is_array($this->arrObjUnion) => $this->arrObjUnion,
+                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) =>
+                    match (true) {
+                        is_object($this->arrObjUnion) => clone $this->arrObjUnion,
+                        default => $this->arrObjUnion,
+                    },
             };
         }
         if (isset($this->objArrUnion)) {
             $this->objArrUnion = match (true) {
-                is_array($this->objArrUnion) || is_array($this->objArrUnion) || is_object($this->objArrUnion) => $this->objArrUnion,
+                is_array($this->objArrUnion) => $this->objArrUnion,
+                is_array($this->objArrUnion) || is_object($this->objArrUnion) =>
+                    match (true) {
+                        is_object($this->objArrUnion) => clone $this->objArrUnion,
+                        default => $this->objArrUnion,
+                    },
             };
         }
         if (isset($this->numKeysDefaults)) {

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObjNest.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObjNest.php
@@ -291,4 +291,14 @@ class MyClassQuxObjNest
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->a)) {
+            $this->a = match (true) {
+                is_object($this->a) => clone $this->a,
+                default => $this->a,
+            };
+        }
+    }
 }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
@@ -242,9 +242,7 @@ class Baz
     public function __clone()
     {
         if (isset($this->grox)) {
-            $this->grox = match (true) {
-                $this->grox instanceof Foo || $this->grox instanceof Bar => clone $this->grox,
-            };
+            $this->grox = clone $this->grox;
         }
     }
 }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
@@ -286,10 +286,7 @@ class Qux
         if (isset($this->grox)) {
             $this->grox = match (true) {
                 is_string($this->grox) || is_array($this->grox) => $this->grox,
-                ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
-                    match (true) {
-                        $this->grox instanceof Foo || $this->grox instanceof Bar => clone $this->grox,
-                    },
+                ($this->grox instanceof Foo || $this->grox instanceof Bar) => clone $this->grox,
             };
         }
     }

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-5.6/MyClass.php
@@ -257,4 +257,12 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = is_object($this->foo) ? clone $this->foo : $this->foo;
+        }
+        $this->bar = is_object($this->bar) ? clone $this->bar : $this->bar;
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-7.4/MyClass.php
@@ -246,4 +246,12 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = is_object($this->foo) ? clone $this->foo : $this->foo;
+        }
+        $this->bar = is_object($this->bar) ? clone $this->bar : $this->bar;
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
@@ -217,4 +217,18 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = match (true) {
+                is_object($this->foo) => clone $this->foo,
+                default => $this->foo,
+            };
+        }
+        $this->bar = match (true) {
+            is_object($this->bar) => clone $this->bar,
+            default => $this->bar,
+        };
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -302,4 +302,18 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        $this->foo = ((is_array($this->foo) || is_object($this->foo))
+            ? is_object($this->foo) ? clone $this->foo : $this->foo
+            : $this->foo
+        );
+        if (isset($this->bar)) {
+            $this->bar = ((is_array($this->bar) || is_object($this->bar))
+                ? is_object($this->bar) ? clone $this->bar : $this->bar
+                : $this->bar
+            );
+        }
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -289,4 +289,18 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        $this->foo = ((is_array($this->foo) || is_object($this->foo))
+            ? is_object($this->foo) ? clone $this->foo : $this->foo
+            : $this->foo
+        );
+        if (isset($this->bar)) {
+            $this->bar = ((is_array($this->bar) || is_object($this->bar))
+                ? is_object($this->bar) ? clone $this->bar : $this->bar
+                : $this->bar
+            );
+        }
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
@@ -247,11 +247,21 @@ class MyClass
     public function __clone()
     {
         $this->foo = match (true) {
-            is_string($this->foo) || is_array($this->foo) || is_object($this->foo) => $this->foo,
+            is_string($this->foo) => $this->foo,
+            is_array($this->foo) || is_object($this->foo) =>
+                match (true) {
+                    is_object($this->foo) => clone $this->foo,
+                    default => $this->foo,
+                },
         };
         if (isset($this->bar)) {
             $this->bar = match (true) {
-                is_string($this->bar) || is_array($this->bar) || is_object($this->bar) => $this->bar,
+                is_string($this->bar) => $this->bar,
+                is_array($this->bar) || is_object($this->bar) =>
+                    match (true) {
+                        is_object($this->bar) => clone $this->bar,
+                        default => $this->bar,
+                    },
             };
         }
     }

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -765,63 +765,49 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = match (true) {
-            is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) || is_bool($this->foo) => $this->foo,
-        };
-        $this->bar = match (true) {
-            is_string($this->bar)
-                || (is_int($this->bar) || is_float($this->bar))
-                || is_bool($this->bar)
-                || is_array($this->bar) =>
-                $this->bar,
-        };
         $this->baz = match (true) {
-            is_string($this->baz)
-                || (is_int($this->baz) || is_float($this->baz))
-                || is_bool($this->baz)
-                || is_array($this->baz) || is_object($this->baz) =>
-                $this->baz,
+            is_string($this->baz) || (is_int($this->baz) || is_float($this->baz)) || is_bool($this->baz) => $this->baz,
+            is_array($this->baz) || is_object($this->baz) =>
+                match (true) {
+                    is_object($this->baz) => clone $this->baz,
+                    default => $this->baz,
+                },
         };
         $this->qux = match (true) {
             is_string($this->qux)
                 || (is_int($this->qux) || is_float($this->qux))
                 || is_bool($this->qux)
-                || is_array($this->qux)
-                || is_array($this->qux) || is_object($this->qux) =>
+                || is_array($this->qux) =>
                 $this->qux,
+            is_array($this->qux) || is_object($this->qux) =>
+                match (true) {
+                    is_object($this->qux) => clone $this->qux,
+                    default => $this->qux,
+                },
         };
         $this->thud = match (true) {
             is_string($this->thud)
                 || (is_int($this->thud) || is_float($this->thud))
                 || is_bool($this->thud)
-                || is_array($this->thud)
-                || is_array($this->thud) || is_object($this->thud) =>
+                || is_array($this->thud) =>
                 $this->thud,
+            is_array($this->thud) || is_object($this->thud) =>
+                match (true) {
+                    is_object($this->thud) => clone $this->thud,
+                    default => $this->thud,
+                },
         };
-        if (isset($this->optFoo)) {
-            $this->optFoo = match (true) {
-                is_string($this->optFoo)
-                    || (is_int($this->optFoo) || is_float($this->optFoo))
-                    || is_bool($this->optFoo) =>
-                    $this->optFoo,
-            };
-        }
-        if (isset($this->optBar)) {
-            $this->optBar = match (true) {
-                is_string($this->optBar)
-                    || (is_int($this->optBar) || is_float($this->optBar))
-                    || is_bool($this->optBar)
-                    || is_array($this->optBar) =>
-                    $this->optBar,
-            };
-        }
         if (isset($this->optBaz)) {
             $this->optBaz = match (true) {
                 is_string($this->optBaz)
                     || (is_int($this->optBaz) || is_float($this->optBaz))
-                    || is_bool($this->optBaz)
-                    || is_array($this->optBaz) || is_object($this->optBaz) =>
+                    || is_bool($this->optBaz) =>
                     $this->optBaz,
+                is_array($this->optBaz) || is_object($this->optBaz) =>
+                    match (true) {
+                        is_object($this->optBaz) => clone $this->optBaz,
+                        default => $this->optBaz,
+                    },
             };
         }
         if (isset($this->optQux)) {
@@ -829,9 +815,13 @@ class MyClass
                 is_string($this->optQux)
                     || (is_int($this->optQux) || is_float($this->optQux))
                     || is_bool($this->optQux)
-                    || is_array($this->optQux)
-                    || is_array($this->optQux) || is_object($this->optQux) =>
+                    || is_array($this->optQux) =>
                     $this->optQux,
+                is_array($this->optQux) || is_object($this->optQux) =>
+                    match (true) {
+                        is_object($this->optQux) => clone $this->optQux,
+                        default => $this->optQux,
+                    },
             };
         }
         if (isset($this->optThud)) {
@@ -839,9 +829,13 @@ class MyClass
                 is_string($this->optThud)
                     || (is_int($this->optThud) || is_float($this->optThud))
                     || is_bool($this->optThud)
-                    || is_array($this->optThud)
-                    || is_array($this->optThud) || is_object($this->optThud) =>
+                    || is_array($this->optThud) =>
                     $this->optThud,
+                is_array($this->optThud) || is_object($this->optThud) =>
+                    match (true) {
+                        is_object($this->optThud) => clone $this->optThud,
+                        default => $this->optThud,
+                    },
             };
         }
     }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-8.4/Record.php
@@ -458,17 +458,10 @@ class Record
             $this->dataArrayNested = array_map(fn ($i) => $i, $this->dataArrayNested);
         }
         if (isset($this->dataArrayAnyOf)) {
-            $this->dataArrayAnyOf = array_map(fn ($i) => match (true) {
-                $i instanceof Phone || $i instanceof Fio => clone $i,
-            }, $this->dataArrayAnyOf);
+            $this->dataArrayAnyOf = array_map(fn ($i) => clone $i, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
-            $this->dataArrayNestedAnyOf = array_map(
-                fn ($i) => array_map(fn ($i) => match (true) {
-                    $i instanceof Phone || $i instanceof Fio => clone $i,
-                }, $i),
-                $this->dataArrayNestedAnyOf,
-            );
+            $this->dataArrayNestedAnyOf = array_map(fn ($i) => array_map(fn ($i) => clone $i, $i), $this->dataArrayNestedAnyOf);
         }
     }
 }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
@@ -160,11 +160,4 @@ class MyObject
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = match (true) {
-            $this->foo instanceof A || $this->foo instanceof B => $this->foo,
-        };
-    }
 }

--- a/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
+++ b/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
@@ -328,11 +328,6 @@ class RefValidation
 
     public function __clone()
     {
-        if (isset($this->bar)) {
-            $this->bar = match (true) {
-                is_string($this->bar) || in_array($this->bar, [1, 2], true) => $this->bar,
-            };
-        }
         if (isset($this->baz)) {
             $this->baz = clone $this->baz;
         }

--- a/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
@@ -401,11 +401,6 @@ class Foo
 
     public function __clone()
     {
-        if (isset($this->a)) {
-            $this->a = match (true) {
-                in_array($this->a, ['a', 'b'], true) || is_array($this->a) => $this->a,
-            };
-        }
         if (isset($this->d)) {
             $this->d = clone $this->d;
         }

--- a/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
@@ -209,13 +209,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = match (true) {
-                is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) => $this->foo,
-            };
-        }
-    }
 }

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-5.6/MyClass.php
@@ -287,4 +287,14 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = is_object($this->foo) ? clone $this->foo : $this->foo;
+        }
+        if (isset($this->encoded)) {
+            $this->encoded = is_object($this->encoded) ? clone $this->encoded : $this->encoded;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-7.4/MyClass.php
@@ -273,4 +273,14 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = is_object($this->foo) ? clone $this->foo : $this->foo;
+        }
+        if (isset($this->encoded)) {
+            $this->encoded = is_object($this->encoded) ? clone $this->encoded : $this->encoded;
+        }
+    }
 }

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
@@ -244,4 +244,20 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = match (true) {
+                is_object($this->foo) => clone $this->foo,
+                default => $this->foo,
+            };
+        }
+        if (isset($this->encoded)) {
+            $this->encoded = match (true) {
+                is_object($this->encoded) => clone $this->encoded,
+                default => $this->encoded,
+            };
+        }
+    }
 }

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
@@ -695,36 +695,24 @@ class MyClass
             $this->arrayOfUnions = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                },
+                    array_map(fn ($i) => $i, $i),
+                (is_array($i) || is_array($i)) => $i,
             }, $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $this->arrayOfRefUnions = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                },
+                    array_map(fn ($i) => $i, $i),
+                (is_array($i) || is_array($i)) => $i,
             }, $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $this->arrayOfRefAndNotRefUnions = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                },
+                    array_map(fn ($i) => $i, $i),
+                (is_array($i) || is_array($i)) => $i,
             }, $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {

--- a/tests/Generator/Fixtures/UnionArrayTyped/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayTyped/Output-8.4/MyClass.php
@@ -527,29 +527,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->unionOfTypedArrays)) {
-            $this->unionOfTypedArrays = match (true) {
-                is_array($this->unionOfTypedArrays) => $this->unionOfTypedArrays,
-            };
-        }
-        if (isset($this->refUnionOfTypedArrays)) {
-            $this->refUnionOfTypedArrays = match (true) {
-                is_array($this->refUnionOfTypedArrays) => $this->refUnionOfTypedArrays,
-            };
-        }
-        if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            $this->refAndNotRefUnionOfTypedArrays = match (true) {
-                is_array($this->refAndNotRefUnionOfTypedArrays) => $this->refAndNotRefUnionOfTypedArrays,
-            };
-        }
-        if (isset($this->unionOfTypedArrayAndString)) {
-            $this->unionOfTypedArrayAndString = match (true) {
-                is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString) =>
-                    $this->unionOfTypedArrayAndString,
-            };
-        }
-    }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -359,20 +359,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = match (true) {
-            is_string($this->foo) => $this->foo,
-        };
-        $this->bar = match (true) {
-            is_string($this->bar) => $this->bar,
-        };
-        $this->baz = match (true) {
-            is_string($this->baz) => $this->baz,
-        };
-        $this->qux = match (true) {
-            is_string($this->qux) => $this->qux,
-        };
-    }
 }

--- a/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
@@ -564,25 +564,13 @@ class MyClass
     public function __clone()
     {
         if (isset($this->objectsUnion)) {
-            $this->objectsUnion = match (true) {
-                $this->objectsUnion instanceof MyClassObjectsUnionAlternative1
-                    || $this->objectsUnion instanceof MyClassObjectsUnionAlternative2 =>
-                    clone $this->objectsUnion,
-            };
+            $this->objectsUnion = clone $this->objectsUnion;
         }
         if (isset($this->refObjectsUnion)) {
-            $this->refObjectsUnion = match (true) {
-                $this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2 => clone $this->refObjectsUnion,
-            };
+            $this->refObjectsUnion = clone $this->refObjectsUnion;
         }
         if (isset($this->refAndNotRefObjectsUnion)) {
-            $this->refAndNotRefObjectsUnion = match (true) {
-                $this->refAndNotRefObjectsUnion instanceof SomeObj1
-                    || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative2
-                    || $this->refAndNotRefObjectsUnion instanceof SomeObj2
-                    || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4 =>
-                    clone $this->refAndNotRefObjectsUnion,
-            };
+            $this->refAndNotRefObjectsUnion = clone $this->refAndNotRefObjectsUnion;
         }
         if (isset($this->objAndStringUnion)) {
             $this->objAndStringUnion = match (true) {

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -346,12 +346,7 @@ class Cat
                     || (is_int($this->hasFur) || is_float($this->hasFur))
                     || is_bool($this->hasFur)
                 ) =>
-                    match (true) {
-                        is_string($this->hasFur)
-                            || (is_int($this->hasFur) || is_float($this->hasFur))
-                            || is_bool($this->hasFur) =>
-                            $this->hasFur,
-                    },
+                    $this->hasFur,
             };
         }
     }

--- a/tests/Generator/Property/UnionPropertyTest.php
+++ b/tests/Generator/Property/UnionPropertyTest.php
@@ -102,11 +102,7 @@ EOCODE;
     public function testCloneProperty()
     {
         $expected = <<<'EOCODE'
-$this->myPropertyName = match (true) {
-    $this->myPropertyName instanceof FooMyPropertyNameAlternative1
-        || $this->myPropertyName instanceof FooMyPropertyNameAlternative2 =>
-        clone $this->myPropertyName,
-};
+$this->myPropertyName = clone $this->myPropertyName;
 EOCODE;
         assertSame($expected, $this->property->cloneAssignment());
     }


### PR DESCRIPTION
## Summary
- deep clone object-type unions
- avoid generating match for identical clone branches
- regenerate fixtures and tests

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68a05af63bb0832db029111f6eaa3ab9