### PR TITLE
Handle raw object cloning and skip redundant __clone methods

### DIFF
--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -557,6 +557,13 @@ class UnionProperty extends AbstractProperty
                 $arms[$map][] = $assert;
             }
 
+            if (count($arms) === 1) {
+                $only = array_key_first($arms);
+                if ($only === $expr) {
+                    return $expr;
+                }
+            }
+
             $match = new MatchGenerator("true");
             foreach ($arms as $map => $asserts) {
                 $conditions = array_values(array_unique($asserts));

--- a/src/Generator/Property/Type/Object/RawObjectProperty.php
+++ b/src/Generator/Property/Type/Object/RawObjectProperty.php
@@ -48,6 +48,11 @@ class RawObjectProperty extends AbstractProperty
         return 'json_decode(json_encode(' . $expr . '))';
     }
 
+    public function cloneExpr(string $expr): string
+    {
+        return 'json_decode(json_encode(' . $expr . '), is_array(' . $expr . '))';
+    }
+
     public function needsValidation(): bool
     {
         // Schema places no restrictions beyond "object", so PHP type hints are

--- a/tests/Generator/Fixtures/AdditionalPropertiesNested/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesNested/Output-8.4/MyClass.php
@@ -226,4 +226,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->bar)) {
+            $this->bar = json_decode(json_encode($this->bar), is_array($this->bar));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/AdditionalPropertiesNestedArr/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesNestedArr/Output-8.4/MyClass.php
@@ -253,7 +253,7 @@ class MyClass
     public function __clone()
     {
         if (isset($this->bar)) {
-            $this->bar = array_map(fn ($i) => $i, $this->bar);
+            $this->bar = array_map(fn ($i) => json_decode(json_encode($i), is_array($i)), $this->bar);
         }
     }
 }

--- a/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-5.6/MyClass.php
@@ -282,4 +282,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->params)) {
+            $this->params = json_decode(json_encode($this->params), is_array($this->params));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-7.4/MyClass.php
@@ -249,4 +249,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->params)) {
+            $this->params = json_decode(json_encode($this->params), is_array($this->params));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AdditionalPropertiesRootAny/Output-8.4/MyClass.php
@@ -230,4 +230,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->params)) {
+            $this->params = json_decode(json_encode($this->params), is_array($this->params));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
@@ -254,13 +254,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = match (true) {
-                is_string($this->foo) || is_int($this->foo) => $this->foo,
-            };
-        }
-    }
 }

--- a/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
@@ -236,13 +236,4 @@ class Cat
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->hasFur)) {
-            $this->hasFur = match (true) {
-                in_array($this->hasFur, ['a', 'b'], true) || is_array($this->hasFur) => $this->hasFur,
-            };
-        }
-    }
 }

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -652,6 +652,16 @@ class MyClass
         return $validator->isValid();
     }
 
+    public function __clone()
+    {
+        if (isset($this->i)) {
+            $this->i = ((is_array($this->i) || is_object($this->i))
+                ? json_decode(json_encode($this->i), is_array($this->i))
+                : $this->i
+            );
+        }
+    }
+
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -569,25 +569,10 @@ class MyClass
 
     public function __clone()
     {
-        $this->b = match (true) {
-            is_array($this->b) || is_string($this->b) => $this->b,
-        };
-        $this->d = match (true) {
-            is_array($this->d) || is_string($this->d) => $this->d,
-        };
-        if (isset($this->f)) {
-            $this->f = match (true) {
-                is_array($this->f) || is_string($this->f) => $this->f,
-            };
-        }
-        if (isset($this->h)) {
-            $this->h = match (true) {
-                is_array($this->h) || is_string($this->h) => $this->h,
-            };
-        }
         if (isset($this->i)) {
             $this->i = match (true) {
-                is_array($this->i) || is_string($this->i) || is_array($this->i) || is_object($this->i) => $this->i,
+                is_array($this->i) || is_string($this->i) => $this->i,
+                is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), is_array($this->i)),
             };
         }
     }

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -594,15 +594,6 @@ class MyClass
         return $validator->isValid();
     }
 
-    public function __clone()
-    {
-        if (isset($this->qwert)) {
-            $this->qwert = match (true) {
-                is_string($this->qwert) || (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
-            };
-        }
-    }
-
     /**
      * Checks if an optional nullable property was explicitly set.
      *

--- a/tests/Generator/Fixtures/EmptyObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/EmptyObject/Output-8.4/MyClass.php
@@ -253,4 +253,11 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->b)) {
+            $this->b = json_decode(json_encode($this->b), is_array($this->b));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -1108,12 +1108,16 @@ class MyClass
         }
         if (isset($this->arrObjUnion)) {
             $this->arrObjUnion = match (true) {
-                is_array($this->arrObjUnion) || is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => $this->arrObjUnion,
+                is_array($this->arrObjUnion) => $this->arrObjUnion,
+                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) =>
+                    json_decode(json_encode($this->arrObjUnion), is_array($this->arrObjUnion)),
             };
         }
         if (isset($this->objArrUnion)) {
             $this->objArrUnion = match (true) {
-                is_array($this->objArrUnion) || is_array($this->objArrUnion) || is_object($this->objArrUnion) => $this->objArrUnion,
+                is_array($this->objArrUnion) => $this->objArrUnion,
+                is_array($this->objArrUnion) || is_object($this->objArrUnion) =>
+                    json_decode(json_encode($this->objArrUnion), is_array($this->objArrUnion)),
             };
         }
         if (isset($this->numKeysDefaults)) {

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObjNest.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClassQuxObjNest.php
@@ -291,4 +291,11 @@ class MyClassQuxObjNest
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->a)) {
+            $this->a = json_decode(json_encode($this->a), is_array($this->a));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-5.6/MyClass.php
@@ -257,4 +257,12 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = json_decode(json_encode($this->foo), is_array($this->foo));
+        }
+        $this->bar = json_decode(json_encode($this->bar), is_array($this->bar));
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-7.4/MyClass.php
@@ -246,4 +246,12 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = json_decode(json_encode($this->foo), is_array($this->foo));
+        }
+        $this->bar = json_decode(json_encode($this->bar), is_array($this->bar));
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutProps/Output-8.4/MyClass.php
@@ -217,4 +217,12 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = json_decode(json_encode($this->foo), is_array($this->foo));
+        }
+        $this->bar = json_decode(json_encode($this->bar), is_array($this->bar));
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -302,4 +302,18 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        $this->foo = ((is_array($this->foo) || is_object($this->foo))
+            ? json_decode(json_encode($this->foo), is_array($this->foo))
+            : $this->foo
+        );
+        if (isset($this->bar)) {
+            $this->bar = ((is_array($this->bar) || is_object($this->bar))
+                ? json_decode(json_encode($this->bar), is_array($this->bar))
+                : $this->bar
+            );
+        }
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -289,4 +289,18 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        $this->foo = ((is_array($this->foo) || is_object($this->foo))
+            ? json_decode(json_encode($this->foo), is_array($this->foo))
+            : $this->foo
+        );
+        if (isset($this->bar)) {
+            $this->bar = ((is_array($this->bar) || is_object($this->bar))
+                ? json_decode(json_encode($this->bar), is_array($this->bar))
+                : $this->bar
+            );
+        }
+    }
 }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
@@ -247,11 +247,13 @@ class MyClass
     public function __clone()
     {
         $this->foo = match (true) {
-            is_string($this->foo) || is_array($this->foo) || is_object($this->foo) => $this->foo,
+            is_string($this->foo) => $this->foo,
+            is_array($this->foo) || is_object($this->foo) => json_decode(json_encode($this->foo), is_array($this->foo)),
         };
         if (isset($this->bar)) {
             $this->bar = match (true) {
-                is_string($this->bar) || is_array($this->bar) || is_object($this->bar) => $this->bar,
+                is_string($this->bar) => $this->bar,
+                is_array($this->bar) || is_object($this->bar) => json_decode(json_encode($this->bar), is_array($this->bar)),
             };
         }
     }

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -765,63 +765,33 @@ class MyClass
 
     public function __clone()
     {
-        $this->foo = match (true) {
-            is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) || is_bool($this->foo) => $this->foo,
-        };
-        $this->bar = match (true) {
-            is_string($this->bar)
-                || (is_int($this->bar) || is_float($this->bar))
-                || is_bool($this->bar)
-                || is_array($this->bar) =>
-                $this->bar,
-        };
         $this->baz = match (true) {
-            is_string($this->baz)
-                || (is_int($this->baz) || is_float($this->baz))
-                || is_bool($this->baz)
-                || is_array($this->baz) || is_object($this->baz) =>
-                $this->baz,
+            is_string($this->baz) || (is_int($this->baz) || is_float($this->baz)) || is_bool($this->baz) => $this->baz,
+            is_array($this->baz) || is_object($this->baz) => json_decode(json_encode($this->baz), is_array($this->baz)),
         };
         $this->qux = match (true) {
             is_string($this->qux)
                 || (is_int($this->qux) || is_float($this->qux))
                 || is_bool($this->qux)
-                || is_array($this->qux)
-                || is_array($this->qux) || is_object($this->qux) =>
+                || is_array($this->qux) =>
                 $this->qux,
+            is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux), is_array($this->qux)),
         };
         $this->thud = match (true) {
             is_string($this->thud)
                 || (is_int($this->thud) || is_float($this->thud))
                 || is_bool($this->thud)
-                || is_array($this->thud)
-                || is_array($this->thud) || is_object($this->thud) =>
+                || is_array($this->thud) =>
                 $this->thud,
+            is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud), is_array($this->thud)),
         };
-        if (isset($this->optFoo)) {
-            $this->optFoo = match (true) {
-                is_string($this->optFoo)
-                    || (is_int($this->optFoo) || is_float($this->optFoo))
-                    || is_bool($this->optFoo) =>
-                    $this->optFoo,
-            };
-        }
-        if (isset($this->optBar)) {
-            $this->optBar = match (true) {
-                is_string($this->optBar)
-                    || (is_int($this->optBar) || is_float($this->optBar))
-                    || is_bool($this->optBar)
-                    || is_array($this->optBar) =>
-                    $this->optBar,
-            };
-        }
         if (isset($this->optBaz)) {
             $this->optBaz = match (true) {
                 is_string($this->optBaz)
                     || (is_int($this->optBaz) || is_float($this->optBaz))
-                    || is_bool($this->optBaz)
-                    || is_array($this->optBaz) || is_object($this->optBaz) =>
+                    || is_bool($this->optBaz) =>
                     $this->optBaz,
+                is_array($this->optBaz) || is_object($this->optBaz) => json_decode(json_encode($this->optBaz), is_array($this->optBaz)),
             };
         }
         if (isset($this->optQux)) {
@@ -829,9 +799,9 @@ class MyClass
                 is_string($this->optQux)
                     || (is_int($this->optQux) || is_float($this->optQux))
                     || is_bool($this->optQux)
-                    || is_array($this->optQux)
-                    || is_array($this->optQux) || is_object($this->optQux) =>
+                    || is_array($this->optQux) =>
                     $this->optQux,
+                is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux), is_array($this->optQux)),
             };
         }
         if (isset($this->optThud)) {
@@ -839,9 +809,9 @@ class MyClass
                 is_string($this->optThud)
                     || (is_int($this->optThud) || is_float($this->optThud))
                     || is_bool($this->optThud)
-                    || is_array($this->optThud)
-                    || is_array($this->optThud) || is_object($this->optThud) =>
+                    || is_array($this->optThud) =>
                     $this->optThud,
+                is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud), is_array($this->optThud)),
             };
         }
     }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
@@ -160,11 +160,4 @@ class MyObject
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = match (true) {
-            $this->foo instanceof A || $this->foo instanceof B => $this->foo,
-        };
-    }
 }

--- a/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
+++ b/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
@@ -328,11 +328,6 @@ class RefValidation
 
     public function __clone()
     {
-        if (isset($this->bar)) {
-            $this->bar = match (true) {
-                is_string($this->bar) || in_array($this->bar, [1, 2], true) => $this->bar,
-            };
-        }
         if (isset($this->baz)) {
             $this->baz = clone $this->baz;
         }

--- a/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
@@ -401,11 +401,6 @@ class Foo
 
     public function __clone()
     {
-        if (isset($this->a)) {
-            $this->a = match (true) {
-                in_array($this->a, ['a', 'b'], true) || is_array($this->a) => $this->a,
-            };
-        }
         if (isset($this->d)) {
             $this->d = clone $this->d;
         }

--- a/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
@@ -209,13 +209,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->foo)) {
-            $this->foo = match (true) {
-                is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) => $this->foo,
-            };
-        }
-    }
 }

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-5.6/MyClass.php
@@ -287,4 +287,14 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = json_decode(json_encode($this->foo), is_array($this->foo));
+        }
+        if (isset($this->encoded)) {
+            $this->encoded = json_decode(json_encode($this->encoded), is_array($this->encoded));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-7.4/MyClass.php
@@ -273,4 +273,14 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = json_decode(json_encode($this->foo), is_array($this->foo));
+        }
+        if (isset($this->encoded)) {
+            $this->encoded = json_decode(json_encode($this->encoded), is_array($this->encoded));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRefDefs/Output-8.4/MyClass.php
@@ -244,4 +244,14 @@ class MyClass
 
         return $validator->isValid();
     }
+
+    public function __clone()
+    {
+        if (isset($this->foo)) {
+            $this->foo = json_decode(json_encode($this->foo), is_array($this->foo));
+        }
+        if (isset($this->encoded)) {
+            $this->encoded = json_decode(json_encode($this->encoded), is_array($this->encoded));
+        }
+    }
 }

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
@@ -695,36 +695,24 @@ class MyClass
             $this->arrayOfUnions = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                },
+                    array_map(fn ($i) => $i, $i),
+                (is_array($i) || is_array($i)) => $i,
             }, $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $this->arrayOfRefUnions = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                },
+                    array_map(fn ($i) => $i, $i),
+                (is_array($i) || is_array($i)) => $i,
             }, $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $this->arrayOfRefAndNotRefUnions = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                },
+                    array_map(fn ($i) => $i, $i),
+                (is_array($i) || is_array($i)) => $i,
             }, $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {

--- a/tests/Generator/Fixtures/UnionArrayTyped/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayTyped/Output-8.4/MyClass.php
@@ -527,29 +527,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        if (isset($this->unionOfTypedArrays)) {
-            $this->unionOfTypedArrays = match (true) {
-                is_array($this->unionOfTypedArrays) => $this->unionOfTypedArrays,
-            };
-        }
-        if (isset($this->refUnionOfTypedArrays)) {
-            $this->refUnionOfTypedArrays = match (true) {
-                is_array($this->refUnionOfTypedArrays) => $this->refUnionOfTypedArrays,
-            };
-        }
-        if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            $this->refAndNotRefUnionOfTypedArrays = match (true) {
-                is_array($this->refAndNotRefUnionOfTypedArrays) => $this->refAndNotRefUnionOfTypedArrays,
-            };
-        }
-        if (isset($this->unionOfTypedArrayAndString)) {
-            $this->unionOfTypedArrayAndString = match (true) {
-                is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString) =>
-                    $this->unionOfTypedArrayAndString,
-            };
-        }
-    }
 }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -359,20 +359,4 @@ class MyClass
 
         return $validator->isValid();
     }
-
-    public function __clone()
-    {
-        $this->foo = match (true) {
-            is_string($this->foo) => $this->foo,
-        };
-        $this->bar = match (true) {
-            is_string($this->bar) => $this->bar,
-        };
-        $this->baz = match (true) {
-            is_string($this->baz) => $this->baz,
-        };
-        $this->qux = match (true) {
-            is_string($this->qux) => $this->qux,
-        };
-    }
 }

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -346,12 +346,7 @@ class Cat
                     || (is_int($this->hasFur) || is_float($this->hasFur))
                     || is_bool($this->hasFur)
                 ) =>
-                    match (true) {
-                        is_string($this->hasFur)
-                            || (is_int($this->hasFur) || is_float($this->hasFur))
-                            || is_bool($this->hasFur) =>
-                            $this->hasFur,
-                    },
+                    $this->hasFur,
             };
         }
     }


### PR DESCRIPTION
## Summary
- deep clone unstructured `object` properties using JSON encode/decode
- avoid generating pointless `__clone` methods when unions don't transform values
- update fixtures and snapshots for new cloning behavior

## Testing
- `vendor/bin/phpstan --memory-limit=512M`
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a05af63bb0832db029111f6eaa3ab9