### PR TITLE
Avoid duplicate union type checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Now it:
 - Handles URL-encoded references
 - Handles definition descriptions and/or top-level schema description and adds it to a class' PHPDoc
 - Generates a `toStdClass()` method returning an object representation of the instance
+- Removes duplicate type checks in generated union conditions.
 
 ### Better support for older PHP versions:
 

--- a/src/Generator/Property/Decorator/NullablePropertyDecorator.php
+++ b/src/Generator/Property/Decorator/NullablePropertyDecorator.php
@@ -191,12 +191,22 @@ class NullablePropertyDecorator implements PropertyDecoratorInterface
 
     public function typeAssertionExpr(string $expr): string
     {
-        return OrGenerator::make(["{$expr} === null", $this->inner->typeAssertionExpr($expr)]);
+        return OrGenerator::make($this->typeAssertionConditions($expr));
     }
 
     public function inputAssertionExpr(string $expr): string
     {
-        return OrGenerator::make(["{$expr} === null", $this->inner->inputAssertionExpr($expr)]);
+        return OrGenerator::make($this->inputAssertionConditions($expr));
+    }
+
+    public function typeAssertionConditions(string $expr): array
+    {
+        return array_merge(["{$expr} === null"], $this->inner->typeAssertionConditions($expr));
+    }
+
+    public function inputAssertionConditions(string $expr): array
+    {
+        return array_merge(["{$expr} === null"], $this->inner->inputAssertionConditions($expr));
     }
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string

--- a/src/Generator/Property/Type/AbstractProperty.php
+++ b/src/Generator/Property/Type/AbstractProperty.php
@@ -140,6 +140,16 @@ abstract class AbstractProperty implements PropertyInterface
         return $this->typeAssertionExpr($expr);
     }
 
+    public function typeAssertionConditions(string $expr): array
+    {
+        return [$this->typeAssertionExpr($expr)];
+    }
+
+    public function inputAssertionConditions(string $expr): array
+    {
+        return [$this->inputAssertionExpr($expr)];
+    }
+
     public function inputMappingExpr(string $expr, bool $asserted = false): string
     {
         return $expr;

--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -66,7 +66,7 @@ class UnionProperty extends AbstractProperty
         $arms = [];
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->inputMappingExpr($accessor, asserted: true);
-            $discriminator = $subProperty->inputAssertionExpr($accessor);
+            $discriminators = $subProperty->inputAssertionConditions($accessor);
 
             if (
                 $subProperty instanceof ReferenceArrayProperty
@@ -74,12 +74,17 @@ class UnionProperty extends AbstractProperty
                 || $subProperty instanceof PrimitiveArrayProperty
             ) {
                 $isArrayCheck = "is_array({$accessor})";
-                if (!str_contains($discriminator, $isArrayCheck)) {
-                    $discriminator = "({$isArrayCheck} && {$discriminator})";
+                foreach ($discriminators as &$discriminator) {
+                    if (!str_contains($discriminator, $isArrayCheck)) {
+                        $discriminator = "({$isArrayCheck} && {$discriminator})";
+                    }
                 }
+                unset($discriminator);
             }
 
-            $arms[$mapping][] = $discriminator;
+            foreach ($discriminators as $discriminator) {
+                $arms[$mapping][] = $discriminator;
+            }
         }
 
         $match = new MatchGenerator("true");
@@ -119,8 +124,8 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProp) {
             $mapping       = $subProp->inputMappingExpr($accessor, asserted: true);
             $assignment    = "\${$name} = {$mapping};";
-            $discriminator = $subProp->inputAssertionExpr($accessor);
-    
+            $discriminators = $subProp->inputAssertionConditions($accessor);
+
             // If this arm is an "array" type, ensure its test guards against non-arrays
             if (
                 $subProp instanceof ReferenceArrayProperty
@@ -128,15 +133,20 @@ class UnionProperty extends AbstractProperty
                 || $subProp instanceof PrimitiveArrayProperty
             ) {
                 $isArrayCheck = "is_array({$accessor})";
-                if (!str_contains($discriminator, $isArrayCheck)) {
-                    $discriminator = "({$isArrayCheck} && {$discriminator})";
+                foreach ($discriminators as &$discriminator) {
+                    if (!str_contains($discriminator, $isArrayCheck)) {
+                        $discriminator = "({$isArrayCheck} && {$discriminator})";
+                    }
                 }
+                unset($discriminator);
             }
-    
+
             if (! isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => [], "fallback" => false];
             }
-            $conversions[$assignment]["discriminators"][] = $discriminator;
+            foreach ($discriminators as $discriminator) {
+                $conversions[$assignment]["discriminators"][] = $discriminator;
+            }
         }
     
         // Turn those into an if/elseif/else chain
@@ -189,8 +199,9 @@ class UnionProperty extends AbstractProperty
 
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExpr("\$this->{$name}");
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
-            $arms[$mapping][] = $discriminator;
+            foreach ($subProperty->typeAssertionConditions("\$this->{$name}") as $discriminator) {
+                $arms[$mapping][] = $discriminator;
+            }
         }
 
         $match = new MatchGenerator("true");
@@ -210,8 +221,9 @@ class UnionProperty extends AbstractProperty
 
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExprStdClass("\$this->{$name}");
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
-            $arms[$mapping][] = $discriminator;
+            foreach ($subProperty->typeAssertionConditions("\$this->{$name}") as $discriminator) {
+                $arms[$mapping][] = $discriminator;
+            }
         }
 
         $match = new MatchGenerator("true");
@@ -238,13 +250,15 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExpr("\$this->{$name}");
             $assignment    = "\${$outputVarName}[{$keyStr}] = {$mapping};";
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+            $discriminators = $subProperty->typeAssertionConditions("\$this->{$name}");
 
             if (!isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => []];
             }
 
-            $conversions[$assignment]["discriminators"][] = $discriminator;
+            foreach ($discriminators as $discriminator) {
+                $conversions[$assignment]["discriminators"][] = $discriminator;
+            }
         }
 
         $indent = StringUtils::indentCode(...);
@@ -279,13 +293,15 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExprStdClass("\$this->{$name}");
             $assignment    = "\${$outputVarName}->{{$keyStr}} = {$mapping};";
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+            $discriminators = $subProperty->typeAssertionConditions("\$this->{$name}");
 
             if (!isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => []];
             }
 
-            $conversions[$assignment]["discriminators"][] = $discriminator;
+            foreach ($discriminators as $discriminator) {
+                $conversions[$assignment]["discriminators"][] = $discriminator;
+            }
         }
 
         $indent = StringUtils::indentCode(...);
@@ -407,10 +423,12 @@ class UnionProperty extends AbstractProperty
         $subAssertions = [];
 
         foreach ($this->subProperties as $prop) {
-            $subAssertions[] = $prop->typeAssertionExpr($expr);
+            foreach ($prop->typeAssertionConditions($expr) as $cond) {
+                $subAssertions[$cond] = true;
+            }
         }
 
-        return OrGenerator::make($subAssertions);
+        return OrGenerator::make(array_keys($subAssertions));
     }
 
     public function inputAssertionExpr(string $expr): string
@@ -418,10 +436,12 @@ class UnionProperty extends AbstractProperty
         $subAssertions = [];
 
         foreach ($this->subProperties as $prop) {
-            $subAssertions[] = $prop->inputAssertionExpr($expr);
+            foreach ($prop->inputAssertionConditions($expr) as $cond) {
+                $subAssertions[$cond] = true;
+            }
         }
 
-        return OrGenerator::make($subAssertions);
+        return OrGenerator::make(array_keys($subAssertions));
     }
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string
@@ -430,8 +450,9 @@ class UnionProperty extends AbstractProperty
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->inputMappingExpr($expr);
-                $assert = $subProperty->inputAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                foreach ($subProperty->inputAssertionConditions($expr) as $assert) {
+                    $arms[$map][] = $assert;
+                }
             }
 
             $match = new MatchGenerator("true");
@@ -447,8 +468,9 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->inputMappingExpr($expr);
-            $assert = $subProperty->inputAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            foreach ($subProperty->inputAssertionConditions($expr) as $assert) {
+                $conversions[$map][] = $assert;
+            }
         }
 
         $out = "null";
@@ -467,8 +489,9 @@ class UnionProperty extends AbstractProperty
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->outputMappingExpr($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                foreach ($subProperty->typeAssertionConditions($expr) as $assert) {
+                    $arms[$map][] = $assert;
+                }
             }
 
             $match = new MatchGenerator("true");
@@ -484,8 +507,9 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->outputMappingExpr($expr);
-            $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            foreach ($subProperty->typeAssertionConditions($expr) as $assert) {
+                $conversions[$map][] = $assert;
+            }
         }
 
         $out = "null";
@@ -504,8 +528,9 @@ class UnionProperty extends AbstractProperty
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->outputMappingExprStdClass($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                foreach ($subProperty->typeAssertionConditions($expr) as $assert) {
+                    $arms[$map][] = $assert;
+                }
             }
 
             $match = new MatchGenerator("true");
@@ -529,8 +554,9 @@ class UnionProperty extends AbstractProperty
                 continue;
             }
 
-            $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            foreach ($subProperty->typeAssertionConditions($expr) as $assert) {
+                $conversions[$map][] = $assert;
+            }
         }
 
         if ($conversions === []) {
@@ -553,8 +579,9 @@ class UnionProperty extends AbstractProperty
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->cloneExpr($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                foreach ($subProperty->typeAssertionConditions($expr) as $assert) {
+                    $arms[$map][] = $assert;
+                }
             }
 
             if (count($arms) === 1) {
@@ -585,8 +612,9 @@ class UnionProperty extends AbstractProperty
                 continue;
             }
 
-            $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            foreach ($subProperty->typeAssertionConditions($expr) as $assert) {
+                $conversions[$map][] = $assert;
+            }
         }
 
         if ($conversions === []) {

--- a/src/Generator/Property/Type/Object/RawObjectProperty.php
+++ b/src/Generator/Property/Type/Object/RawObjectProperty.php
@@ -43,6 +43,21 @@ class RawObjectProperty extends AbstractProperty
         return 'is_array(' . $expr . ') || is_object(' . $expr . ')';
     }
 
+    public function typeAssertionConditions(string $expr): array
+    {
+        return ['is_array(' . $expr . ')', 'is_object(' . $expr . ')'];
+    }
+
+    public function inputAssertionExpr(string $expr): string
+    {
+        return $this->typeAssertionExpr($expr);
+    }
+
+    public function inputAssertionConditions(string $expr): array
+    {
+        return $this->typeAssertionConditions($expr);
+    }
+
     public function outputMappingExpr(string $expr): string
     {
         return 'json_decode(json_encode(' . $expr . '), true)';

--- a/src/Generator/ReferencedType/ReferencedTypeClass.php
+++ b/src/Generator/ReferencedType/ReferencedTypeClass.php
@@ -61,11 +61,21 @@ readonly class ReferencedTypeClass implements ReferencedTypeInterface
         return "{$expr} instanceof {$cls}";
     }
 
+    public function typeAssertionConditions(string $expr): array
+    {
+        return [$this->typeAssertionExpr($expr)];
+    }
+
     public function inputAssertionExpr(string $expr): string
     {
         $cls = $this->relativeName();
         $VALIDATE_INPUT = MethodNames::VALIDATE_INPUT;
         return "{$cls}::{$VALIDATE_INPUT}({$expr}, true)";
+    }
+
+    public function inputAssertionConditions(string $expr): array
+    {
+        return [$this->inputAssertionExpr($expr)];
     }
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string

--- a/src/Generator/ReferencedType/ReferencedTypeEnum.php
+++ b/src/Generator/ReferencedType/ReferencedTypeEnum.php
@@ -86,6 +86,11 @@ readonly class ReferencedTypeEnum implements ReferencedTypeInterface
         return EnumUtils::assertionExpr($this->schema['enum'], $expr);
     }
 
+    public function typeAssertionConditions(string $expr): array
+    {
+        return [$this->typeAssertionExpr($expr)];
+    }
+
     public function inputAssertionExpr(string $expr): string
     {
         if ($this->canUseNativeEnum()) {
@@ -93,6 +98,11 @@ readonly class ReferencedTypeEnum implements ReferencedTypeInterface
         }
 
         return EnumUtils::assertionExpr($this->schema['enum'], $expr);
+    }
+
+    public function inputAssertionConditions(string $expr): array
+    {
+        return [$this->inputAssertionExpr($expr)];
     }
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string

--- a/src/Generator/ReferencedType/ReferencedTypeUnknown.php
+++ b/src/Generator/ReferencedType/ReferencedTypeUnknown.php
@@ -61,9 +61,19 @@ readonly class ReferencedTypeUnknown implements ReferencedTypeInterface
         return "true";
     }
 
+    public function typeAssertionConditions(string $expr): array
+    {
+        return [$this->typeAssertionExpr($expr)];
+    }
+
     public function inputAssertionExpr(string $expr): string
     {
         return "true";
+    }
+
+    public function inputAssertionConditions(string $expr): array
+    {
+        return [$this->inputAssertionExpr($expr)];
     }
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string

--- a/src/Generator/TypeExpressionInterface.php
+++ b/src/Generator/TypeExpressionInterface.php
@@ -32,12 +32,30 @@ interface TypeExpressionInterface
      *                      or accessor like `$this->property`
      */
     public function typeAssertionExpr(string $expr): string;
-    
+
     /**
      * Generates a boolean expression that checks whether a raw input value can
      * be converted to this property type.
      */
     public function inputAssertionExpr(string $expr): string;
+
+    /**
+     * Returns individual conditions combined by {@see typeAssertionExpr} with logical OR.
+     *
+     * Implementations may return more than one element when a type assertion itself
+     * is composed of multiple disjunctive checks.  Each returned string MUST be a
+     * valid boolean expression.
+     *
+     * @return array<int,string>
+     */
+    public function typeAssertionConditions(string $expr): array;
+
+    /**
+     * Returns individual conditions combined by {@see inputAssertionExpr} with logical OR.
+     *
+     * @return array<int,string>
+     */
+    public function inputAssertionConditions(string $expr): array;
     
     /**
      * Generates an expression that maps an input value to the internal PHP value representation.

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -492,10 +492,7 @@ class MyClass
         $i = null;
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
-                ? ((is_array($input->{'i'})
-                    || is_string($input->{'i'})
-                    || is_array($input->{'i'}) || is_object($input->{'i'})
-                )
+                ? ((is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}))
                     ? $input->{'i'}
                     : null
                 )

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -406,10 +406,7 @@ class MyClass
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
                 ? match (true) {
-                    is_array($input->{'i'})
-                        || is_string($input->{'i'})
-                        || is_array($input->{'i'}) || is_object($input->{'i'}) =>
-                        $input->{'i'},
+                    is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}) => $input->{'i'},
                     default => null,
                 }
                 : null

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -835,17 +835,13 @@ class MyClass
             : null;
         $arrObjUnion = isset($input->{'arrObjUnion'})
             ? match (true) {
-                is_array($input->{'arrObjUnion'})
-                    || is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) =>
-                    $input->{'arrObjUnion'},
+                is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) => $input->{'arrObjUnion'},
                 default => null,
             }
             : null;
         $objArrUnion = isset($input->{'objArrUnion'})
             ? match (true) {
-                is_array($input->{'objArrUnion'})
-                    || is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) =>
-                    $input->{'objArrUnion'},
+                is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) => $input->{'objArrUnion'},
                 default => null,
             }
             : null;

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -417,7 +417,8 @@ class MyClass
             is_string($input->{'baz'})
                 || (is_int($input->{'baz'}) || is_float($input->{'baz'}))
                 || is_bool($input->{'baz'})
-                || is_array($input->{'baz'}) || is_object($input->{'baz'}) =>
+                || is_array($input->{'baz'})
+                || is_object($input->{'baz'}) =>
                 $input->{'baz'},
             default => throw new \InvalidArgumentException("could not build property 'baz' from JSON"),
         };
@@ -426,16 +427,13 @@ class MyClass
                 || (is_int($input->{'qux'}) || is_float($input->{'qux'}))
                 || is_bool($input->{'qux'})
                 || is_array($input->{'qux'})
-                || is_array($input->{'qux'}) || is_object($input->{'qux'}) =>
+                || is_object($input->{'qux'}) =>
                 $input->{'qux'},
             default => throw new \InvalidArgumentException("could not build property 'qux' from JSON"),
         };
         $thud = ($input->{'thud'} !== null
             ? match (true) {
-                is_string($input->{'thud'})
-                    || is_array($input->{'thud'})
-                    || is_array($input->{'thud'}) || is_object($input->{'thud'}) =>
-                    $input->{'thud'},
+                is_string($input->{'thud'}) || is_array($input->{'thud'}) || is_object($input->{'thud'}) => $input->{'thud'},
                 (is_int($input->{'thud'}) || is_float($input->{'thud'})) =>
                     (str_contains((string)$input->{'thud'}, '.')
                         ? (float)$input->{'thud'}
@@ -484,10 +482,7 @@ class MyClass
             : null;
         $optQux = isset($input->{'optQux'})
             ? match (true) {
-                is_string($input->{'optQux'})
-                    || is_array($input->{'optQux'})
-                    || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) =>
-                    $input->{'optQux'},
+                is_string($input->{'optQux'}) || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) => $input->{'optQux'},
                 (is_int($input->{'optQux'}) || is_float($input->{'optQux'})) =>
                     (str_contains((string)$input->{'optQux'}, '.')
                         ? (float)$input->{'optQux'}
@@ -501,10 +496,7 @@ class MyClass
         if (property_exists($input, 'optThud')) {
             $optThud = ($input->{'optThud'} !== null
                 ? match (true) {
-                    is_string($input->{'optThud'})
-                        || is_array($input->{'optThud'})
-                        || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) =>
-                        $input->{'optThud'},
+                    is_string($input->{'optThud'}) || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) => $input->{'optThud'},
                     (is_int($input->{'optThud'}) || is_float($input->{'optThud'})) =>
                         (str_contains((string)$input->{'optThud'}, '.')
                             ? (float)$input->{'optThud'}

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
@@ -456,7 +456,7 @@ class MyClass
                         : null
                     )
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $input->{'arrayOfUnions'})
             : null;
         $arrayOfRefUnions = isset($input->{'arrayOfRefUnions'})
@@ -470,7 +470,7 @@ class MyClass
                         : null
                     )
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $input->{'arrayOfRefUnions'})
             : null;
         $arrayOfRefAndNotRefUnions = isset($input->{'arrayOfRefAndNotRefUnions'})
@@ -484,7 +484,7 @@ class MyClass
                         : null
                     )
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $input->{'arrayOfRefAndNotRefUnions'})
             : null;
         $arrayOfUnionOfStringAndArray = isset($input->{'arrayOfUnionOfStringAndArray'})
@@ -529,7 +529,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
@@ -537,7 +537,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
@@ -545,7 +545,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
@@ -577,7 +577,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
@@ -585,7 +585,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
@@ -593,7 +593,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : (((is_array($i))) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
@@ -447,7 +447,7 @@ class MyClass
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -463,7 +463,7 @@ class MyClass
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -479,7 +479,7 @@ class MyClass
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -531,7 +531,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -546,7 +546,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -561,7 +561,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -600,7 +600,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -615,7 +615,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -630,7 +630,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                (is_array($i)) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -696,7 +696,7 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => $i, $i),
-                (is_array($i) || is_array($i)) => $i,
+                (is_array($i)) => $i,
             }, $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
@@ -704,7 +704,7 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => $i, $i),
-                (is_array($i) || is_array($i)) => $i,
+                (is_array($i)) => $i,
             }, $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
@@ -712,7 +712,7 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => $i, $i),
-                (is_array($i) || is_array($i)) => $i,
+                (is_array($i)) => $i,
             }, $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -161,11 +161,10 @@ class Cat
         if (property_exists($input, 'hasFur')) {
             $hasFur = ($input->{'hasFur'} !== null
                 ? match (true) {
-                    ($input->{'hasFur'} === null || is_bool($input->{'hasFur'})) =>
+                    $input->{'hasFur'} === null || is_bool($input->{'hasFur'}) =>
                         ($input->{'hasFur'} !== null ? (bool)$input->{'hasFur'} : null),
-                    ($input->{'hasFur'} === null
-                        || (is_string($input->{'hasFur'}) || (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})))
-                    ) =>
+                    $input->{'hasFur'} === null
+                        || (is_string($input->{'hasFur'}) || (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'}))) =>
                         ($input->{'hasFur'} !== null
                             ? match (true) {
                                 is_string($input->{'hasFur'}) => $input->{'hasFur'},
@@ -222,10 +221,9 @@ class Cat
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
             $output['hasFur'] = ($this->hasFur !== null
                 ? match (true) {
-                    ($this->hasFur === null || is_bool($this->hasFur)) => ($this->hasFur !== null ? $this->hasFur : null),
-                    ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
+                    $this->hasFur === null || is_bool($this->hasFur) => ($this->hasFur !== null ? $this->hasFur : null),
+                    $this->hasFur === null
+                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur))) =>
                         ($this->hasFur !== null
                             ? match (true) {
                                 is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
@@ -265,10 +263,9 @@ class Cat
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
             $output->{'hasFur'} = ($this->hasFur !== null
                 ? match (true) {
-                    ($this->hasFur === null || is_bool($this->hasFur)) => ($this->hasFur !== null ? $this->hasFur : null),
-                    ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
+                    $this->hasFur === null || is_bool($this->hasFur) => ($this->hasFur !== null ? $this->hasFur : null),
+                    $this->hasFur === null
+                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur))) =>
                         ($this->hasFur !== null
                             ? match (true) {
                                 is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
@@ -337,10 +334,9 @@ class Cat
     {
         if (isset($this->hasFur)) {
             $this->hasFur = match (true) {
-                ($this->hasFur === null || is_bool($this->hasFur))
-                    || ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
+                $this->hasFur === null
+                    || is_bool($this->hasFur)
+                    || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur))) =>
                     (isset($this->hasFur) ? clone $this->hasFur : null),
                 (is_string($this->hasFur)
                     || (is_int($this->hasFur) || is_float($this->hasFur))


### PR DESCRIPTION
## Summary
- provide access to atomic type conditions and reuse them across property types
- split raw object checks into separate array and object conditions
- merge unique conditions when generating union property branches to prevent duplicate `is_array` guards

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68a06af9d398832db17280007f29ca77