### PR TITLE
Refactor UnionProperty code generation

### DIFF
--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -59,251 +59,75 @@ class UnionProperty extends AbstractProperty
         return isset($schema["oneOf"]) || isset($schema["anyOf"]);
     }
 
-    public function convertInputToTypeMatch(): string
-    {
-        $inputVarName = ArgumentNames::INPUT;
-        $accessor = "\${$inputVarName}->{{$this->keyStr()}}";
-        $arms = [];
-        foreach ($this->subProperties as $subProperty) {
-            $mapping       = $subProperty->inputMappingExpr($accessor, asserted: true);
-            $discriminator = $subProperty->inputAssertionExpr($accessor);
-
-            if (
-                $subProperty instanceof ReferenceArrayProperty
-                || $subProperty instanceof ObjectArrayProperty
-                || $subProperty instanceof PrimitiveArrayProperty
-            ) {
-                $isArrayCheck = "is_array({$accessor})";
-                if (!str_contains($discriminator, $isArrayCheck)) {
-                    $discriminator = "({$isArrayCheck} && {$discriminator})";
-                }
-            }
-
-            $arms[$mapping][] = $discriminator;
-        }
-
-        $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
-            $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
-        }
-
-        $match->addArm(
-            "default",
-            "throw new \\InvalidArgumentException(\"could not build property '{$this->key()}' from JSON\")"
-        );
-
-        // assign into the camel‑cased local variable
-        return "\${$this->varName()} = {$match->generate()};";
-    }
-
     public function convertInputToType(): string
     {
-        // PHP 8+ uses match() which already guards correctly
-        if ($this->request->isAtLeastPHP("8.0")) {
-            return $this->convertInputToTypeMatch();
-        }
-    
-        $name   = $this->varName();
-        $keyStr = $this->keyStr();
-    
-        $inputVarName = ArgumentNames::INPUT;
-        $accessor = "\${$inputVarName}->{{$keyStr}}";
-    
-        // Start with a "fallback" that just reassigns the raw value
-        $conversions = [
-            "\${$name} = {$accessor};" => ["discriminators" => [], "fallback" => true],
-        ];
-    
-        // Build up per‑arm conversions
-        foreach ($this->subProperties as $subProp) {
-            $mapping       = $subProp->inputMappingExpr($accessor, asserted: true);
-            $assignment    = "\${$name} = {$mapping};";
-            $discriminator = $subProp->inputAssertionExpr($accessor);
-    
-            // If this arm is an "array" type, ensure its test guards against non-arrays
-            if (
-                $subProp instanceof ReferenceArrayProperty
-                || $subProp instanceof ObjectArrayProperty
-                || $subProp instanceof PrimitiveArrayProperty
-            ) {
-                $isArrayCheck = "is_array({$accessor})";
-                if (!str_contains($discriminator, $isArrayCheck)) {
-                    $discriminator = "({$isArrayCheck} && {$discriminator})";
-                }
-            }
-    
-            if (! isset($conversions[$assignment])) {
-                $conversions[$assignment] = ["discriminators" => [], "fallback" => false];
-            }
-            $conversions[$assignment]["discriminators"][] = $discriminator;
-        }
-    
-        // Turn those into an if/elseif/else chain
-        $branches = [];
-        $fallback = null;
+        $name           = $this->varName();
+        $inputVarName   = ArgumentNames::INPUT;
+        $accessor       = "\${$inputVarName}->{{$this->keyStr()}}";
 
-        $indent = StringUtils::indentCode(...);
-    
-        foreach ($conversions as $assignment => $info) {
-            if ($info["fallback"]) {
-                $fallback = $assignment;
-                continue;
-            }
-
-            $keyword = count($branches) ? "elseif" : "if";
-            $conditions = array_values(array_unique($info["discriminators"]));
-            $parenthesizedCondition = OrGenerator::make($conditions);
-
-            $branches[] = 
-                <<<PHP
-                {$keyword} {$parenthesizedCondition} {
-                {$indent($assignment)}
-                }
-                PHP;
-        }
-    
-        // Attach the fallback at the end
-        if ($fallback !== null) {
-            if (count($branches) > 0) {
-                $branches[] =
-                    <<<PHP
-                    else {
-                    {$indent($fallback)}
+        $arms = $this->collectArms(
+            fn(PropertyInterface $p) => $p->inputMappingExpr($accessor, asserted: true),
+            function (PropertyInterface $p) use ($accessor): string {
+                $discriminator = $p->inputAssertionExpr($accessor);
+                if (
+                    $p instanceof ReferenceArrayProperty
+                    || $p instanceof ObjectArrayProperty
+                    || $p instanceof PrimitiveArrayProperty
+                ) {
+                    $isArrayCheck = "is_array({$accessor})";
+                    if (!str_contains($discriminator, $isArrayCheck)) {
+                        $discriminator = "({$isArrayCheck} && {$discriminator})";
                     }
-                    PHP;
-            } else {
-                $branches[] = $fallback;
+                }
+                return $discriminator;
+            }
+        );
+
+        $assignmentTemplate = "\${$name} = %s;";
+        $fallback           = "\${$name} = {$accessor};";
+        $matchDefault       = "throw new \\InvalidArgumentException(\"could not build property '{$this->key()}' from JSON\")";
+        if (!$this->request->isAtLeastPHP('8.0')) {
+            if (isset($arms[$accessor])) {
+                unset($arms[$accessor]);
+            }
+            if ($arms === []) {
+                return $fallback;
             }
         }
-    
-        return join(" ", $branches);
-    }
-    
 
-    private function convertTypeToArrayMatch(): string
-    {
-        $name   = $this->propName();
-        $keyStr = $this->keyStr();
-        $arms  = [];
-
-        foreach ($this->subProperties as $subProperty) {
-            $mapping       = $subProperty->outputMappingExpr("\$this->{$name}");
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
-            $arms[$mapping][] = $discriminator;
-        }
-
-        $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
-            $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
-        }
-        $outputVarName = VariableNames::OUTPUT;
-        return "\${$outputVarName}[{$keyStr}] = {$match->generate()};";
-    }
-
-    private function convertTypeToStdClassMatch(): string
-    {
-        $name   = $this->propName();
-        $keyStr = $this->keyStr();
-        $arms  = [];
-
-        foreach ($this->subProperties as $subProperty) {
-            $mapping       = $subProperty->outputMappingExprStdClass("\$this->{$name}");
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
-            $arms[$mapping][] = $discriminator;
-        }
-
-        $match = new MatchGenerator("true");
-        foreach ($arms as $mapping => $discriminators) {
-            $conditions = array_values(array_unique($discriminators));
-            $match->addArm(OrGenerator::make($conditions, parens: false), $mapping);
-        }
-
-        $outputVarName = VariableNames::OUTPUT;
-        return "\${$outputVarName}->{{$keyStr}} = {$match->generate()};";
+        return $this->renderAssignments($arms, $assignmentTemplate, $matchDefault, $fallback);
     }
 
     public function convertTypeToArray(): string
     {
-        $outputVarName = VariableNames::OUTPUT;
-        if ($this->request->isAtLeastPHP("8.0")) {
-            return $this->convertTypeToArrayMatch();
-        }
+        $name         = $this->propName();
+        $keyStr       = $this->keyStr();
+        $outputVar    = VariableNames::OUTPUT;
 
-        $name   = $this->propName();
-        $keyStr = $this->keyStr();
-        $conversions = [];
+        $arms = $this->collectArms(
+            fn(PropertyInterface $p) => $p->outputMappingExpr("\$this->{$name}"),
+            fn(PropertyInterface $p) => $p->typeAssertionExpr("\$this->{$name}")
+        );
 
-        foreach ($this->subProperties as $subProperty) {
-            $mapping       = $subProperty->outputMappingExpr("\$this->{$name}");
-            $assignment    = "\${$outputVarName}[{$keyStr}] = {$mapping};";
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+        $assignmentTemplate = "\${$outputVar}[{$keyStr}] = %s;";
 
-            if (!isset($conversions[$assignment])) {
-                $conversions[$assignment] = ["discriminators" => []];
-            }
-
-            $conversions[$assignment]["discriminators"][] = $discriminator;
-        }
-
-        $indent = StringUtils::indentCode(...);
-
-        $branches = [];
-        foreach ($conversions as $assignment => $conversion) {
-            $conditions = array_values(array_unique($conversion["discriminators"]));
-            $parenthesizedCondition = OrGenerator::make($conditions);
-            $keyword = count($branches) ? "elseif" : "if";
-            $branches[] =
-                <<<PHP
-                {$keyword} {$parenthesizedCondition} {
-                {$indent($assignment)}
-                }
-                PHP;
-        }
-
-        return join(" ", $branches);
+        return $this->renderAssignments($arms, $assignmentTemplate, null, null);
     }
 
     public function convertTypeToStdClass(): string
     {
-        $outputVarName = VariableNames::OUTPUT;
-        if ($this->request->isAtLeastPHP("8.0")) {
-            return $this->convertTypeToStdClassMatch();
-        }
+        $name      = $this->propName();
+        $keyStr    = $this->keyStr();
+        $outputVar = VariableNames::OUTPUT;
 
-        $name   = $this->propName();
-        $keyStr = $this->keyStr();
-        $conversions = [];
+        $arms = $this->collectArms(
+            fn(PropertyInterface $p) => $p->outputMappingExprStdClass("\$this->{$name}"),
+            fn(PropertyInterface $p) => $p->typeAssertionExpr("\$this->{$name}")
+        );
 
-        foreach ($this->subProperties as $subProperty) {
-            $mapping       = $subProperty->outputMappingExprStdClass("\$this->{$name}");
-            $assignment    = "\${$outputVarName}->{{$keyStr}} = {$mapping};";
-            $discriminator = $subProperty->typeAssertionExpr("\$this->{$name}");
+        $assignmentTemplate = "\${$outputVar}->{{$keyStr}} = %s;";
 
-            if (!isset($conversions[$assignment])) {
-                $conversions[$assignment] = ["discriminators" => []];
-            }
-
-            $conversions[$assignment]["discriminators"][] = $discriminator;
-        }
-
-        $indent = StringUtils::indentCode(...);
-
-        $branches = [];
-        foreach ($conversions as $assignment => $conversion) {
-            $conditions = array_values(array_unique($conversion["discriminators"]));
-            $parenthesizedCondition = OrGenerator::make($conditions);
-            $keyword = count($branches) ? "elseif" : "if";
-            $branches[] =
-                <<<PHP
-                {$keyword} {$parenthesizedCondition} {
-                {$indent($assignment)}
-                }
-                PHP;
-        }
-
-        return join(" ", $branches);
+        return $this->renderAssignments($arms, $assignmentTemplate, null, null);
     }
 
     /**
@@ -423,184 +247,60 @@ class UnionProperty extends AbstractProperty
 
         return OrGenerator::make($subAssertions);
     }
-
     public function inputMappingExpr(string $expr, bool $asserted = false): string
     {
-        if ($this->request->isAtLeastPHP("8.0")) {
-            $arms = [];
-            foreach ($this->subProperties as $subProperty) {
-                $map = $subProperty->inputMappingExpr($expr);
-                $assert = $subProperty->inputAssertionExpr($expr);
-                $arms[$map][] = $assert;
-            }
+        $arms = $this->collectArms(
+            fn(PropertyInterface $p) => $p->inputMappingExpr($expr),
+            fn(PropertyInterface $p) => $p->inputAssertionExpr($expr)
+        );
 
-            $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
-                $match->addArm(OrGenerator::make($conditions, parens: false), $map);
-            }
-            $match->addArm("default", "null");
-
-            return $match->generate();
-        }
-
-        $conversions = [];
-        foreach ($this->subProperties as $subProperty) {
-            $map = $subProperty->inputMappingExpr($expr);
-            $assert = $subProperty->inputAssertionExpr($expr);
-            $conversions[$map][] = $assert;
-        }
-
-        $out = "null";
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
-            $cond = OrGenerator::make($conditions);
-            $out = TernaryGenerator::make($cond, $map, $out);
-        }
-
-        return $out;
+        return $this->renderConditionalExpr($arms, 'null');
     }
 
     public function outputMappingExpr(string $expr): string
     {
-        if ($this->request->isAtLeastPHP("8.0")) {
-            $arms = [];
-            foreach ($this->subProperties as $subProperty) {
-                $map = $subProperty->outputMappingExpr($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
-            }
+        $arms = $this->collectArms(
+            fn(PropertyInterface $p) => $p->outputMappingExpr($expr),
+            fn(PropertyInterface $p) => $p->typeAssertionExpr($expr)
+        );
 
-            $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
-                $match->addArm(OrGenerator::make($conditions, parens: false), $map);
-            }
-            $match->addArm("default", "null");
-
-            return $match->generate();
-        }
-
-        $conversions = [];
-        foreach ($this->subProperties as $subProperty) {
-            $map = $subProperty->outputMappingExpr($expr);
-            $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
-        }
-
-        $out = "null";
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
-            $cond = OrGenerator::make($conditions);
-            $out = TernaryGenerator::make($cond, $map, $out);
-        }
-
-        return $out;
+        return $this->renderConditionalExpr($arms, 'null');
     }
 
     public function outputMappingExprStdClass(string $expr): string
     {
-        if ($this->request->isAtLeastPHP("8.0")) {
-            $arms = [];
-            foreach ($this->subProperties as $subProperty) {
-                $map = $subProperty->outputMappingExprStdClass($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
-            }
+        $arms = $this->collectArms(
+            fn(PropertyInterface $p) => $p->outputMappingExprStdClass($expr),
+            fn(PropertyInterface $p) => $p->typeAssertionExpr($expr),
+            fn(string $map) => $map === 'null'
+        );
 
-            $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
-                $match->addArm(OrGenerator::make($conditions, parens: false), $map);
-            }
-            $match->addArm("default", "null");
-
-            return $match->generate();
-        }
-
-        $conversions = [];
-        foreach ($this->subProperties as $subProperty) {
-            $map = $subProperty->outputMappingExprStdClass($expr);
-            if ($map === 'null') {
-                // Mapping to `null` does not need a dedicated branch as it is the
-                // default output when no other condition matches. Skipping such
-                // branches also prevents generating ternaries with identical
-                // expressions for both outcomes.
-                continue;
-            }
-
-            $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
-        }
-
-        if ($conversions === []) {
+        if ($arms === []) {
             return 'null';
         }
 
-        $out = 'null';
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
-            $cond = OrGenerator::make($conditions);
-            $out = TernaryGenerator::make($cond, $map, $out);
-        }
-
-        return $out;
+        return $this->renderConditionalExpr($arms, 'null');
     }
 
     public function cloneExpr(string $expr): string
     {
-        if ($this->request->isAtLeastPHP("8.0")) {
-            $arms = [];
-            foreach ($this->subProperties as $subProperty) {
-                $map = $subProperty->cloneExpr($expr);
-                $assert = $subProperty->typeAssertionExpr($expr);
-                $arms[$map][] = $assert;
-            }
+        $arms = $this->collectArms(
+            fn(PropertyInterface $p) => $p->cloneExpr($expr),
+            fn(PropertyInterface $p) => $p->typeAssertionExpr($expr),
+            $this->request->isAtLeastPHP('8.0')
+                ? null
+                : fn(string $map): bool => $map === $expr,
+        );
 
-            if (count($arms) === 1) {
-                $map = array_key_first($arms);
-                if ($map === $expr) {
-                    return $expr;
-                }
-                return $map;
-            }
-
-            $match = new MatchGenerator("true");
-            foreach ($arms as $map => $asserts) {
-                $conditions = array_values(array_unique($asserts));
-                $match->addArm(OrGenerator::make($conditions, parens: false), $map);
-            }
-
-            return $match->generate();
-        }
-
-        $conversions = [];
-        foreach ($this->subProperties as $subProperty) {
-            $map = $subProperty->cloneExpr($expr);
-            if ($map === $expr) {
-                // Identity mapping does not require a conditional branch. If the
-                // expression does not need to be transformed, it can safely fall
-                // through to the default case, avoiding ternaries where both
-                // branches are identical.
-                continue;
-            }
-
-            $assert = $subProperty->typeAssertionExpr($expr);
-            $conversions[$map][] = $assert;
-        }
-
-        if ($conversions === []) {
+        if ($arms === []) {
             return $expr;
         }
 
-        $out = $expr;
-        foreach (array_reverse($conversions) as $map => $asserts) {
-            $conditions = array_values(array_unique($asserts));
-            $cond = OrGenerator::make($conditions);
-            $out = TernaryGenerator::make($cond, $map, $out);
+        if ($this->request->isAtLeastPHP('8.0') && count($arms) === 1) {
+            return array_key_first($arms);
         }
 
-        return $out;
+        return $this->renderConditionalExpr($arms, $expr, false);
     }
 
     public function allowsNull(): bool
@@ -627,5 +327,123 @@ class UnionProperty extends AbstractProperty
         }
 
         return false;
+    }
+
+    /**
+     * @param callable(PropertyInterface):string $mapFn
+     * @param callable(PropertyInterface):string $assertFn
+     * @param callable(string):bool|null $skipFn
+     * @return array<string,string[]>
+     */
+    private function collectArms(callable $mapFn, callable $assertFn, ?callable $skipFn = null): array
+    {
+        $arms = [];
+        foreach ($this->subProperties as $subProperty) {
+            $map = $mapFn($subProperty);
+            if ($skipFn !== null && $skipFn($map)) {
+                continue;
+            }
+            $assert = $assertFn($subProperty);
+            $arms[$map][] = $assert;
+        }
+
+        return $arms;
+    }
+
+    /**
+     * @param array<string,string[]> $arms
+     */
+    private function renderMatch(array $arms, ?string $default): string
+    {
+        $match = new MatchGenerator('true');
+        foreach ($arms as $map => $asserts) {
+            $conditions = array_values(array_unique($asserts));
+            $match->addArm(OrGenerator::make($conditions, parens: false), $map);
+        }
+        if ($default !== null) {
+            $match->addArm('default', $default);
+        }
+
+        return $match->generate();
+    }
+
+    /**
+     * @param array<string,string[]> $arms
+     */
+    private function renderTernary(array $arms, string $default): string
+    {
+        $out = $default;
+        foreach (array_reverse($arms) as $map => $asserts) {
+            $conditions = array_values(array_unique($asserts));
+            $cond       = OrGenerator::make($conditions);
+            $out        = TernaryGenerator::make($cond, $map, $out);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string,string[]> $arms
+     */
+    private function renderConditionalExpr(array $arms, string $default, bool $includeMatchDefault = true): string
+    {
+        if ($this->request->isAtLeastPHP('8.0')) {
+            return $this->renderMatch($arms, $includeMatchDefault ? $default : null);
+        }
+
+        return $this->renderTernary($arms, $default);
+    }
+
+    /**
+     * @param array<string,string[]> $arms
+     */
+    private function renderIfChain(array $arms, string $assignmentTemplate, ?string $fallback): string
+    {
+        $indent   = StringUtils::indentCode(...);
+        $branches = [];
+        $i        = 0;
+        foreach ($arms as $map => $asserts) {
+            $assignment             = sprintf($assignmentTemplate, $map);
+            $conditions             = array_values(array_unique($asserts));
+            $parenthesizedCondition = OrGenerator::make($conditions);
+            $keyword                = $i === 0 ? 'if' : 'elseif';
+            $branches[]             = <<<PHP
+                {$keyword} {$parenthesizedCondition} {
+                {$indent($assignment)}
+                }
+                PHP;
+            $i++;
+        }
+
+        if ($fallback !== null) {
+            if ($branches !== []) {
+                $branches[] = <<<PHP
+                    else {
+                    {$indent($fallback)}
+                    }
+                    PHP;
+            } else {
+                $branches[] = $fallback;
+            }
+        }
+
+        return join(' ', $branches);
+    }
+
+    /**
+     * @param array<string,string[]> $arms
+     */
+    private function renderAssignments(
+        array $arms,
+        string $assignmentTemplate,
+        ?string $matchDefault,
+        ?string $fallback
+    ): string {
+        if ($this->request->isAtLeastPHP('8.0')) {
+            $expr = $this->renderMatch($arms, $matchDefault);
+            return sprintf($assignmentTemplate, $expr);
+        }
+
+        return $this->renderIfChain($arms, $assignmentTemplate, $fallback);
     }
 }


### PR DESCRIPTION
## Summary
- Consolidate UnionProperty's PHP 8 and pre-8 code paths into shared helpers
- Centralize input/output mapping and clone logic via common intermediate representation

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: Match expression does not handle remaining value: true; Match expression does not handle remaining value: true; Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f98a03ec832d85d61e0ebbe16dd0