### PR TITLE
Deduplicate union property condition checks

### DIFF
--- a/src/Generator/Property/Decorator/NullablePropertyDecorator.php
+++ b/src/Generator/Property/Decorator/NullablePropertyDecorator.php
@@ -199,6 +199,20 @@ class NullablePropertyDecorator implements PropertyDecoratorInterface
         return OrGenerator::make(["{$expr} === null", $this->inner->inputAssertionExpr($expr)]);
     }
 
+    public function inputAssertionConditions(string $expr): array
+    {
+        return array_merge([
+            "{$expr} === null",
+        ], $this->inner->inputAssertionConditions($expr));
+    }
+
+    public function typeAssertionConditions(string $expr): array
+    {
+        return array_merge([
+            "{$expr} === null",
+        ], $this->inner->typeAssertionConditions($expr));
+    }
+
     public function inputMappingExpr(string $expr, bool $asserted = false): string
     {
         // Let the inner property build its own mapping (casts, builder calls, …)

--- a/src/Generator/Property/Type/AbstractProperty.php
+++ b/src/Generator/Property/Type/AbstractProperty.php
@@ -140,6 +140,16 @@ abstract class AbstractProperty implements PropertyInterface
         return $this->typeAssertionExpr($expr);
     }
 
+    public function inputAssertionConditions(string $expr): array
+    {
+        return [$this->inputAssertionExpr($expr)];
+    }
+
+    public function typeAssertionConditions(string $expr): array
+    {
+        return [$this->typeAssertionExpr($expr)];
+    }
+
     public function inputMappingExpr(string $expr, bool $asserted = false): string
     {
         return $expr;

--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -65,8 +65,8 @@ class UnionProperty extends AbstractProperty
         $accessor = "\${$inputVarName}->{{$this->keyStr()}}";
         $arms = [];
         foreach ($this->subProperties as $subProperty) {
-            $mapping       = $subProperty->inputMappingExpr($accessor, asserted: true);
-            $discriminator = $subProperty->inputAssertionExpr($accessor);
+            $mapping    = $subProperty->inputMappingExpr($accessor, asserted: true);
+            $conditions = $subProperty->inputAssertionConditions($accessor);
 
             if (
                 $subProperty instanceof ReferenceArrayProperty
@@ -74,17 +74,19 @@ class UnionProperty extends AbstractProperty
                 || $subProperty instanceof PrimitiveArrayProperty
             ) {
                 $isArrayCheck = "is_array({$accessor})";
-                if (!str_contains($discriminator, $isArrayCheck)) {
-                    $discriminator = "({$isArrayCheck} && {$discriminator})";
+                if (!in_array($isArrayCheck, $conditions, true)) {
+                    $conditions[] = $isArrayCheck;
                 }
             }
 
-            $arms[$mapping][] = $discriminator;
+            foreach ($conditions as $cond) {
+                $arms[$mapping][] = $cond;
+            }
         }
 
         $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
+        foreach ($arms as $mapping => $conds) {
+            $conditions = array_values(array_unique($conds));
             $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
         }
 
@@ -117,10 +119,10 @@ class UnionProperty extends AbstractProperty
     
         // Build up per‑arm conversions
         foreach ($this->subProperties as $subProp) {
-            $mapping       = $subProp->inputMappingExpr($accessor, asserted: true);
-            $assignment    = "\${$name} = {$mapping};";
-            $discriminator = $subProp->inputAssertionExpr($accessor);
-    
+            $mapping    = $subProp->inputMappingExpr($accessor, asserted: true);
+            $assignment = "\${$name} = {$mapping};";
+            $conditions = $subProp->inputAssertionConditions($accessor);
+
             // If this arm is an "array" type, ensure its test guards against non-arrays
             if (
                 $subProp instanceof ReferenceArrayProperty
@@ -128,15 +130,18 @@ class UnionProperty extends AbstractProperty
                 || $subProp instanceof PrimitiveArrayProperty
             ) {
                 $isArrayCheck = "is_array({$accessor})";
-                if (!str_contains($discriminator, $isArrayCheck)) {
-                    $discriminator = "({$isArrayCheck} && {$discriminator})";
+                if (!in_array($isArrayCheck, $conditions, true)) {
+                    $conditions[] = $isArrayCheck;
                 }
             }
-    
+
             if (! isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => [], "fallback" => false];
             }
-            $conversions[$assignment]["discriminators"][] = $discriminator;
+            $conversions[$assignment]["discriminators"] = array_merge(
+                $conversions[$assignment]["discriminators"],
+                $conditions
+            );
         }
     
         // Turn those into an if/elseif/else chain
@@ -188,14 +193,16 @@ class UnionProperty extends AbstractProperty
         $arms  = [];
 
         foreach ($this->subProperties as $subProperty) {
-            $mapping       = $subProperty->outputMappingExpr("\$this->{$name}");
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
-            $arms[$mapping][] = $discriminator;
+            $mapping    = $subProperty->outputMappingExpr("\$this->{$name}");
+            $conditions = $subProperty->typeAssertionConditions("\$this->{$name}");
+            foreach ($conditions as $cond) {
+                $arms[$mapping][] = $cond;
+            }
         }
 
         $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
+        foreach ($arms as $mapping => $conds) {
+            $conditions = array_values(array_unique($conds));
             $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
         }
         $outputVarName = VariableNames::OUTPUT;
@@ -209,14 +216,16 @@ class UnionProperty extends AbstractProperty
         $arms  = [];
 
         foreach ($this->subProperties as $subProperty) {
-            $mapping       = $subProperty->outputMappingExprStdClass("\$this->{$name}");
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
-            $arms[$mapping][] = $discriminator;
+            $mapping    = $subProperty->outputMappingExprStdClass("\$this->{$name}");
+            $conditions = $subProperty->typeAssertionConditions("\$this->{$name}");
+            foreach ($conditions as $cond) {
+                $arms[$mapping][] = $cond;
+            }
         }
 
         $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
+        foreach ($arms as $mapping => $conds) {
+            $conditions = array_values(array_unique($conds));
             $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
         }
 
@@ -236,15 +245,18 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
 
         foreach ($this->subProperties as $subProperty) {
-            $mapping       = $subProperty->outputMappingExpr("\$this->{$name}");
-            $assignment    = "\${$outputVarName}[{$keyStr}] = {$mapping};";
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+            $mapping    = $subProperty->outputMappingExpr("\$this->{$name}");
+            $assignment = "\${$outputVarName}[{$keyStr}] = {$mapping};";
+            $conditions = $subProperty->typeAssertionConditions("\$this->{$name}");
 
             if (!isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => []];
             }
 
-            $conversions[$assignment]["discriminators"][] = $discriminator;
+            $conversions[$assignment]["discriminators"] = array_merge(
+                $conversions[$assignment]["discriminators"],
+                $conditions
+            );
         }
 
         $indent = StringUtils::indentCode(...);
@@ -277,15 +289,18 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
 
         foreach ($this->subProperties as $subProperty) {
-            $mapping       = $subProperty->outputMappingExprStdClass("\$this->{$name}");
-            $assignment    = "\${$outputVarName}->{{$keyStr}} = {$mapping};";
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+            $mapping    = $subProperty->outputMappingExprStdClass("\$this->{$name}");
+            $assignment = "\${$outputVarName}->{{$keyStr}} = {$mapping};";
+            $conditions = $subProperty->typeAssertionConditions("\$this->{$name}");
 
             if (!isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => []];
             }
 
-            $conversions[$assignment]["discriminators"][] = $discriminator;
+            $conversions[$assignment]["discriminators"] = array_merge(
+                $conversions[$assignment]["discriminators"],
+                $conditions
+            );
         }
 
         $indent = StringUtils::indentCode(...);
@@ -404,24 +419,28 @@ class UnionProperty extends AbstractProperty
 
     public function typeAssertionExpr(string $expr): string
     {
-        $subAssertions = [];
+        $conditions = [];
 
         foreach ($this->subProperties as $prop) {
-            $subAssertions[] = $prop->typeAssertionExpr($expr);
+            $conditions = array_merge($conditions, $prop->typeAssertionConditions($expr));
         }
 
-        return OrGenerator::make($subAssertions);
+        $conditions = array_values(array_unique($conditions));
+
+        return OrGenerator::make($conditions);
     }
 
     public function inputAssertionExpr(string $expr): string
     {
-        $subAssertions = [];
+        $conditions = [];
 
         foreach ($this->subProperties as $prop) {
-            $subAssertions[] = $prop->inputAssertionExpr($expr);
+            $conditions = array_merge($conditions, $prop->inputAssertionConditions($expr));
         }
 
-        return OrGenerator::make($subAssertions);
+        $conditions = array_values(array_unique($conditions));
+
+        return OrGenerator::make($conditions);
     }
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string
@@ -429,9 +448,11 @@ class UnionProperty extends AbstractProperty
         if ($this->request->isAtLeastPHP("8.0")) {
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
-                $map = $subProperty->inputMappingExpr($expr);
-                $assert = $subProperty->inputAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                $map       = $subProperty->inputMappingExpr($expr);
+                $conds     = $subProperty->inputAssertionConditions($expr);
+                foreach ($conds as $cond) {
+                    $arms[$map][] = $cond;
+                }
             }
 
             $match = new MatchGenerator("true");
@@ -446,9 +467,9 @@ class UnionProperty extends AbstractProperty
 
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
-            $map = $subProperty->inputMappingExpr($expr);
-            $assert = $subProperty->inputAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            $map   = $subProperty->inputMappingExpr($expr);
+            $conds = $subProperty->inputAssertionConditions($expr);
+            $conversions[$map] = array_merge($conversions[$map] ?? [], $conds);
         }
 
         $out = "null";
@@ -466,9 +487,11 @@ class UnionProperty extends AbstractProperty
         if ($this->request->isAtLeastPHP("8.0")) {
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
-                $map = $subProperty->outputMappingExpr($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                $map    = $subProperty->outputMappingExpr($expr);
+                $conds  = $subProperty->typeAssertionConditions($expr);
+                foreach ($conds as $cond) {
+                    $arms[$map][] = $cond;
+                }
             }
 
             $match = new MatchGenerator("true");
@@ -483,9 +506,9 @@ class UnionProperty extends AbstractProperty
 
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
-            $map = $subProperty->outputMappingExpr($expr);
-            $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            $map   = $subProperty->outputMappingExpr($expr);
+            $conds = $subProperty->typeAssertionConditions($expr);
+            $conversions[$map] = array_merge($conversions[$map] ?? [], $conds);
         }
 
         $out = "null";
@@ -503,9 +526,11 @@ class UnionProperty extends AbstractProperty
         if ($this->request->isAtLeastPHP("8.0")) {
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
-                $map = $subProperty->outputMappingExprStdClass($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                $map   = $subProperty->outputMappingExprStdClass($expr);
+                $conds = $subProperty->typeAssertionConditions($expr);
+                foreach ($conds as $cond) {
+                    $arms[$map][] = $cond;
+                }
             }
 
             $match = new MatchGenerator("true");
@@ -529,8 +554,8 @@ class UnionProperty extends AbstractProperty
                 continue;
             }
 
-            $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            $conds = $subProperty->typeAssertionConditions($expr);
+            $conversions[$map] = array_merge($conversions[$map] ?? [], $conds);
         }
 
         if ($conversions === []) {
@@ -552,9 +577,11 @@ class UnionProperty extends AbstractProperty
         if ($this->request->isAtLeastPHP("8.0")) {
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
-                $map = $subProperty->cloneExpr($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                $map   = $subProperty->cloneExpr($expr);
+                $conds = $subProperty->typeAssertionConditions($expr);
+                foreach ($conds as $cond) {
+                    $arms[$map][] = $cond;
+                }
             }
 
             if (count($arms) === 1) {
@@ -585,8 +612,8 @@ class UnionProperty extends AbstractProperty
                 continue;
             }
 
-            $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            $conds = $subProperty->typeAssertionConditions($expr);
+            $conversions[$map] = array_merge($conversions[$map] ?? [], $conds);
         }
 
         if ($conversions === []) {

--- a/src/Generator/Property/Type/Object/RawObjectProperty.php
+++ b/src/Generator/Property/Type/Object/RawObjectProperty.php
@@ -38,9 +38,22 @@ class RawObjectProperty extends AbstractProperty
         return null;
     }
 
+    public function typeAssertionConditions(string $expr): array
+    {
+        return [
+            'is_array(' . $expr . ')',
+            'is_object(' . $expr . ')',
+        ];
+    }
+
+    public function inputAssertionConditions(string $expr): array
+    {
+        return $this->typeAssertionConditions($expr);
+    }
+
     public function typeAssertionExpr(string $expr): string
     {
-        return 'is_array(' . $expr . ') || is_object(' . $expr . ')';
+        return implode(' || ', $this->typeAssertionConditions($expr));
     }
 
     public function outputMappingExpr(string $expr): string

--- a/src/Generator/Property/Type/PropertyInterface.php
+++ b/src/Generator/Property/Type/PropertyInterface.php
@@ -117,6 +117,36 @@ interface PropertyInterface extends TypeExpressionInterface
     public function convertTypeToStdClass(): string;
 
     /**
+     * Returns a list of individual assertion expressions that must all be
+     * satisfied for {@see inputAssertionExpr()} to hold.
+     *
+     * Implementations may return multiple expressions when their assertion is
+     * composed of several OR'ed conditions.  Each element should be a standalone
+     * PHP expression without surrounding parentheses.
+     *
+     * The default implementation in {@see AbstractProperty} returns an array
+     * containing the result of {@see inputAssertionExpr()}.
+     *
+     * @return list<string>
+     */
+    public function inputAssertionConditions(string $expr): array;
+
+    /**
+     * Returns a list of individual assertion expressions that must all be
+     * satisfied for {@see typeAssertionExpr()} to hold.
+     *
+     * Implementations may return multiple expressions when their assertion is
+     * composed of several OR'ed conditions.  Each element should be a standalone
+     * PHP expression without surrounding parentheses.
+     *
+     * The default implementation in {@see AbstractProperty} returns an array
+     * containing the result of {@see typeAssertionExpr()}.
+     *
+     * @return list<string>
+     */
+    public function typeAssertionConditions(string $expr): array;
+
+    /**
      * Generates additional PHP classes or enums required by this property.
      *
      * For example nested object definitions or union arms may be emitted as

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -492,10 +492,7 @@ class MyClass
         $i = null;
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
-                ? ((is_array($input->{'i'})
-                    || is_string($input->{'i'})
-                    || is_array($input->{'i'}) || is_object($input->{'i'})
-                )
+                ? ((is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}))
                     ? $input->{'i'}
                     : null
                 )

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -406,10 +406,7 @@ class MyClass
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
                 ? match (true) {
-                    is_array($input->{'i'})
-                        || is_string($input->{'i'})
-                        || is_array($input->{'i'}) || is_object($input->{'i'}) =>
-                        $input->{'i'},
+                    is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}) => $input->{'i'},
                     default => null,
                 }
                 : null

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -835,17 +835,13 @@ class MyClass
             : null;
         $arrObjUnion = isset($input->{'arrObjUnion'})
             ? match (true) {
-                is_array($input->{'arrObjUnion'})
-                    || is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) =>
-                    $input->{'arrObjUnion'},
+                is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) => $input->{'arrObjUnion'},
                 default => null,
             }
             : null;
         $objArrUnion = isset($input->{'objArrUnion'})
             ? match (true) {
-                is_array($input->{'objArrUnion'})
-                    || is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) =>
-                    $input->{'objArrUnion'},
+                is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) => $input->{'objArrUnion'},
                 default => null,
             }
             : null;

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -417,7 +417,8 @@ class MyClass
             is_string($input->{'baz'})
                 || (is_int($input->{'baz'}) || is_float($input->{'baz'}))
                 || is_bool($input->{'baz'})
-                || is_array($input->{'baz'}) || is_object($input->{'baz'}) =>
+                || is_array($input->{'baz'})
+                || is_object($input->{'baz'}) =>
                 $input->{'baz'},
             default => throw new \InvalidArgumentException("could not build property 'baz' from JSON"),
         };
@@ -426,16 +427,13 @@ class MyClass
                 || (is_int($input->{'qux'}) || is_float($input->{'qux'}))
                 || is_bool($input->{'qux'})
                 || is_array($input->{'qux'})
-                || is_array($input->{'qux'}) || is_object($input->{'qux'}) =>
+                || is_object($input->{'qux'}) =>
                 $input->{'qux'},
             default => throw new \InvalidArgumentException("could not build property 'qux' from JSON"),
         };
         $thud = ($input->{'thud'} !== null
             ? match (true) {
-                is_string($input->{'thud'})
-                    || is_array($input->{'thud'})
-                    || is_array($input->{'thud'}) || is_object($input->{'thud'}) =>
-                    $input->{'thud'},
+                is_string($input->{'thud'}) || is_array($input->{'thud'}) || is_object($input->{'thud'}) => $input->{'thud'},
                 (is_int($input->{'thud'}) || is_float($input->{'thud'})) =>
                     (str_contains((string)$input->{'thud'}, '.')
                         ? (float)$input->{'thud'}
@@ -484,10 +482,7 @@ class MyClass
             : null;
         $optQux = isset($input->{'optQux'})
             ? match (true) {
-                is_string($input->{'optQux'})
-                    || is_array($input->{'optQux'})
-                    || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) =>
-                    $input->{'optQux'},
+                is_string($input->{'optQux'}) || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) => $input->{'optQux'},
                 (is_int($input->{'optQux'}) || is_float($input->{'optQux'})) =>
                     (str_contains((string)$input->{'optQux'}, '.')
                         ? (float)$input->{'optQux'}
@@ -501,10 +496,7 @@ class MyClass
         if (property_exists($input, 'optThud')) {
             $optThud = ($input->{'optThud'} !== null
                 ? match (true) {
-                    is_string($input->{'optThud'})
-                        || is_array($input->{'optThud'})
-                        || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) =>
-                        $input->{'optThud'},
+                    is_string($input->{'optThud'}) || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) => $input->{'optThud'},
                     (is_int($input->{'optThud'}) || is_float($input->{'optThud'})) =>
                         (str_contains((string)$input->{'optThud'}, '.')
                             ? (float)$input->{'optThud'}

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
@@ -456,7 +456,7 @@ class MyClass
                         : null
                     )
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $input->{'arrayOfUnions'})
             : null;
         $arrayOfRefUnions = isset($input->{'arrayOfRefUnions'})
@@ -470,7 +470,7 @@ class MyClass
                         : null
                     )
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $input->{'arrayOfRefUnions'})
             : null;
         $arrayOfRefAndNotRefUnions = isset($input->{'arrayOfRefAndNotRefUnions'})
@@ -484,7 +484,7 @@ class MyClass
                         : null
                     )
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $input->{'arrayOfRefAndNotRefUnions'})
             : null;
         $arrayOfUnionOfStringAndArray = isset($input->{'arrayOfUnionOfStringAndArray'})
@@ -529,7 +529,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
@@ -537,7 +537,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
@@ -545,7 +545,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
@@ -577,7 +577,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
@@ -585,7 +585,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
@@ -593,7 +593,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
@@ -447,7 +447,7 @@ class MyClass
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -463,7 +463,7 @@ class MyClass
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -479,7 +479,7 @@ class MyClass
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -531,7 +531,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -546,7 +546,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -561,7 +561,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -600,7 +600,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -615,7 +615,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -630,7 +630,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -696,7 +696,7 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => $i, $i),
-                (is_array($i) || is_array($i)) => $i,
+                (is_array($i)) => $i,
             }, $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
@@ -704,7 +704,7 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => $i, $i),
-                (is_array($i) || is_array($i)) => $i,
+                (is_array($i)) => $i,
             }, $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
@@ -712,7 +712,7 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => $i, $i),
-                (is_array($i) || is_array($i)) => $i,
+                (is_array($i)) => $i,
             }, $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -161,11 +161,10 @@ class Cat
         if (property_exists($input, 'hasFur')) {
             $hasFur = ($input->{'hasFur'} !== null
                 ? match (true) {
-                    ($input->{'hasFur'} === null || is_bool($input->{'hasFur'})) =>
+                    $input->{'hasFur'} === null || is_bool($input->{'hasFur'}) =>
                         ($input->{'hasFur'} !== null ? (bool)$input->{'hasFur'} : null),
-                    ($input->{'hasFur'} === null
-                        || (is_string($input->{'hasFur'}) || (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})))
-                    ) =>
+                    $input->{'hasFur'} === null
+                        || (is_string($input->{'hasFur'}) || (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'}))) =>
                         ($input->{'hasFur'} !== null
                             ? match (true) {
                                 is_string($input->{'hasFur'}) => $input->{'hasFur'},
@@ -222,10 +221,9 @@ class Cat
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
             $output['hasFur'] = ($this->hasFur !== null
                 ? match (true) {
-                    ($this->hasFur === null || is_bool($this->hasFur)) => ($this->hasFur !== null ? $this->hasFur : null),
-                    ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
+                    $this->hasFur === null || is_bool($this->hasFur) => ($this->hasFur !== null ? $this->hasFur : null),
+                    $this->hasFur === null
+                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur))) =>
                         ($this->hasFur !== null
                             ? match (true) {
                                 is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
@@ -265,10 +263,9 @@ class Cat
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
             $output->{'hasFur'} = ($this->hasFur !== null
                 ? match (true) {
-                    ($this->hasFur === null || is_bool($this->hasFur)) => ($this->hasFur !== null ? $this->hasFur : null),
-                    ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
+                    $this->hasFur === null || is_bool($this->hasFur) => ($this->hasFur !== null ? $this->hasFur : null),
+                    $this->hasFur === null
+                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur))) =>
                         ($this->hasFur !== null
                             ? match (true) {
                                 is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
@@ -337,10 +334,9 @@ class Cat
     {
         if (isset($this->hasFur)) {
             $this->hasFur = match (true) {
-                ($this->hasFur === null || is_bool($this->hasFur))
-                    || ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
+                $this->hasFur === null
+                    || is_bool($this->hasFur)
+                    || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur))) =>
                     (isset($this->hasFur) ? clone $this->hasFur : null),
                 (is_string($this->hasFur)
                     || (is_int($this->hasFur) || is_float($this->hasFur))


### PR DESCRIPTION
## Summary
- split assertion expressions into individual conditions
- build union property conditionals from unique atomic checks
- update raw object handling and snapshots

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68a06af9d398832db17280007f29ca77