### PR TITLE
Deduplicate union type checks

### DIFF
--- a/src/Generator/Property/Decorator/NullablePropertyDecorator.php
+++ b/src/Generator/Property/Decorator/NullablePropertyDecorator.php
@@ -191,12 +191,26 @@ class NullablePropertyDecorator implements PropertyDecoratorInterface
 
     public function typeAssertionExpr(string $expr): string
     {
-        return OrGenerator::make(["{$expr} === null", $this->inner->typeAssertionExpr($expr)]);
+        return OrGenerator::make($this->typeAssertionExprs($expr));
     }
 
     public function inputAssertionExpr(string $expr): string
     {
-        return OrGenerator::make(["{$expr} === null", $this->inner->inputAssertionExpr($expr)]);
+        return OrGenerator::make($this->inputAssertionExprs($expr));
+    }
+
+    public function typeAssertionExprs(string $expr): array
+    {
+        $conditions = $this->inner->typeAssertionExprs($expr);
+        $conditions[] = "{$expr} === null";
+        return array_values(array_unique($conditions));
+    }
+
+    public function inputAssertionExprs(string $expr): array
+    {
+        $conditions = $this->inner->inputAssertionExprs($expr);
+        $conditions[] = "{$expr} === null";
+        return array_values(array_unique($conditions));
     }
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string

--- a/src/Generator/Property/Decorator/OptionalPropertyDecorator.php
+++ b/src/Generator/Property/Decorator/OptionalPropertyDecorator.php
@@ -42,11 +42,25 @@ class OptionalPropertyDecorator extends NullablePropertyDecorator
             : $this->inner->typeAssertionExpr($expr);
     }
 
+    public function typeAssertionExprs(string $expr): array
+    {
+        return $this->allowsNull()
+            ? parent::typeAssertionExprs($expr)
+            : $this->inner->typeAssertionExprs($expr);
+    }
+
     public function inputAssertionExpr(string $expr): string
     {
         return $this->allowsNull()
             ? parent::inputAssertionExpr($expr)
             : $this->inner->inputAssertionExpr($expr);
+    }
+
+    public function inputAssertionExprs(string $expr): array
+    {
+        return $this->allowsNull()
+            ? parent::inputAssertionExprs($expr)
+            : $this->inner->inputAssertionExprs($expr);
     }
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string

--- a/src/Generator/Property/Type/AbstractProperty.php
+++ b/src/Generator/Property/Type/AbstractProperty.php
@@ -140,6 +140,16 @@ abstract class AbstractProperty implements PropertyInterface
         return $this->typeAssertionExpr($expr);
     }
 
+    public function typeAssertionExprs(string $expr): array
+    {
+        return [ $this->typeAssertionExpr($expr) ];
+    }
+
+    public function inputAssertionExprs(string $expr): array
+    {
+        return [ $this->inputAssertionExpr($expr) ];
+    }
+
     public function inputMappingExpr(string $expr, bool $asserted = false): string
     {
         return $expr;

--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -54,6 +54,31 @@ class UnionProperty extends AbstractProperty
         parent::__construct($key, $schema, $generatorRequest);
     }
 
+    /**
+     * Deduplicate discriminator conditions across all mapping arms while
+     * preserving their evaluation order. Conditions that already appeared in
+     * previous arms are removed from subsequent ones to avoid redundant checks.
+     *
+     * @param array<string,list<string>> $arms
+     * @return array<string,list<string>>
+     */
+    private function deduplicateConditions(array $arms): array
+    {
+        $used = [];
+        $out = [];
+        foreach ($arms as $mapping => $conds) {
+            $conds = array_values(array_unique($conds));
+            $conds = array_values(array_diff($conds, $used));
+            if ($conds === []) {
+                continue;
+            }
+            $used = array_merge($used, $conds);
+            $out[$mapping] = $conds;
+        }
+
+        return $out;
+    }
+
     public static function canHandleSchema(array $schema): bool
     {
         return isset($schema["oneOf"]) || isset($schema["anyOf"]);
@@ -66,7 +91,7 @@ class UnionProperty extends AbstractProperty
         $arms = [];
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->inputMappingExpr($accessor, asserted: true);
-            $discriminator = $subProperty->inputAssertionExpr($accessor);
+            $discriminators = $subProperty->inputAssertionExprs($accessor);
 
             if (
                 $subProperty instanceof ReferenceArrayProperty
@@ -74,17 +99,18 @@ class UnionProperty extends AbstractProperty
                 || $subProperty instanceof PrimitiveArrayProperty
             ) {
                 $isArrayCheck = "is_array({$accessor})";
-                if (!str_contains($discriminator, $isArrayCheck)) {
-                    $discriminator = "({$isArrayCheck} && {$discriminator})";
+                if (!in_array($isArrayCheck, $discriminators, true)) {
+                    $discriminators[] = $isArrayCheck;
                 }
             }
 
-            $arms[$mapping][] = $discriminator;
+            $arms[$mapping] = array_merge($arms[$mapping] ?? [], $discriminators);
         }
 
+        $arms = $this->deduplicateConditions($arms);
+
         $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
+        foreach ($arms as $mapping => $conditions) {
             $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
         }
 
@@ -114,13 +140,13 @@ class UnionProperty extends AbstractProperty
         $conversions = [
             "\${$name} = {$accessor};" => ["discriminators" => [], "fallback" => true],
         ];
-    
+
         // Build up per‑arm conversions
         foreach ($this->subProperties as $subProp) {
             $mapping       = $subProp->inputMappingExpr($accessor, asserted: true);
             $assignment    = "\${$name} = {$mapping};";
-            $discriminator = $subProp->inputAssertionExpr($accessor);
-    
+            $discriminators = $subProp->inputAssertionExprs($accessor);
+
             // If this arm is an "array" type, ensure its test guards against non-arrays
             if (
                 $subProp instanceof ReferenceArrayProperty
@@ -128,15 +154,18 @@ class UnionProperty extends AbstractProperty
                 || $subProp instanceof PrimitiveArrayProperty
             ) {
                 $isArrayCheck = "is_array({$accessor})";
-                if (!str_contains($discriminator, $isArrayCheck)) {
-                    $discriminator = "({$isArrayCheck} && {$discriminator})";
+                if (!in_array($isArrayCheck, $discriminators, true)) {
+                    $discriminators[] = $isArrayCheck;
                 }
             }
-    
+
             if (! isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => [], "fallback" => false];
             }
-            $conversions[$assignment]["discriminators"][] = $discriminator;
+            $conversions[$assignment]["discriminators"] = array_merge(
+                $conversions[$assignment]["discriminators"],
+                $discriminators,
+            );
         }
     
         // Turn those into an if/elseif/else chain
@@ -145,17 +174,23 @@ class UnionProperty extends AbstractProperty
 
         $indent = StringUtils::indentCode(...);
     
+        $conditionArms = [];
         foreach ($conversions as $assignment => $info) {
             if ($info["fallback"]) {
                 $fallback = $assignment;
                 continue;
             }
 
+            $conditionArms[$assignment] = $info["discriminators"];
+        }
+
+        $conditionArms = $this->deduplicateConditions($conditionArms);
+
+        foreach ($conditionArms as $assignment => $conditions) {
             $keyword = count($branches) ? "elseif" : "if";
-            $conditions = array_values(array_unique($info["discriminators"]));
             $parenthesizedCondition = OrGenerator::make($conditions);
 
-            $branches[] = 
+            $branches[] =
                 <<<PHP
                 {$keyword} {$parenthesizedCondition} {
                 {$indent($assignment)}
@@ -189,13 +224,14 @@ class UnionProperty extends AbstractProperty
 
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExpr("\$this->{$name}");
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
-            $arms[$mapping][] = $discriminator;
+            $discriminators = $subProperty->typeAssertionExprs("\$this->{$name}");
+            $arms[$mapping] = array_merge($arms[$mapping] ?? [], $discriminators);
         }
 
+        $arms = $this->deduplicateConditions($arms);
+
         $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
+        foreach ($arms as $mapping => $conditions) {
             $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
         }
         $outputVarName = VariableNames::OUTPUT;
@@ -210,13 +246,14 @@ class UnionProperty extends AbstractProperty
 
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExprStdClass("\$this->{$name}");
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
-            $arms[$mapping][] = $discriminator;
+            $discriminators = $subProperty->typeAssertionExprs("\$this->{$name}");
+            $arms[$mapping] = array_merge($arms[$mapping] ?? [], $discriminators);
         }
 
+        $arms = $this->deduplicateConditions($arms);
+
         $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
+        foreach ($arms as $mapping => $conditions) {
             $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
         }
 
@@ -238,20 +275,28 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExpr("\$this->{$name}");
             $assignment    = "\${$outputVarName}[{$keyStr}] = {$mapping};";
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+            $discriminators = $subProperty->typeAssertionExprs("\$this->{$name}");
 
             if (!isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => []];
             }
 
-            $conversions[$assignment]["discriminators"][] = $discriminator;
+            $conversions[$assignment]["discriminators"] = array_merge(
+                $conversions[$assignment]["discriminators"],
+                $discriminators,
+            );
         }
 
         $indent = StringUtils::indentCode(...);
 
+        $conditionArms = [];
+        foreach ($conversions as $assignment => $info) {
+            $conditionArms[$assignment] = $info['discriminators'];
+        }
+        $conditionArms = $this->deduplicateConditions($conditionArms);
+
         $branches = [];
-        foreach ($conversions as $assignment => $conversion) {
-            $conditions = array_values(array_unique($conversion["discriminators"]));
+        foreach ($conditionArms as $assignment => $conditions) {
             $parenthesizedCondition = OrGenerator::make($conditions);
             $keyword = count($branches) ? "elseif" : "if";
             $branches[] =
@@ -279,20 +324,28 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $mapping       = $subProperty->outputMappingExprStdClass("\$this->{$name}");
             $assignment    = "\${$outputVarName}->{{$keyStr}} = {$mapping};";
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+            $discriminators = $subProperty->typeAssertionExprs("\$this->{$name}");
 
             if (!isset($conversions[$assignment])) {
                 $conversions[$assignment] = ["discriminators" => []];
             }
 
-            $conversions[$assignment]["discriminators"][] = $discriminator;
+            $conversions[$assignment]["discriminators"] = array_merge(
+                $conversions[$assignment]["discriminators"],
+                $discriminators,
+            );
         }
 
         $indent = StringUtils::indentCode(...);
 
+        $conditionArms = [];
+        foreach ($conversions as $assignment => $info) {
+            $conditionArms[$assignment] = $info['discriminators'];
+        }
+        $conditionArms = $this->deduplicateConditions($conditionArms);
+
         $branches = [];
-        foreach ($conversions as $assignment => $conversion) {
-            $conditions = array_values(array_unique($conversion["discriminators"]));
+        foreach ($conditionArms as $assignment => $conditions) {
             $parenthesizedCondition = OrGenerator::make($conditions);
             $keyword = count($branches) ? "elseif" : "if";
             $branches[] =
@@ -404,24 +457,30 @@ class UnionProperty extends AbstractProperty
 
     public function typeAssertionExpr(string $expr): string
     {
-        $subAssertions = [];
-
-        foreach ($this->subProperties as $prop) {
-            $subAssertions[] = $prop->typeAssertionExpr($expr);
-        }
-
-        return OrGenerator::make($subAssertions);
+        return OrGenerator::make($this->typeAssertionExprs($expr));
     }
 
     public function inputAssertionExpr(string $expr): string
     {
-        $subAssertions = [];
+        return OrGenerator::make($this->inputAssertionExprs($expr));
+    }
 
+    public function typeAssertionExprs(string $expr): array
+    {
+        $conditions = [];
         foreach ($this->subProperties as $prop) {
-            $subAssertions[] = $prop->inputAssertionExpr($expr);
+            $conditions = array_merge($conditions, $prop->typeAssertionExprs($expr));
         }
+        return array_values(array_unique($conditions));
+    }
 
-        return OrGenerator::make($subAssertions);
+    public function inputAssertionExprs(string $expr): array
+    {
+        $conditions = [];
+        foreach ($this->subProperties as $prop) {
+            $conditions = array_merge($conditions, $prop->inputAssertionExprs($expr));
+        }
+        return array_values(array_unique($conditions));
     }
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string
@@ -430,13 +489,14 @@ class UnionProperty extends AbstractProperty
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->inputMappingExpr($expr);
-                $assert = $subProperty->inputAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                $asserts = $subProperty->inputAssertionExprs($expr);
+                $arms[$map] = array_merge($arms[$map] ?? [], $asserts);
             }
 
+            $arms = $this->deduplicateConditions($arms);
+
             $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
+            foreach ($arms as $map => $conditions) {
                 $match->addArm(OrGenerator::make($conditions, parens: false), $map);
             }
             $match->addArm("default", "null");
@@ -447,13 +507,18 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->inputMappingExpr($expr);
-            $assert = $subProperty->inputAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            $asserts = $subProperty->inputAssertionExprs($expr);
+            $conversions[$map] = array_merge($conversions[$map] ?? [], $asserts);
         }
 
-        $out = "null";
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
+        $conversions = $this->deduplicateConditions($conversions);
+
+        if ($conversions === []) {
+            return 'null';
+        }
+
+        $out = 'null';
+        foreach (array_reverse($conversions) as $map => $conditions) {
             $cond = OrGenerator::make($conditions);
             $out = TernaryGenerator::make($cond, $map, $out);
         }
@@ -467,13 +532,14 @@ class UnionProperty extends AbstractProperty
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->outputMappingExpr($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                $asserts = $subProperty->typeAssertionExprs($expr);
+                $arms[$map] = array_merge($arms[$map] ?? [], $asserts);
             }
 
+            $arms = $this->deduplicateConditions($arms);
+
             $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
+            foreach ($arms as $map => $conditions) {
                 $match->addArm(OrGenerator::make($conditions, parens: false), $map);
             }
             $match->addArm("default", "null");
@@ -484,13 +550,14 @@ class UnionProperty extends AbstractProperty
         $conversions = [];
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->outputMappingExpr($expr);
-            $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            $asserts = $subProperty->typeAssertionExprs($expr);
+            $conversions[$map] = array_merge($conversions[$map] ?? [], $asserts);
         }
 
+        $conversions = $this->deduplicateConditions($conversions);
+
         $out = "null";
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
+        foreach (array_reverse($conversions) as $map => $conditions) {
             $cond = OrGenerator::make($conditions);
             $out = TernaryGenerator::make($cond, $map, $out);
         }
@@ -504,13 +571,14 @@ class UnionProperty extends AbstractProperty
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->outputMappingExprStdClass($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                $asserts = $subProperty->typeAssertionExprs($expr);
+                $arms[$map] = array_merge($arms[$map] ?? [], $asserts);
             }
 
+            $arms = $this->deduplicateConditions($arms);
+
             $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
+            foreach ($arms as $map => $conditions) {
                 $match->addArm(OrGenerator::make($conditions, parens: false), $map);
             }
             $match->addArm("default", "null");
@@ -522,24 +590,21 @@ class UnionProperty extends AbstractProperty
         foreach ($this->subProperties as $subProperty) {
             $map = $subProperty->outputMappingExprStdClass($expr);
             if ($map === 'null') {
-                // Mapping to `null` does not need a dedicated branch as it is the
-                // default output when no other condition matches. Skipping such
-                // branches also prevents generating ternaries with identical
-                // expressions for both outcomes.
                 continue;
             }
 
-            $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            $asserts = $subProperty->typeAssertionExprs($expr);
+            $conversions[$map] = array_merge($conversions[$map] ?? [], $asserts);
         }
+
+        $conversions = $this->deduplicateConditions($conversions);
 
         if ($conversions === []) {
             return 'null';
         }
 
         $out = 'null';
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
+        foreach (array_reverse($conversions) as $map => $conditions) {
             $cond = OrGenerator::make($conditions);
             $out = TernaryGenerator::make($cond, $map, $out);
         }
@@ -553,8 +618,8 @@ class UnionProperty extends AbstractProperty
             $arms = [];
             foreach ($this->subProperties as $subProperty) {
                 $map = $subProperty->cloneExpr($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
+                $asserts = $subProperty->typeAssertionExprs($expr);
+                $arms[$map] = array_merge($arms[$map] ?? [], $asserts);
             }
 
             if (count($arms) === 1) {
@@ -565,9 +630,10 @@ class UnionProperty extends AbstractProperty
                 return $map;
             }
 
+            $arms = $this->deduplicateConditions($arms);
+
             $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
+            foreach ($arms as $map => $conditions) {
                 $match->addArm(OrGenerator::make($conditions, parens: false), $map);
             }
 
@@ -585,17 +651,18 @@ class UnionProperty extends AbstractProperty
                 continue;
             }
 
-            $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
+            $asserts = $subProperty->typeAssertionExprs($expr);
+            $conversions[$map] = array_merge($conversions[$map] ?? [], $asserts);
         }
+
+        $conversions = $this->deduplicateConditions($conversions);
 
         if ($conversions === []) {
             return $expr;
         }
 
         $out = $expr;
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
+        foreach (array_reverse($conversions) as $map => $conditions) {
             $cond = OrGenerator::make($conditions);
             $out = TernaryGenerator::make($cond, $map, $out);
         }

--- a/src/Generator/Property/Type/Object/RawObjectProperty.php
+++ b/src/Generator/Property/Type/Object/RawObjectProperty.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator\Property\Type\Object;
 
 use Composer\Semver\Semver;
+use Helmich\Schema2Class\Generator\Expression\OrGenerator;
 use Helmich\Schema2Class\Generator\Expression\TernaryGenerator;
 use Helmich\Schema2Class\Generator\Property\Type\AbstractProperty;
 
@@ -40,7 +41,17 @@ class RawObjectProperty extends AbstractProperty
 
     public function typeAssertionExpr(string $expr): string
     {
-        return 'is_array(' . $expr . ') || is_object(' . $expr . ')';
+        return OrGenerator::make($this->typeAssertionExprs($expr), parens: false);
+    }
+
+    public function typeAssertionExprs(string $expr): array
+    {
+        return ['is_array(' . $expr . ')', 'is_object(' . $expr . ')'];
+    }
+
+    public function inputAssertionExprs(string $expr): array
+    {
+        return $this->typeAssertionExprs($expr);
     }
 
     public function outputMappingExpr(string $expr): string

--- a/src/Generator/ReferencedType/ReferencedTypeClass.php
+++ b/src/Generator/ReferencedType/ReferencedTypeClass.php
@@ -94,4 +94,14 @@ readonly class ReferencedTypeClass implements ReferencedTypeInterface
         $TO_STD_CLASS = MethodNames::TO_STD_CLASS;
         return "{$expr}->{$TO_STD_CLASS}({$inclDefaultsArg})";
     }
+
+    public function typeAssertionExprs(string $expr): array
+    {
+        return [ $this->typeAssertionExpr($expr) ];
+    }
+
+    public function inputAssertionExprs(string $expr): array
+    {
+        return [ $this->inputAssertionExpr($expr) ];
+    }
 }

--- a/src/Generator/ReferencedType/ReferencedTypeEnum.php
+++ b/src/Generator/ReferencedType/ReferencedTypeEnum.php
@@ -123,4 +123,14 @@ readonly class ReferencedTypeEnum implements ReferencedTypeInterface
         return $this->canUseNativeEnum();
     }
 
+    public function typeAssertionExprs(string $expr): array
+    {
+        return [ $this->typeAssertionExpr($expr) ];
+    }
+
+    public function inputAssertionExprs(string $expr): array
+    {
+        return [ $this->inputAssertionExpr($expr) ];
+    }
+
 }

--- a/src/Generator/ReferencedType/ReferencedTypeUnknown.php
+++ b/src/Generator/ReferencedType/ReferencedTypeUnknown.php
@@ -80,4 +80,14 @@ readonly class ReferencedTypeUnknown implements ReferencedTypeInterface
     {
         return $expr;
     }
+
+    public function typeAssertionExprs(string $expr): array
+    {
+        return [ $this->typeAssertionExpr($expr) ];
+    }
+
+    public function inputAssertionExprs(string $expr): array
+    {
+        return [ $this->inputAssertionExpr($expr) ];
+    }
 }

--- a/src/Generator/TypeExpressionInterface.php
+++ b/src/Generator/TypeExpressionInterface.php
@@ -32,12 +32,34 @@ interface TypeExpressionInterface
      *                      or accessor like `$this->property`
      */
     public function typeAssertionExpr(string $expr): string;
+
+    /**
+     * Returns the individual conditions that make up the
+     * {@see typeAssertionExpr} boolean expression.
+     *
+     * Implementations typically return an array of simple checks that are
+     * combined with logical OR. Consumers may use these atomic expressions to
+     * build complex conditionals while avoiding duplicated checks.
+     *
+     * @param string $expr  Expression referencing the value being asserted.
+     * @return list<string>
+     */
+    public function typeAssertionExprs(string $expr): array;
     
     /**
      * Generates a boolean expression that checks whether a raw input value can
      * be converted to this property type.
      */
     public function inputAssertionExpr(string $expr): string;
+
+    /**
+     * Returns the individual conditions that make up the
+     * {@see inputAssertionExpr} boolean expression.
+     *
+     * @param string $expr  Expression referencing the input being asserted.
+     * @return list<string>
+     */
+    public function inputAssertionExprs(string $expr): array;
     
     /**
      * Generates an expression that maps an input value to the internal PHP value representation.

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -492,10 +492,7 @@ class MyClass
         $i = null;
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
-                ? ((is_array($input->{'i'})
-                    || is_string($input->{'i'})
-                    || is_array($input->{'i'}) || is_object($input->{'i'})
-                )
+                ? ((is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}))
                     ? $input->{'i'}
                     : null
                 )
@@ -553,10 +550,7 @@ class MyClass
             $output['i'] = ($this->i !== null
                 ? ((is_array($this->i) || is_string($this->i))
                     ? $this->i
-                    : ((is_array($this->i) || is_object($this->i))
-                        ? json_decode(json_encode($this->i), true)
-                        : null
-                    )
+                    : ((is_object($this->i)) ? json_decode(json_encode($this->i), true) : null)
                 )
                 : null
             );
@@ -603,10 +597,7 @@ class MyClass
             $output->{'i'} = ($this->i !== null
                 ? ((is_array($this->i) || is_string($this->i))
                     ? $this->i
-                    : ((is_array($this->i) || is_object($this->i))
-                        ? json_decode(json_encode($this->i))
-                        : null
-                    )
+                    : ((is_object($this->i)) ? json_decode(json_encode($this->i)) : null)
                 )
                 : null
             );

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -406,10 +406,7 @@ class MyClass
         if (property_exists($input, 'i')) {
             $i = ($input->{'i'} !== null
                 ? match (true) {
-                    is_array($input->{'i'})
-                        || is_string($input->{'i'})
-                        || is_array($input->{'i'}) || is_object($input->{'i'}) =>
-                        $input->{'i'},
+                    is_array($input->{'i'}) || is_string($input->{'i'}) || is_object($input->{'i'}) => $input->{'i'},
                     default => null,
                 }
                 : null
@@ -469,7 +466,7 @@ class MyClass
             $output['i'] = ($this->i !== null
                 ? match (true) {
                     is_array($this->i) || is_string($this->i) => $this->i,
-                    is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), true),
+                    is_object($this->i) => json_decode(json_encode($this->i), true),
                     default => null,
                 }
                 : null
@@ -520,7 +517,7 @@ class MyClass
             $output->{'i'} = ($this->i !== null
                 ? match (true) {
                     is_array($this->i) || is_string($this->i) => $this->i,
-                    is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i)),
+                    is_object($this->i) => json_decode(json_encode($this->i)),
                     default => null,
                 }
                 : null
@@ -572,7 +569,7 @@ class MyClass
         if (isset($this->i)) {
             $this->i = match (true) {
                 is_array($this->i) || is_string($this->i) => $this->i,
-                is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), is_array($this->i)),
+                is_object($this->i) => json_decode(json_encode($this->i), is_array($this->i)),
             };
         }
     }

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -835,17 +835,13 @@ class MyClass
             : null;
         $arrObjUnion = isset($input->{'arrObjUnion'})
             ? match (true) {
-                is_array($input->{'arrObjUnion'})
-                    || is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) =>
-                    $input->{'arrObjUnion'},
+                is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) => $input->{'arrObjUnion'},
                 default => null,
             }
             : null;
         $objArrUnion = isset($input->{'objArrUnion'})
             ? match (true) {
-                is_array($input->{'objArrUnion'})
-                    || is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) =>
-                    $input->{'objArrUnion'},
+                is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) => $input->{'objArrUnion'},
                 default => null,
             }
             : null;
@@ -929,13 +925,13 @@ class MyClass
         if (isset($this->arrObjUnion)) {
             $output['arrObjUnion'] = match (true) {
                 is_array($this->arrObjUnion) => $this->arrObjUnion,
-                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion), true),
+                is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion), true),
             };
         }
         if (isset($this->objArrUnion)) {
             $output['objArrUnion'] = match (true) {
                 is_array($this->objArrUnion) => $this->objArrUnion,
-                is_array($this->objArrUnion) || is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion), true),
+                is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion), true),
             };
         }
         if (isset($this->numKeysDefaults)) {
@@ -1004,13 +1000,13 @@ class MyClass
         if (isset($this->arrObjUnion)) {
             $output->{'arrObjUnion'} = match (true) {
                 is_array($this->arrObjUnion) => $this->arrObjUnion,
-                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion)),
+                is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion)),
             };
         }
         if (isset($this->objArrUnion)) {
             $output->{'objArrUnion'} = match (true) {
                 is_array($this->objArrUnion) => $this->objArrUnion,
-                is_array($this->objArrUnion) || is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion)),
+                is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion)),
             };
         }
         if (isset($this->numKeysDefaults)) {
@@ -1109,15 +1105,13 @@ class MyClass
         if (isset($this->arrObjUnion)) {
             $this->arrObjUnion = match (true) {
                 is_array($this->arrObjUnion) => $this->arrObjUnion,
-                is_array($this->arrObjUnion) || is_object($this->arrObjUnion) =>
-                    json_decode(json_encode($this->arrObjUnion), is_array($this->arrObjUnion)),
+                is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion), is_array($this->arrObjUnion)),
             };
         }
         if (isset($this->objArrUnion)) {
             $this->objArrUnion = match (true) {
                 is_array($this->objArrUnion) => $this->objArrUnion,
-                is_array($this->objArrUnion) || is_object($this->objArrUnion) =>
-                    json_decode(json_encode($this->objArrUnion), is_array($this->objArrUnion)),
+                is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion), is_array($this->objArrUnion)),
             };
         }
         if (isset($this->numKeysDefaults)) {

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -197,7 +197,7 @@ class Qux
         $grox = isset($input->{'grox'})
             ? ((is_string($input->{'grox'}) || is_array($input->{'grox'}))
                 ? $input->{'grox'}
-                : (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
+                : ((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true))
                     ? ((Foo::validateInput($input->{'grox'}, true))
                         ? Foo::fromInput($input->{'grox'}, $validate)
                         : ((Bar::validateInput($input->{'grox'}, true))
@@ -232,7 +232,7 @@ class Qux
         if (isset($this->grox)) {
             if (is_string($this->grox) || is_array($this->grox)) {
                 $output['grox'] = $this->grox;
-            } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
+            } elseif ($this->grox instanceof Foo || $this->grox instanceof Bar) {
                 $output['grox'] = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toArray()
                     : null
@@ -255,7 +255,7 @@ class Qux
         if (isset($this->grox)) {
             if (is_string($this->grox) || is_array($this->grox)) {
                 $output->{'grox'} = $this->grox;
-            } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
+            } elseif ($this->grox instanceof Foo || $this->grox instanceof Bar) {
                 $output->{'grox'} = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toStdClass()
                     : null
@@ -305,7 +305,7 @@ class Qux
     public function __clone()
     {
         if (isset($this->grox)) {
-            $this->grox = ((($this->grox instanceof Foo || $this->grox instanceof Bar))
+            $this->grox = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                 ? (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? clone $this->grox
                     : $this->grox

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -185,7 +185,7 @@ class Qux
         $grox = isset($input->{'grox'})
             ? ((is_string($input->{'grox'}) || is_array($input->{'grox'}))
                 ? $input->{'grox'}
-                : (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
+                : ((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true))
                     ? ((Foo::validateInput($input->{'grox'}, true))
                         ? Foo::fromInput($input->{'grox'}, $validate)
                         : ((Bar::validateInput($input->{'grox'}, true))
@@ -220,7 +220,7 @@ class Qux
         if (isset($this->grox)) {
             if (is_string($this->grox) || is_array($this->grox)) {
                 $output['grox'] = $this->grox;
-            } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
+            } elseif ($this->grox instanceof Foo || $this->grox instanceof Bar) {
                 $output['grox'] = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toArray()
                     : null
@@ -243,7 +243,7 @@ class Qux
         if (isset($this->grox)) {
             if (is_string($this->grox) || is_array($this->grox)) {
                 $output->{'grox'} = $this->grox;
-            } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
+            } elseif ($this->grox instanceof Foo || $this->grox instanceof Bar) {
                 $output->{'grox'} = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toStdClass()
                     : null
@@ -294,7 +294,7 @@ class Qux
     public function __clone()
     {
         if (isset($this->grox)) {
-            $this->grox = ((($this->grox instanceof Foo || $this->grox instanceof Bar))
+            $this->grox = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                 ? (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? clone $this->grox
                     : $this->grox

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
@@ -178,7 +178,7 @@ class Qux
         $grox = isset($input->{'grox'})
             ? match (true) {
                 is_string($input->{'grox'}) || is_array($input->{'grox'}) => $input->{'grox'},
-                (Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)) =>
+                Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true) =>
                     match (true) {
                         Foo::validateInput($input->{'grox'}, true) => Foo::fromInput($input->{'grox'}, $validate),
                         Bar::validateInput($input->{'grox'}, true) => Bar::fromInput($input->{'grox'}, $validate),
@@ -210,7 +210,7 @@ class Qux
         if (isset($this->grox)) {
             $output['grox'] = match (true) {
                 is_string($this->grox) || is_array($this->grox) => $this->grox,
-                ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
+                $this->grox instanceof Foo || $this->grox instanceof Bar =>
                     match (true) {
                         $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toArray(),
                         default => null,
@@ -233,7 +233,7 @@ class Qux
         if (isset($this->grox)) {
             $output->{'grox'} = match (true) {
                 is_string($this->grox) || is_array($this->grox) => $this->grox,
-                ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
+                $this->grox instanceof Foo || $this->grox instanceof Bar =>
                     match (true) {
                         $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toStdClass(),
                         default => null,
@@ -286,7 +286,7 @@ class Qux
         if (isset($this->grox)) {
             $this->grox = match (true) {
                 is_string($this->grox) || is_array($this->grox) => $this->grox,
-                ($this->grox instanceof Foo || $this->grox instanceof Bar) => clone $this->grox,
+                $this->grox instanceof Foo || $this->grox instanceof Bar => clone $this->grox,
             };
         }
     }

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -417,7 +417,8 @@ class MyClass
             is_string($input->{'baz'})
                 || (is_int($input->{'baz'}) || is_float($input->{'baz'}))
                 || is_bool($input->{'baz'})
-                || is_array($input->{'baz'}) || is_object($input->{'baz'}) =>
+                || is_array($input->{'baz'})
+                || is_object($input->{'baz'}) =>
                 $input->{'baz'},
             default => throw new \InvalidArgumentException("could not build property 'baz' from JSON"),
         };
@@ -426,16 +427,13 @@ class MyClass
                 || (is_int($input->{'qux'}) || is_float($input->{'qux'}))
                 || is_bool($input->{'qux'})
                 || is_array($input->{'qux'})
-                || is_array($input->{'qux'}) || is_object($input->{'qux'}) =>
+                || is_object($input->{'qux'}) =>
                 $input->{'qux'},
             default => throw new \InvalidArgumentException("could not build property 'qux' from JSON"),
         };
         $thud = ($input->{'thud'} !== null
             ? match (true) {
-                is_string($input->{'thud'})
-                    || is_array($input->{'thud'})
-                    || is_array($input->{'thud'}) || is_object($input->{'thud'}) =>
-                    $input->{'thud'},
+                is_string($input->{'thud'}) || is_array($input->{'thud'}) || is_object($input->{'thud'}) => $input->{'thud'},
                 (is_int($input->{'thud'}) || is_float($input->{'thud'})) =>
                     (str_contains((string)$input->{'thud'}, '.')
                         ? (float)$input->{'thud'}
@@ -484,10 +482,7 @@ class MyClass
             : null;
         $optQux = isset($input->{'optQux'})
             ? match (true) {
-                is_string($input->{'optQux'})
-                    || is_array($input->{'optQux'})
-                    || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) =>
-                    $input->{'optQux'},
+                is_string($input->{'optQux'}) || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) => $input->{'optQux'},
                 (is_int($input->{'optQux'}) || is_float($input->{'optQux'})) =>
                     (str_contains((string)$input->{'optQux'}, '.')
                         ? (float)$input->{'optQux'}
@@ -501,10 +496,7 @@ class MyClass
         if (property_exists($input, 'optThud')) {
             $optThud = ($input->{'optThud'} !== null
                 ? match (true) {
-                    is_string($input->{'optThud'})
-                        || is_array($input->{'optThud'})
-                        || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) =>
-                        $input->{'optThud'},
+                    is_string($input->{'optThud'}) || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) => $input->{'optThud'},
                     (is_int($input->{'optThud'}) || is_float($input->{'optThud'})) =>
                         (str_contains((string)$input->{'optThud'}, '.')
                             ? (float)$input->{'optThud'}
@@ -569,7 +561,7 @@ class MyClass
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
                 $this->qux,
-            is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux), true),
+            is_object($this->qux) => json_decode(json_encode($this->qux), true),
         };
         $output['thud'] = match (true) {
             is_string($this->thud)
@@ -577,7 +569,7 @@ class MyClass
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
                 $this->thud,
-            is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud), true),
+            is_object($this->thud) => json_decode(json_encode($this->thud), true),
         };
         if (isset($this->optFoo)) {
             $output['optFoo'] = match (true) {
@@ -612,7 +604,7 @@ class MyClass
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
                     $this->optQux,
-                is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux), true),
+                is_object($this->optQux) => json_decode(json_encode($this->optQux), true),
             };
         }
         if (isset($this->optThud) || array_key_exists('optThud', $this->_providedOptionals)) {
@@ -623,7 +615,7 @@ class MyClass
                         || is_bool($this->optThud)
                         || is_array($this->optThud) =>
                         $this->optThud,
-                    is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud), true),
+                    is_object($this->optThud) => json_decode(json_encode($this->optThud), true),
                     default => null,
                 }
                 : null
@@ -662,7 +654,7 @@ class MyClass
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
                 $this->qux,
-            is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux)),
+            is_object($this->qux) => json_decode(json_encode($this->qux)),
         };
         $output->{'thud'} = match (true) {
             is_string($this->thud)
@@ -670,7 +662,7 @@ class MyClass
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
                 $this->thud,
-            is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud)),
+            is_object($this->thud) => json_decode(json_encode($this->thud)),
         };
         if (isset($this->optFoo)) {
             $output->{'optFoo'} = match (true) {
@@ -705,7 +697,7 @@ class MyClass
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
                     $this->optQux,
-                is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux)),
+                is_object($this->optQux) => json_decode(json_encode($this->optQux)),
             };
         }
         if (isset($this->optThud) || array_key_exists('optThud', $this->_providedOptionals)) {
@@ -716,7 +708,7 @@ class MyClass
                         || is_bool($this->optThud)
                         || is_array($this->optThud) =>
                         $this->optThud,
-                    is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud)),
+                    is_object($this->optThud) => json_decode(json_encode($this->optThud)),
                     default => null,
                 }
                 : null
@@ -775,7 +767,7 @@ class MyClass
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
                 $this->qux,
-            is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux), is_array($this->qux)),
+            is_object($this->qux) => json_decode(json_encode($this->qux), is_array($this->qux)),
         };
         $this->thud = match (true) {
             is_string($this->thud)
@@ -783,7 +775,7 @@ class MyClass
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
                 $this->thud,
-            is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud), is_array($this->thud)),
+            is_object($this->thud) => json_decode(json_encode($this->thud), is_array($this->thud)),
         };
         if (isset($this->optBaz)) {
             $this->optBaz = match (true) {
@@ -801,7 +793,7 @@ class MyClass
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
                     $this->optQux,
-                is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux), is_array($this->optQux)),
+                is_object($this->optQux) => json_decode(json_encode($this->optQux), is_array($this->optQux)),
             };
         }
         if (isset($this->optThud)) {
@@ -811,7 +803,7 @@ class MyClass
                     || is_bool($this->optThud)
                     || is_array($this->optThud) =>
                     $this->optThud,
-                is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud), is_array($this->optThud)),
+                is_object($this->optThud) => json_decode(json_encode($this->optThud), is_array($this->optThud)),
             };
         }
     }

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
@@ -456,7 +456,7 @@ class MyClass
                         : null
                     )
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $input->{'arrayOfUnions'})
             : null;
         $arrayOfRefUnions = isset($input->{'arrayOfRefUnions'})
@@ -470,7 +470,7 @@ class MyClass
                         : null
                     )
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $input->{'arrayOfRefUnions'})
             : null;
         $arrayOfRefAndNotRefUnions = isset($input->{'arrayOfRefAndNotRefUnions'})
@@ -484,7 +484,7 @@ class MyClass
                         : null
                     )
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $input->{'arrayOfRefAndNotRefUnions'})
             : null;
         $arrayOfUnionOfStringAndArray = isset($input->{'arrayOfUnionOfStringAndArray'})
@@ -529,7 +529,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
@@ -537,7 +537,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
@@ -545,7 +545,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
@@ -577,7 +577,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
@@ -585,7 +585,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
@@ -593,7 +593,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
                 ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : ((is_array($i)) ? ((is_array($i)) ? $i : null) : null)
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
@@ -447,7 +447,7 @@ class MyClass
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -463,7 +463,7 @@ class MyClass
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -479,7 +479,7 @@ class MyClass
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -531,7 +531,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -546,7 +546,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -561,7 +561,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -600,7 +600,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -615,7 +615,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -630,7 +630,7 @@ class MyClass
                         is_string($i) || (is_int($i) || is_float($i)) => $i,
                         default => null,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
+                is_array($i) => match (true) {
                     is_array($i) => $i,
                     default => null,
                 },
@@ -696,7 +696,7 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => $i, $i),
-                (is_array($i) || is_array($i)) => $i,
+                is_array($i) => $i,
             }, $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
@@ -704,7 +704,7 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => $i, $i),
-                (is_array($i) || is_array($i)) => $i,
+                is_array($i) => $i,
             }, $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
@@ -712,7 +712,7 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => $i, $i),
-                (is_array($i) || is_array($i)) => $i,
+                is_array($i) => $i,
             }, $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -161,11 +161,9 @@ class Cat
         if (property_exists($input, 'hasFur')) {
             $hasFur = ($input->{'hasFur'} !== null
                 ? match (true) {
-                    ($input->{'hasFur'} === null || is_bool($input->{'hasFur'})) =>
+                    is_bool($input->{'hasFur'}) || $input->{'hasFur'} === null =>
                         ($input->{'hasFur'} !== null ? (bool)$input->{'hasFur'} : null),
-                    ($input->{'hasFur'} === null
-                        || (is_string($input->{'hasFur'}) || (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})))
-                    ) =>
+                    is_string($input->{'hasFur'}) || (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})) =>
                         ($input->{'hasFur'} !== null
                             ? match (true) {
                                 is_string($input->{'hasFur'}) => $input->{'hasFur'},
@@ -178,20 +176,6 @@ class Cat
                             }
                             : null
                         ),
-                    (is_string($input->{'hasFur'})
-                        || (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'}))
-                        || is_bool($input->{'hasFur'})
-                    ) =>
-                        match (true) {
-                            is_string($input->{'hasFur'}) => $input->{'hasFur'},
-                            (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})) =>
-                                (str_contains((string)$input->{'hasFur'}, '.')
-                                    ? (float)$input->{'hasFur'}
-                                    : (int)$input->{'hasFur'}
-                                ),
-                            is_bool($input->{'hasFur'}) => (bool)$input->{'hasFur'},
-                            default => null,
-                        },
                     default => null,
                 }
                 : null
@@ -222,10 +206,8 @@ class Cat
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
             $output['hasFur'] = ($this->hasFur !== null
                 ? match (true) {
-                    ($this->hasFur === null || is_bool($this->hasFur)) => ($this->hasFur !== null ? $this->hasFur : null),
-                    ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
+                    is_bool($this->hasFur) || $this->hasFur === null => ($this->hasFur !== null ? $this->hasFur : null),
+                    is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) =>
                         ($this->hasFur !== null
                             ? match (true) {
                                 is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
@@ -233,17 +215,6 @@ class Cat
                             }
                             : null
                         ),
-                    (is_string($this->hasFur)
-                        || (is_int($this->hasFur) || is_float($this->hasFur))
-                        || is_bool($this->hasFur)
-                    ) =>
-                        match (true) {
-                            is_string($this->hasFur)
-                                || (is_int($this->hasFur) || is_float($this->hasFur))
-                                || is_bool($this->hasFur) =>
-                                $this->hasFur,
-                            default => null,
-                        },
                     default => null,
                 }
                 : null
@@ -265,10 +236,8 @@ class Cat
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
             $output->{'hasFur'} = ($this->hasFur !== null
                 ? match (true) {
-                    ($this->hasFur === null || is_bool($this->hasFur)) => ($this->hasFur !== null ? $this->hasFur : null),
-                    ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
+                    is_bool($this->hasFur) || $this->hasFur === null => ($this->hasFur !== null ? $this->hasFur : null),
+                    is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) =>
                         ($this->hasFur !== null
                             ? match (true) {
                                 is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
@@ -276,17 +245,6 @@ class Cat
                             }
                             : null
                         ),
-                    (is_string($this->hasFur)
-                        || (is_int($this->hasFur) || is_float($this->hasFur))
-                        || is_bool($this->hasFur)
-                    ) =>
-                        match (true) {
-                            is_string($this->hasFur)
-                                || (is_int($this->hasFur) || is_float($this->hasFur))
-                                || is_bool($this->hasFur) =>
-                                $this->hasFur,
-                            default => null,
-                        },
                     default => null,
                 }
                 : null
@@ -337,16 +295,11 @@ class Cat
     {
         if (isset($this->hasFur)) {
             $this->hasFur = match (true) {
-                ($this->hasFur === null || is_bool($this->hasFur))
-                    || ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
+                is_bool($this->hasFur)
+                    || $this->hasFur === null
+                    || is_string($this->hasFur)
+                    || (is_int($this->hasFur) || is_float($this->hasFur)) =>
                     (isset($this->hasFur) ? clone $this->hasFur : null),
-                (is_string($this->hasFur)
-                    || (is_int($this->hasFur) || is_float($this->hasFur))
-                    || is_bool($this->hasFur)
-                ) =>
-                    $this->hasFur,
             };
         }
     }


### PR DESCRIPTION
## Summary
- avoid repeated `is_array` conditions when combining union property branches
- split raw object assertions into atomic checks for union filtering
- regenerate fixtures

## Testing
- `vendor/bin/phpunit`
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: 3 match.unhandled errors in Spec/SpecificationOptions.php)*

------
https://chatgpt.com/codex/tasks/task_e_68a06af9d398832db17280007f29ca77