### PR TITLE
Fix cloning for raw object unions and skip redundant __clone methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Now it:
 - Deterministic resolution of class property, accessor method and temporary variable names via a unified resolver, allowing case-sensitive properties and avoiding collisions with reserved names.
 - Option `mutableSetters` allows generating mutable `setX()` methods (optionally chainable).
 - Skips emitting empty `__construct` or `__clone` methods.
+- Deep clones properties of type `object` without defined structure and avoids
+  generating redundant `__clone` methods for unions whose members don't require
+  cloning.
 - Prints a notice when skipping `definitions` that do not describe an object.
 - Validates written files with `php -l` to ensure generated code is syntactically correct.
 - Handles URL-encoded references

--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -551,10 +551,18 @@ class UnionProperty extends AbstractProperty
     {
         if ($this->request->isAtLeastPHP("8.0")) {
             $arms = [];
+            $allIdentity = true;
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->cloneExpr($expr);
                 $assert = $subProperty->typeAssertionExpr($expr);
                 $arms[$map][] = $assert;
+                if ($map !== $expr) {
+                    $allIdentity = false;
+                }
+            }
+
+            if ($allIdentity) {
+                return $expr;
             }
 
             $match = new MatchGenerator("true");

--- a/src/Generator/Property/Type/Object/RawObjectProperty.php
+++ b/src/Generator/Property/Type/Object/RawObjectProperty.php
@@ -48,6 +48,13 @@ class RawObjectProperty extends AbstractProperty
         return 'json_decode(json_encode(' . $expr . '))';
     }
 
+    public function cloneExpr(string $expr): string
+    {
+        return 'is_array(' . $expr . ')
+            ? json_decode(json_encode(' . $expr . '), true)
+            : json_decode(json_encode(' . $expr . '))';
+    }
+
     public function needsValidation(): bool
     {
         // Schema places no restrictions beyond "object", so PHP type hints are

--- a/tests/Generator/Fixtures/AdditionalPropertiesNested/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesNested/Output-8.4/MyClass.php
@@ -226,4 +226,13 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->bar)) {
+            $this->bar = is_array($this->bar)
+                        ? json_decode(json_encode($this->bar), true)
+                        : json_decode(json_encode($this->bar));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/AdditionalPropertiesNestedArr/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesNestedArr/Output-8.4/MyClass.php
@@ -253,7 +253,12 @@ class MyClass
     public function __clone()
     {
         if (isset($this->bar)) {
-            $this->bar = array_map(fn ($i) => $i, $this->bar);
+            $this->bar = array_map(
+                fn ($i) => is_array($i)
+                            ? json_decode(json_encode($i), true)
+                            : json_decode(json_encode($i)),
+                $this->bar,
+            );
         }
     }
 }

--- a/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-5.6/MyClass.php
@@ -282,4 +282,13 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->params)) {
+            $this->params = is_array($this->params)
+                        ? json_decode(json_encode($this->params), true)
+                        : json_decode(json_encode($this->params));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-7.4/MyClass.php
@@ -249,4 +249,13 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->params)) {
+            $this->params = is_array($this->params)
+                        ? json_decode(json_encode($this->params), true)
+                        : json_decode(json_encode($this->params));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-8.4/MyClass.php
@@ -230,4 +230,13 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->params)) {
+            $this->params = is_array($this->params)
+                        ? json_decode(json_encode($this->params), true)
+                        : json_decode(json_encode($this->params));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
@@ -254,13 +254,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = match (true) {
-                is_string($this->foo) || is_int($this->foo) => $this->foo,
-            };
-        }
-    }
 }

--- a/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
@@ -236,13 +236,4 @@ class Cat
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->hasFur)) {
-            $this->hasFur = match (true) {
-                in_array($this->hasFur, ['a', 'b'], true) || is_array($this->hasFur) => $this->hasFur,
-            };
-        }
-    }
 }

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -652,6 +652,18 @@ class MyClass
         return $validator->isValid();
     }
 
+    public function __clone()
+    {
+        if (isset($this->i)) {
+            $this->i = ((is_array($this->i) || is_object($this->i))
+                ? is_array($this->i)
+                            ? json_decode(json_encode($this->i), true)
+                            : json_decode(json_encode($this->i))
+                : $this->i
+            );
+        }
+    }
+
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -569,25 +569,13 @@ class MyClass
 
     public function __clone()
     {
-        $this->b = match (true) {
-            is_array($this->b) || is_string($this->b) => $this->b,
-        };
-        $this->d = match (true) {
-            is_array($this->d) || is_string($this->d) => $this->d,
-        };
-        if (isset($this->f)) {
-            $this->f = match (true) {
-                is_array($this->f) || is_string($this->f) => $this->f,
-            };
-        }
-        if (isset($this->h)) {
-            $this->h = match (true) {
-                is_array($this->h) || is_string($this->h) => $this->h,
-            };
-        }
         if (isset($this->i)) {
             $this->i = match (true) {
-                is_array($this->i) || is_string($this->i) || is_array($this->i) || is_object($this->i) => $this->i,
+                is_array($this->i) || is_string($this->i) => $this->i,
+                is_array($this->i) || is_object($this->i) =>
+                    is_array($this->i)
+                                ? json_decode(json_encode($this->i), true)
+                                : json_decode(json_encode($this->i)),
             };
         }
     }

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -594,15 +594,6 @@ class MyClass
         return $validator->isValid();
     }
 
-    public function __clone()
-    {
-        if (isset($this->qwert)) {
-            $this->qwert = match (true) {
-                is_string($this->qwert) || (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
-            };
-        }
-    }
-
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/EmptyObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/EmptyObject/Output-8.4/MyClass.php
@@ -253,4 +253,13 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->b)) {
+            $this->b = is_array($this->b)
+                        ? json_decode(json_encode($this->b), true)
+                        : json_decode(json_encode($this->b));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -1108,12 +1108,20 @@ class MyClass
         }
         if (isset($this->arrObjUnion)) {
             $this->arrObjUnion = match (true) {
-                is_array($this->arrObjUnion) || is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => $this->arrObjUnion,
+                is_array($this->arrObjUnion) => $this->arrObjUnion,
+                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) =>
+                    is_array($this->arrObjUnion)
+                                ? json_decode(json_encode($this->arrObjUnion), true)
+                                : json_decode(json_encode($this->arrObjUnion)),
             };
         }
         if (isset($this->objArrUnion)) {
             $this->objArrUnion = match (true) {
-                is_array($this->objArrUnion) || is_array($this->objArrUnion) || is_object($this->objArrUnion) => $this->objArrUnion,
+                is_array($this->objArrUnion) => $this->objArrUnion,
+                is_array($this->objArrUnion) || is_object($this->objArrUnion) =>
+                    is_array($this->objArrUnion)
+                                ? json_decode(json_encode($this->objArrUnion), true)
+                                : json_decode(json_encode($this->objArrUnion)),
             };
         }
         if (isset($this->numKeysDefaults)) {

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObjNest.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObjNest.php
@@ -291,4 +291,13 @@ class MyClassQuxObjNest
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->a)) {
+            $this->a = is_array($this->a)
+                        ? json_decode(json_encode($this->a), true)
+                        : json_decode(json_encode($this->a));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-5.6/MyClass.php
@@ -257,4 +257,16 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = is_array($this->foo)
+                        ? json_decode(json_encode($this->foo), true)
+                        : json_decode(json_encode($this->foo));
+        }
+        $this->bar = is_array($this->bar)
+                    ? json_decode(json_encode($this->bar), true)
+                    : json_decode(json_encode($this->bar));
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-7.4/MyClass.php
@@ -246,4 +246,16 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = is_array($this->foo)
+                        ? json_decode(json_encode($this->foo), true)
+                        : json_decode(json_encode($this->foo));
+        }
+        $this->bar = is_array($this->bar)
+                    ? json_decode(json_encode($this->bar), true)
+                    : json_decode(json_encode($this->bar));
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
@@ -217,4 +217,16 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = is_array($this->foo)
+                        ? json_decode(json_encode($this->foo), true)
+                        : json_decode(json_encode($this->foo));
+        }
+        $this->bar = is_array($this->bar)
+                    ? json_decode(json_encode($this->bar), true)
+                    : json_decode(json_encode($this->bar));
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -302,4 +302,22 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        $this->foo = ((is_array($this->foo) || is_object($this->foo))
+            ? is_array($this->foo)
+                        ? json_decode(json_encode($this->foo), true)
+                        : json_decode(json_encode($this->foo))
+            : $this->foo
+        );
+        if (isset($this->bar)) {
+            $this->bar = ((is_array($this->bar) || is_object($this->bar))
+                ? is_array($this->bar)
+                            ? json_decode(json_encode($this->bar), true)
+                            : json_decode(json_encode($this->bar))
+                : $this->bar
+            );
+        }
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -289,4 +289,22 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        $this->foo = ((is_array($this->foo) || is_object($this->foo))
+            ? is_array($this->foo)
+                        ? json_decode(json_encode($this->foo), true)
+                        : json_decode(json_encode($this->foo))
+            : $this->foo
+        );
+        if (isset($this->bar)) {
+            $this->bar = ((is_array($this->bar) || is_object($this->bar))
+                ? is_array($this->bar)
+                            ? json_decode(json_encode($this->bar), true)
+                            : json_decode(json_encode($this->bar))
+                : $this->bar
+            );
+        }
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
@@ -247,11 +247,19 @@ class MyClass
     public function __clone()
     {
         $this->foo = match (true) {
-            is_string($this->foo) || is_array($this->foo) || is_object($this->foo) => $this->foo,
+            is_string($this->foo) => $this->foo,
+            is_array($this->foo) || is_object($this->foo) =>
+                is_array($this->foo)
+                            ? json_decode(json_encode($this->foo), true)
+                            : json_decode(json_encode($this->foo)),
         };
         if (isset($this->bar)) {
             $this->bar = match (true) {
-                is_string($this->bar) || is_array($this->bar) || is_object($this->bar) => $this->bar,
+                is_string($this->bar) => $this->bar,
+                is_array($this->bar) || is_object($this->bar) =>
+                    is_array($this->bar)
+                                ? json_decode(json_encode($this->bar), true)
+                                : json_decode(json_encode($this->bar)),
             };
         }
     }

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -765,63 +765,45 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = match (true) {
-            is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) || is_bool($this->foo) => $this->foo,
-        };
-        $this->bar = match (true) {
-            is_string($this->bar)
-                || (is_int($this->bar) || is_float($this->bar))
-                || is_bool($this->bar)
-                || is_array($this->bar) =>
-                $this->bar,
-        };
         $this->baz = match (true) {
-            is_string($this->baz)
-                || (is_int($this->baz) || is_float($this->baz))
-                || is_bool($this->baz)
-                || is_array($this->baz) || is_object($this->baz) =>
-                $this->baz,
+            is_string($this->baz) || (is_int($this->baz) || is_float($this->baz)) || is_bool($this->baz) => $this->baz,
+            is_array($this->baz) || is_object($this->baz) =>
+                is_array($this->baz)
+                            ? json_decode(json_encode($this->baz), true)
+                            : json_decode(json_encode($this->baz)),
         };
         $this->qux = match (true) {
             is_string($this->qux)
                 || (is_int($this->qux) || is_float($this->qux))
                 || is_bool($this->qux)
-                || is_array($this->qux)
-                || is_array($this->qux) || is_object($this->qux) =>
+                || is_array($this->qux) =>
                 $this->qux,
+            is_array($this->qux) || is_object($this->qux) =>
+                is_array($this->qux)
+                            ? json_decode(json_encode($this->qux), true)
+                            : json_decode(json_encode($this->qux)),
         };
         $this->thud = match (true) {
             is_string($this->thud)
                 || (is_int($this->thud) || is_float($this->thud))
                 || is_bool($this->thud)
-                || is_array($this->thud)
-                || is_array($this->thud) || is_object($this->thud) =>
+                || is_array($this->thud) =>
                 $this->thud,
+            is_array($this->thud) || is_object($this->thud) =>
+                is_array($this->thud)
+                            ? json_decode(json_encode($this->thud), true)
+                            : json_decode(json_encode($this->thud)),
         };
-        if (isset($this->optFoo)) {
-            $this->optFoo = match (true) {
-                is_string($this->optFoo)
-                    || (is_int($this->optFoo) || is_float($this->optFoo))
-                    || is_bool($this->optFoo) =>
-                    $this->optFoo,
-            };
-        }
-        if (isset($this->optBar)) {
-            $this->optBar = match (true) {
-                is_string($this->optBar)
-                    || (is_int($this->optBar) || is_float($this->optBar))
-                    || is_bool($this->optBar)
-                    || is_array($this->optBar) =>
-                    $this->optBar,
-            };
-        }
         if (isset($this->optBaz)) {
             $this->optBaz = match (true) {
                 is_string($this->optBaz)
                     || (is_int($this->optBaz) || is_float($this->optBaz))
-                    || is_bool($this->optBaz)
-                    || is_array($this->optBaz) || is_object($this->optBaz) =>
+                    || is_bool($this->optBaz) =>
                     $this->optBaz,
+                is_array($this->optBaz) || is_object($this->optBaz) =>
+                    is_array($this->optBaz)
+                                ? json_decode(json_encode($this->optBaz), true)
+                                : json_decode(json_encode($this->optBaz)),
             };
         }
         if (isset($this->optQux)) {
@@ -829,9 +811,12 @@ class MyClass
                 is_string($this->optQux)
                     || (is_int($this->optQux) || is_float($this->optQux))
                     || is_bool($this->optQux)
-                    || is_array($this->optQux)
-                    || is_array($this->optQux) || is_object($this->optQux) =>
+                    || is_array($this->optQux) =>
                     $this->optQux,
+                is_array($this->optQux) || is_object($this->optQux) =>
+                    is_array($this->optQux)
+                                ? json_decode(json_encode($this->optQux), true)
+                                : json_decode(json_encode($this->optQux)),
             };
         }
         if (isset($this->optThud)) {
@@ -839,9 +824,12 @@ class MyClass
                 is_string($this->optThud)
                     || (is_int($this->optThud) || is_float($this->optThud))
                     || is_bool($this->optThud)
-                    || is_array($this->optThud)
-                    || is_array($this->optThud) || is_object($this->optThud) =>
+                    || is_array($this->optThud) =>
                     $this->optThud,
+                is_array($this->optThud) || is_object($this->optThud) =>
+                    is_array($this->optThud)
+                                ? json_decode(json_encode($this->optThud), true)
+                                : json_decode(json_encode($this->optThud)),
             };
         }
     }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
@@ -160,11 +160,4 @@ class MyObject
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = match (true) {
-            $this->foo instanceof A || $this->foo instanceof B => $this->foo,
-        };
-    }
 }

--- a/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
+++ b/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
@@ -328,11 +328,6 @@ class RefValidation
 
     public function __clone()
     {
-        if (isset($this->bar)) {
-            $this->bar = match (true) {
-                is_string($this->bar) || in_array($this->bar, [1, 2], true) => $this->bar,
-            };
-        }
         if (isset($this->baz)) {
             $this->baz = clone $this->baz;
         }

--- a/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
@@ -401,11 +401,6 @@ class Foo
 
     public function __clone()
     {
-        if (isset($this->a)) {
-            $this->a = match (true) {
-                in_array($this->a, ['a', 'b'], true) || is_array($this->a) => $this->a,
-            };
-        }
         if (isset($this->d)) {
             $this->d = clone $this->d;
         }

--- a/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
@@ -209,13 +209,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = match (true) {
-                is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) => $this->foo,
-            };
-        }
-    }
 }

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-5.6/MyClass.php
@@ -287,4 +287,18 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = is_array($this->foo)
+                        ? json_decode(json_encode($this->foo), true)
+                        : json_decode(json_encode($this->foo));
+        }
+        if (isset($this->encoded)) {
+            $this->encoded = is_array($this->encoded)
+                        ? json_decode(json_encode($this->encoded), true)
+                        : json_decode(json_encode($this->encoded));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-7.4/MyClass.php
@@ -273,4 +273,18 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = is_array($this->foo)
+                        ? json_decode(json_encode($this->foo), true)
+                        : json_decode(json_encode($this->foo));
+        }
+        if (isset($this->encoded)) {
+            $this->encoded = is_array($this->encoded)
+                        ? json_decode(json_encode($this->encoded), true)
+                        : json_decode(json_encode($this->encoded));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
@@ -244,4 +244,18 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = is_array($this->foo)
+                        ? json_decode(json_encode($this->foo), true)
+                        : json_decode(json_encode($this->foo));
+        }
+        if (isset($this->encoded)) {
+            $this->encoded = is_array($this->encoded)
+                        ? json_decode(json_encode($this->encoded), true)
+                        : json_decode(json_encode($this->encoded));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
@@ -695,36 +695,24 @@ class MyClass
             $this->arrayOfUnions = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                },
+                    array_map(fn ($i) => $i, $i),
+                (is_array($i) || is_array($i)) => $i,
             }, $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $this->arrayOfRefUnions = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                },
+                    array_map(fn ($i) => $i, $i),
+                (is_array($i) || is_array($i)) => $i,
             }, $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $this->arrayOfRefAndNotRefUnions = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                },
+                    array_map(fn ($i) => $i, $i),
+                (is_array($i) || is_array($i)) => $i,
             }, $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {

--- a/tests/Generator/Fixtures/UnionArrayTyped/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayTyped/Output-8.4/MyClass.php
@@ -527,29 +527,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->unionOfTypedArrays)) {
-            $this->unionOfTypedArrays = match (true) {
-                is_array($this->unionOfTypedArrays) => $this->unionOfTypedArrays,
-            };
-        }
-        if (isset($this->refUnionOfTypedArrays)) {
-            $this->refUnionOfTypedArrays = match (true) {
-                is_array($this->refUnionOfTypedArrays) => $this->refUnionOfTypedArrays,
-            };
-        }
-        if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            $this->refAndNotRefUnionOfTypedArrays = match (true) {
-                is_array($this->refAndNotRefUnionOfTypedArrays) => $this->refAndNotRefUnionOfTypedArrays,
-            };
-        }
-        if (isset($this->unionOfTypedArrayAndString)) {
-            $this->unionOfTypedArrayAndString = match (true) {
-                is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString) =>
-                    $this->unionOfTypedArrayAndString,
-            };
-        }
-    }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -359,20 +359,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = match (true) {
-            is_string($this->foo) => $this->foo,
-        };
-        $this->bar = match (true) {
-            is_string($this->bar) => $this->bar,
-        };
-        $this->baz = match (true) {
-            is_string($this->baz) => $this->baz,
-        };
-        $this->qux = match (true) {
-            is_string($this->qux) => $this->qux,
-        };
-    }
 }

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -346,12 +346,7 @@ class Cat
                     || (is_int($this->hasFur) || is_float($this->hasFur))
                     || is_bool($this->hasFur)
                 ) =>
-                    match (true) {
-                        is_string($this->hasFur)
-                            || (is_int($this->hasFur) || is_float($this->hasFur))
-                            || is_bool($this->hasFur) =>
-                            $this->hasFur,
-                    },
+                    $this->hasFur,
             };
         }
     }

--- a/tests/Generator/Property/UnionPropertyTest.php
+++ b/tests/Generator/Property/UnionPropertyTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use function PHPUnit\Framework\assertSame;
 use function PHPUnit\Framework\assertTrue;
 use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertNull;
 use Helmich\Schema2Class\Generator\Definition\Definition;
 use Helmich\Schema2Class\Generator\Property\Type\Composite\UnionProperty;
 use Helmich\Schema2Class\Generator\ReferenceLookup\DefinitionsReferenceLookup;
@@ -109,6 +110,20 @@ $this->myPropertyName = match (true) {
 };
 EOCODE;
         assertSame($expected, $this->property->cloneAssignment());
+    }
+
+    public function testClonePropertyWithOnlyIdentityMappings(): void
+    {
+        $prop = new UnionProperty(
+            'foo',
+            ['anyOf' => [
+                ['type' => 'string'],
+                ['type' => 'string'],
+            ]],
+            $this->generatorRequest,
+        );
+
+        assertNull($prop->cloneAssignment());
     }
 
     public function testAllowsNullIfSubPropertyAllowsNull(): void


### PR DESCRIPTION
## Summary
- deep-clone properties typed as unspecified objects
- avoid generating useless `__clone` implementations for unions without transformations
- cover identity unions with a regression test and refresh snapshots

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68a05af63bb0832db029111f6eaa3ab9