### PR TITLE
Fix redundant type checks for array/object union properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Now it:
 - Deterministic resolution of class property, accessor method and temporary variable names via a unified resolver, allowing case-sensitive properties and avoiding collisions with reserved names.
 - Option `mutableSetters` allows generating mutable `setX()` methods (optionally chainable).
 - Skips emitting empty `__construct` or `__clone` methods.
+- Removes redundant type-check branches for union properties combining array and object alternatives.
 - Prints a notice when skipping `definitions` that do not describe an object.
 - Validates written files with `php -l` to ensure generated code is syntactically correct.
 - Handles URL-encoded references

--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -17,7 +17,9 @@ use Helmich\Schema2Class\Generator\Property\Type\AbstractProperty;
 use Helmich\Schema2Class\Generator\Property\Type\Array\ObjectArrayProperty;
 use Helmich\Schema2Class\Generator\Property\Type\Array\PrimitiveArrayProperty;
 use Helmich\Schema2Class\Generator\Property\Type\Array\ReferenceArrayProperty;
+use Helmich\Schema2Class\Generator\Property\Type\Array\TypedArrayProperty;
 use Helmich\Schema2Class\Generator\Property\Type\Object\NestedObjectProperty;
+use Helmich\Schema2Class\Generator\Property\Type\Object\RawObjectProperty;
 use Helmich\Schema2Class\Generator\Property\Type\PropertyInterface;
 use Helmich\Schema2Class\Generator\Property\Type\ReferenceProperty;
 use Helmich\Schema2Class\Generator\ReferencedType\ReferencedTypeClass;
@@ -51,6 +53,27 @@ class UnionProperty extends AbstractProperty
             return PropertyBuilder::buildPropertyFromSchema($generatorRequest, "{$key}Alternative" . ($idx + 1), $subSchema, true);
         }, array_keys($schema["oneOf"]));
 
+        $hasArray = false;
+        foreach ($this->subProperties as $subProperty) {
+            if (
+                $subProperty instanceof PrimitiveArrayProperty
+                || $subProperty instanceof ObjectArrayProperty
+                || $subProperty instanceof ReferenceArrayProperty
+                || $subProperty instanceof TypedArrayProperty
+            ) {
+                $hasArray = true;
+                break;
+            }
+        }
+
+        if ($hasArray) {
+            foreach ($this->subProperties as $subProperty) {
+                if ($subProperty instanceof RawObjectProperty) {
+                    $subProperty->allowArrays(false);
+                }
+            }
+        }
+
         parent::__construct($key, $schema, $generatorRequest);
     }
 
@@ -72,6 +95,7 @@ class UnionProperty extends AbstractProperty
                 $subProperty instanceof ReferenceArrayProperty
                 || $subProperty instanceof ObjectArrayProperty
                 || $subProperty instanceof PrimitiveArrayProperty
+                || $subProperty instanceof TypedArrayProperty
             ) {
                 $isArrayCheck = "is_array({$accessor})";
                 if (!str_contains($discriminator, $isArrayCheck)) {
@@ -126,6 +150,7 @@ class UnionProperty extends AbstractProperty
                 $subProp instanceof ReferenceArrayProperty
                 || $subProp instanceof ObjectArrayProperty
                 || $subProp instanceof PrimitiveArrayProperty
+                || $subProp instanceof TypedArrayProperty
             ) {
                 $isArrayCheck = "is_array({$accessor})";
                 if (!str_contains($discriminator, $isArrayCheck)) {

--- a/src/Generator/Property/Type/Object/RawObjectProperty.php
+++ b/src/Generator/Property/Type/Object/RawObjectProperty.php
@@ -12,6 +12,8 @@ use Helmich\Schema2Class\Generator\Property\Type\AbstractProperty;
  */
 class RawObjectProperty extends AbstractProperty
 {
+    private bool $allowArrays = true;
+
     public static function canHandleSchema(array $schema): bool
     {
         $isObject = (isset($schema['type']) && $schema['type'] === 'object');
@@ -27,20 +29,22 @@ class RawObjectProperty extends AbstractProperty
 
     public function typeAnnotation(): string
     {
-        return 'array|object';
+        return $this->allowArrays ? 'array|object' : 'object';
     }
 
     public function typeHint(): ?string
     {
         if (Semver::satisfies($this->request->getTargetPHPVersion(), '>=8.0')) {
-            return 'array|object';
+            return $this->allowArrays ? 'array|object' : 'object';
         }
         return null;
     }
 
     public function typeAssertionExpr(string $expr): string
     {
-        return 'is_array(' . $expr . ') || is_object(' . $expr . ')';
+        return $this->allowArrays
+            ? 'is_array(' . $expr . ') || is_object(' . $expr . ')'
+            : 'is_object(' . $expr . ')';
     }
 
     public function outputMappingExpr(string $expr): string
@@ -58,7 +62,10 @@ class RawObjectProperty extends AbstractProperty
         // TODO: in fact, when such object stored as array, it can contain nested objects (that's
         // why we deep-clone it in that case too), but they will be converted to arrays as well.
         // Gotta rethink raw objects handling maintaining both consistency and convenience.
-        return "json_decode(json_encode({$expr}), is_array({$expr}))";
+        if ($this->allowArrays) {
+            return "json_decode(json_encode({$expr}), is_array({$expr}))";
+        }
+        return "json_decode(json_encode({$expr}))";
     }
 
     public function needsValidation(): bool
@@ -66,5 +73,10 @@ class RawObjectProperty extends AbstractProperty
         // Schema places no restrictions beyond "object", so PHP type hints are
         // sufficient (or validation would be meaningless for PHP < 8).
         return false;
+    }
+
+    public function allowArrays(bool $allow): void
+    {
+        $this->allowArrays = $allow;
     }
 }

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -492,10 +492,7 @@ class MyClass
         $i = null;
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
-                ? ((is_array($input->{'i'})
-                    || is_string($input->{'i'})
-                    || is_array($input->{'i'}) || is_object($input->{'i'})
-                )
+                ? ((is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}))
                     ? $input->{'i'}
                     : null
                 )
@@ -553,10 +550,7 @@ class MyClass
             $output['i'] = ($this->i !== null
                 ? ((is_array($this->i) || is_string($this->i))
                     ? $this->i
-                    : ((is_array($this->i) || is_object($this->i))
-                        ? json_decode(json_encode($this->i), true)
-                        : null
-                    )
+                    : ((is_object($this->i)) ? json_decode(json_encode($this->i), true) : null)
                 )
                 : null
             );
@@ -603,10 +597,7 @@ class MyClass
             $output->{'i'} = ($this->i !== null
                 ? ((is_array($this->i) || is_string($this->i))
                     ? $this->i
-                    : ((is_array($this->i) || is_object($this->i))
-                        ? json_decode(json_encode($this->i))
-                        : null
-                    )
+                    : ((is_object($this->i)) ? json_decode(json_encode($this->i)) : null)
                 )
                 : null
             );
@@ -655,10 +646,7 @@ class MyClass
     public function __clone()
     {
         if (isset($this->i)) {
-            $this->i = ((is_array($this->i) || is_object($this->i))
-                ? json_decode(json_encode($this->i), is_array($this->i))
-                : $this->i
-            );
+            $this->i = ((is_object($this->i)) ? json_decode(json_encode($this->i)) : $this->i);
         }
     }
 

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -406,10 +406,7 @@ class MyClass
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
                 ? match (true) {
-                    is_array($input->{'i'})
-                        || is_string($input->{'i'})
-                        || is_array($input->{'i'}) || is_object($input->{'i'}) =>
-                        $input->{'i'},
+                    is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}) => $input->{'i'},
                     default => null,
                 }
                 : null
@@ -469,7 +466,7 @@ class MyClass
             $output['i'] = ($this->i !== null
                 ? match (true) {
                     is_array($this->i) || is_string($this->i) => $this->i,
-                    is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), true),
+                    is_object($this->i) => json_decode(json_encode($this->i), true),
                     default => null,
                 }
                 : null
@@ -520,7 +517,7 @@ class MyClass
             $output->{'i'} = ($this->i !== null
                 ? match (true) {
                     is_array($this->i) || is_string($this->i) => $this->i,
-                    is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i)),
+                    is_object($this->i) => json_decode(json_encode($this->i)),
                     default => null,
                 }
                 : null
@@ -572,7 +569,7 @@ class MyClass
         if (isset($this->i)) {
             $this->i = match (true) {
                 is_array($this->i) || is_string($this->i) => $this->i,
-                is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), is_array($this->i)),
+                is_object($this->i) => json_decode(json_encode($this->i)),
             };
         }
     }

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -835,17 +835,13 @@ class MyClass
             : null;
         $arrObjUnion = isset($input->{'arrObjUnion'})
             ? match (true) {
-                is_array($input->{'arrObjUnion'})
-                    || is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) =>
-                    $input->{'arrObjUnion'},
+                is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) => $input->{'arrObjUnion'},
                 default => null,
             }
             : null;
         $objArrUnion = isset($input->{'objArrUnion'})
             ? match (true) {
-                is_array($input->{'objArrUnion'})
-                    || is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) =>
-                    $input->{'objArrUnion'},
+                is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) => $input->{'objArrUnion'},
                 default => null,
             }
             : null;
@@ -929,13 +925,13 @@ class MyClass
         if (isset($this->arrObjUnion)) {
             $output['arrObjUnion'] = match (true) {
                 is_array($this->arrObjUnion) => $this->arrObjUnion,
-                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion), true),
+                is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion), true),
             };
         }
         if (isset($this->objArrUnion)) {
             $output['objArrUnion'] = match (true) {
                 is_array($this->objArrUnion) => $this->objArrUnion,
-                is_array($this->objArrUnion) || is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion), true),
+                is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion), true),
             };
         }
         if (isset($this->numKeysDefaults)) {
@@ -1004,13 +1000,13 @@ class MyClass
         if (isset($this->arrObjUnion)) {
             $output->{'arrObjUnion'} = match (true) {
                 is_array($this->arrObjUnion) => $this->arrObjUnion,
-                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion)),
+                is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion)),
             };
         }
         if (isset($this->objArrUnion)) {
             $output->{'objArrUnion'} = match (true) {
                 is_array($this->objArrUnion) => $this->objArrUnion,
-                is_array($this->objArrUnion) || is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion)),
+                is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion)),
             };
         }
         if (isset($this->numKeysDefaults)) {
@@ -1109,15 +1105,13 @@ class MyClass
         if (isset($this->arrObjUnion)) {
             $this->arrObjUnion = match (true) {
                 is_array($this->arrObjUnion) => $this->arrObjUnion,
-                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) =>
-                    json_decode(json_encode($this->arrObjUnion), is_array($this->arrObjUnion)),
+                is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion)),
             };
         }
         if (isset($this->objArrUnion)) {
             $this->objArrUnion = match (true) {
                 is_array($this->objArrUnion) => $this->objArrUnion,
-                is_array($this->objArrUnion) || is_object($this->objArrUnion) =>
-                    json_decode(json_encode($this->objArrUnion), is_array($this->objArrUnion)),
+                is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion)),
             };
         }
         if (isset($this->numKeysDefaults)) {

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -426,16 +426,13 @@ class MyClass
                 || (is_int($input->{'qux'}) || is_float($input->{'qux'}))
                 || is_bool($input->{'qux'})
                 || is_array($input->{'qux'})
-                || is_array($input->{'qux'}) || is_object($input->{'qux'}) =>
+                || is_object($input->{'qux'}) =>
                 $input->{'qux'},
             default => throw new \InvalidArgumentException("could not build property 'qux' from JSON"),
         };
         $thud = ($input->{'thud'} !== null
             ? match (true) {
-                is_string($input->{'thud'})
-                    || is_array($input->{'thud'})
-                    || is_array($input->{'thud'}) || is_object($input->{'thud'}) =>
-                    $input->{'thud'},
+                is_string($input->{'thud'}) || is_array($input->{'thud'}) || is_object($input->{'thud'}) => $input->{'thud'},
                 (is_int($input->{'thud'}) || is_float($input->{'thud'})) =>
                     (str_contains((string)$input->{'thud'}, '.')
                         ? (float)$input->{'thud'}
@@ -484,10 +481,7 @@ class MyClass
             : null;
         $optQux = isset($input->{'optQux'})
             ? match (true) {
-                is_string($input->{'optQux'})
-                    || is_array($input->{'optQux'})
-                    || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) =>
-                    $input->{'optQux'},
+                is_string($input->{'optQux'}) || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) => $input->{'optQux'},
                 (is_int($input->{'optQux'}) || is_float($input->{'optQux'})) =>
                     (str_contains((string)$input->{'optQux'}, '.')
                         ? (float)$input->{'optQux'}
@@ -501,10 +495,7 @@ class MyClass
         if (property_exists($input, 'optThud')) {
             $optThud = ($input->{'optThud'} !== null
                 ? match (true) {
-                    is_string($input->{'optThud'})
-                        || is_array($input->{'optThud'})
-                        || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) =>
-                        $input->{'optThud'},
+                    is_string($input->{'optThud'}) || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) => $input->{'optThud'},
                     (is_int($input->{'optThud'}) || is_float($input->{'optThud'})) =>
                         (str_contains((string)$input->{'optThud'}, '.')
                             ? (float)$input->{'optThud'}
@@ -569,7 +560,7 @@ class MyClass
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
                 $this->qux,
-            is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux), true),
+            is_object($this->qux) => json_decode(json_encode($this->qux), true),
         };
         $output['thud'] = match (true) {
             is_string($this->thud)
@@ -577,7 +568,7 @@ class MyClass
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
                 $this->thud,
-            is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud), true),
+            is_object($this->thud) => json_decode(json_encode($this->thud), true),
         };
         if (isset($this->optFoo)) {
             $output['optFoo'] = match (true) {
@@ -612,7 +603,7 @@ class MyClass
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
                     $this->optQux,
-                is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux), true),
+                is_object($this->optQux) => json_decode(json_encode($this->optQux), true),
             };
         }
         if (isset($this->optThud) || array_key_exists('optThud', $this->_providedOptionals)) {
@@ -623,7 +614,7 @@ class MyClass
                         || is_bool($this->optThud)
                         || is_array($this->optThud) =>
                         $this->optThud,
-                    is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud), true),
+                    is_object($this->optThud) => json_decode(json_encode($this->optThud), true),
                     default => null,
                 }
                 : null
@@ -662,7 +653,7 @@ class MyClass
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
                 $this->qux,
-            is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux)),
+            is_object($this->qux) => json_decode(json_encode($this->qux)),
         };
         $output->{'thud'} = match (true) {
             is_string($this->thud)
@@ -670,7 +661,7 @@ class MyClass
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
                 $this->thud,
-            is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud)),
+            is_object($this->thud) => json_decode(json_encode($this->thud)),
         };
         if (isset($this->optFoo)) {
             $output->{'optFoo'} = match (true) {
@@ -705,7 +696,7 @@ class MyClass
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
                     $this->optQux,
-                is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux)),
+                is_object($this->optQux) => json_decode(json_encode($this->optQux)),
             };
         }
         if (isset($this->optThud) || array_key_exists('optThud', $this->_providedOptionals)) {
@@ -716,7 +707,7 @@ class MyClass
                         || is_bool($this->optThud)
                         || is_array($this->optThud) =>
                         $this->optThud,
-                    is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud)),
+                    is_object($this->optThud) => json_decode(json_encode($this->optThud)),
                     default => null,
                 }
                 : null
@@ -775,7 +766,7 @@ class MyClass
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
                 $this->qux,
-            is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux), is_array($this->qux)),
+            is_object($this->qux) => json_decode(json_encode($this->qux)),
         };
         $this->thud = match (true) {
             is_string($this->thud)
@@ -783,7 +774,7 @@ class MyClass
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
                 $this->thud,
-            is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud), is_array($this->thud)),
+            is_object($this->thud) => json_decode(json_encode($this->thud)),
         };
         if (isset($this->optBaz)) {
             $this->optBaz = match (true) {
@@ -801,7 +792,7 @@ class MyClass
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
                     $this->optQux,
-                is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux), is_array($this->optQux)),
+                is_object($this->optQux) => json_decode(json_encode($this->optQux)),
             };
         }
         if (isset($this->optThud)) {
@@ -811,7 +802,7 @@ class MyClass
                     || is_bool($this->optThud)
                     || is_array($this->optThud) =>
                     $this->optThud,
-                is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud), is_array($this->optThud)),
+                is_object($this->optThud) => json_decode(json_encode($this->optThud)),
             };
         }
     }


### PR DESCRIPTION
## Summary
- allow RawObjectProperty to ignore array values when an array alternative exists
- teach UnionProperty to disable RawObjectProperty array handling and include typed arrays in array checks
- update fixtures and changelog

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68a06af9d398832db17280007f29ca77