### PR TITLE
Fix union property fallback handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Now it:
 - Improves type hints and PHPDoc type generation for complex types like unions, nested arrays, etc.
 - Adds a guard against passing anything other than an array/object to `fromInput`, building multi-line validation error messages.
 - Setter methods (`withX()`) now accept an optional `$validate` argument to be able skip validation, mirroring `fromInput()`.
+- Union properties no longer default to `null` when no variant matches; unmatched values are kept as-is and validators are only
+  called when the input is of the correct type.
 - Added support for `additionalProperties` - extra properties, when schema allows them, accessible and writable via according methods of the generated class.
 - Deterministic resolution of class property, accessor method and temporary variable names via a unified resolver, allowing case-sensitive properties and avoiding collisions with reserved names.
 - Option `mutableSetters` allows generating mutable `setX()` methods (optionally chainable).

--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -36,6 +36,7 @@ class UnionProperty extends AbstractProperty
 {
     /** @var PropertyInterface[] */
     private array $subProperties;
+    private bool $hasArraySubtype = false;
 
     public function __construct(string $key, array $schema, GeneratorRequest $generatorRequest)
     {
@@ -50,6 +51,17 @@ class UnionProperty extends AbstractProperty
             $subSchema = $subSchemas[$idx];
             return PropertyBuilder::buildPropertyFromSchema($generatorRequest, "{$key}Alternative" . ($idx + 1), $subSchema, true);
         }, array_keys($schema["oneOf"]));
+
+        foreach ($this->subProperties as $subProperty) {
+            if (
+                $subProperty instanceof ReferenceArrayProperty
+                || $subProperty instanceof ObjectArrayProperty
+                || $subProperty instanceof PrimitiveArrayProperty
+            ) {
+                $this->hasArraySubtype = true;
+                break;
+            }
+        }
 
         parent::__construct($key, $schema, $generatorRequest);
     }
@@ -79,6 +91,14 @@ class UnionProperty extends AbstractProperty
                     if (!str_contains($discriminator, $isArrayCheck)) {
                         $discriminator = "({$isArrayCheck} && {$discriminator})";
                     }
+                } elseif (
+                    $sub instanceof NestedObjectProperty
+                    || ($sub instanceof ReferenceProperty && $sub->getRefType() instanceof ReferencedTypeClass)
+                ) {
+                    $isObjCheck = $this->hasArraySubtype
+                        ? "is_object({$accessor})"
+                        : "(is_object({$accessor}) || is_array({$accessor}))";
+                    $discriminator = "({$isObjCheck} && {$discriminator})";
                 }
 
                 return $discriminator;
@@ -254,20 +274,53 @@ class UnionProperty extends AbstractProperty
     {
         $arms = $this->collectArms(
             mappingFn: fn(PropertyInterface $sub): string => $sub->inputMappingExpr($expr),
-            assertFn: fn(PropertyInterface $sub): string => $sub->inputAssertionExpr($expr)
+            assertFn: function (PropertyInterface $sub) use ($expr): string {
+                $discriminator = $sub->inputAssertionExpr($expr);
+
+                if (
+                    $sub instanceof ReferenceArrayProperty
+                    || $sub instanceof ObjectArrayProperty
+                    || $sub instanceof PrimitiveArrayProperty
+                ) {
+                    $isArrayCheck = "is_array({$expr})";
+                    if (!str_contains($discriminator, $isArrayCheck)) {
+                        $discriminator = "({$isArrayCheck} && {$discriminator})";
+                    }
+                } elseif (
+                    $sub instanceof NestedObjectProperty
+                    || ($sub instanceof ReferenceProperty && $sub->getRefType() instanceof ReferencedTypeClass)
+                ) {
+                    $isObjCheck = $this->hasArraySubtype
+                        ? "is_object({$expr})"
+                        : "(is_object({$expr}) || is_array({$expr}))";
+                    $discriminator = "({$isObjCheck} && {$discriminator})";
+                }
+
+                return $discriminator;
+            },
+            skipMapFn: fn(string $map): bool => $map === $expr,
         );
 
-        return $this->renderConditionalExpr($arms, 'null');
+        if ($arms === []) {
+            return $expr;
+        }
+
+        return $this->renderConditionalExpr($arms, $expr);
     }
 
     public function outputMappingExpr(string $expr): string
     {
         $arms = $this->collectArms(
             mappingFn: fn(PropertyInterface $sub): string => $sub->outputMappingExpr($expr),
-            assertFn: fn(PropertyInterface $sub): string => $sub->typeAssertionExpr($expr)
+            assertFn: fn(PropertyInterface $sub): string => $sub->typeAssertionExpr($expr),
+            skipMapFn: fn(string $map): bool => $map === $expr,
         );
 
-        return $this->renderConditionalExpr($arms, 'null');
+        if ($arms === []) {
+            return $expr;
+        }
+
+        return $this->renderConditionalExpr($arms, $expr);
     }
 
     public function outputMappingExprStdClass(string $expr): string
@@ -275,14 +328,14 @@ class UnionProperty extends AbstractProperty
         $arms = $this->collectArms(
             mappingFn: fn(PropertyInterface $sub): string => $sub->outputMappingExprStdClass($expr),
             assertFn: fn(PropertyInterface $sub): string => $sub->typeAssertionExpr($expr),
-            skipMapFn: fn(string $map) => $map === 'null'
+            skipMapFn: fn(string $map): bool => $map === $expr,
         );
 
         if ($arms === []) {
-            return 'null';
+            return $expr;
         }
 
-        return $this->renderConditionalExpr($arms, 'null');
+        return $this->renderConditionalExpr($arms, $expr);
     }
 
     public function cloneExpr(string $expr): string

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
@@ -186,10 +186,7 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'})
-            ? ((is_string($input->{'foo'}))
-                ? $input->{'foo'}
-                : ((is_int($input->{'foo'})) ? (int)$input->{'foo'} : null)
-            )
+            ? ((is_int($input->{'foo'})) ? (int)$input->{'foo'} : $input->{'foo'})
             : null;
 
         $obj = new self($foo);

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
@@ -146,9 +146,8 @@ class MyClass
 
         $foo = isset($input->{'foo'})
             ? match (true) {
-                is_string($input->{'foo'}) => $input->{'foo'},
                 is_int($input->{'foo'}) => (int)$input->{'foo'},
-                default => null,
+                default => $input->{'foo'},
             }
             : null;
 

--- a/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
@@ -147,12 +147,7 @@ class Cat
             static::validateInput($input);
         }
 
-        $hasFur = isset($input->{'hasFur'})
-            ? match (true) {
-                in_array($input->{'hasFur'}, ['a', 'b'], true) || is_array($input->{'hasFur'}) => $input->{'hasFur'},
-                default => null,
-            }
-            : null;
+        $hasFur = isset($input->{'hasFur'}) ? $input->{'hasFur'} : null;
 
         $obj = new self($hasFur);
 

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -468,14 +468,9 @@ class MyClass
         $a = $input->{'a'};
         $b = $input->{'b'};
         $c = ($input->{'c'} !== null ? $input->{'c'} : null);
-        $d = ($input->{'d'} !== null
-            ? ((is_array($input->{'d'}) || is_string($input->{'d'})) ? $input->{'d'} : null)
-            : null
-        );
+        $d = ($input->{'d'} !== null ? $input->{'d'} : null);
         $e = isset($input->{'e'}) ? $input->{'e'} : null;
-        $f = isset($input->{'f'})
-            ? ((is_array($input->{'f'}) || is_string($input->{'f'})) ? $input->{'f'} : null)
-            : null;
+        $f = isset($input->{'f'}) ? $input->{'f'} : null;
         $g = null;
         if (property_exists($input, 'g')) {
             $g = ($input->{'g'} !== null ? $input->{'g'} : null);
@@ -483,24 +478,12 @@ class MyClass
         }
         $h = null;
         if (property_exists($input, 'h')) {
-            $h = ($input->{'h'} !== null
-                ? ((is_array($input->{'h'}) || is_string($input->{'h'})) ? $input->{'h'} : null)
-                : null
-            );
+            $h = ($input->{'h'} !== null ? $input->{'h'} : null);
             $_providedOptionals['h'] = true;
         }
         $i = null;
         if (property_exists($input, 'i')) {
-            $i = ($input->{'i'} !== null
-                ? ((is_array($input->{'i'})
-                    || is_string($input->{'i'})
-                    || is_array($input->{'i'}) || is_object($input->{'i'})
-                )
-                    ? $input->{'i'}
-                    : null
-                )
-                : null
-            );
+            $i = ($input->{'i'} !== null ? $input->{'i'} : null);
             $_providedOptionals['i'] = true;
         }
 
@@ -544,19 +527,13 @@ class MyClass
             $output['g'] = ($this->g !== null ? $this->g : null);
         }
         if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
-            $output['h'] = ($this->h !== null
-                ? ((is_array($this->h) || is_string($this->h)) ? $this->h : null)
-                : null
-            );
+            $output['h'] = ($this->h !== null ? $this->h : null);
         }
         if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
             $output['i'] = ($this->i !== null
-                ? ((is_array($this->i) || is_string($this->i))
-                    ? $this->i
-                    : ((is_array($this->i) || is_object($this->i))
-                        ? json_decode(json_encode($this->i), true)
-                        : null
-                    )
+                ? ((is_array($this->i) || is_object($this->i))
+                    ? json_decode(json_encode($this->i), true)
+                    : $this->i
                 )
                 : null
             );
@@ -594,19 +571,13 @@ class MyClass
             $output->{'g'} = ($this->g !== null ? $this->g : null);
         }
         if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
-            $output->{'h'} = ($this->h !== null
-                ? ((is_array($this->h) || is_string($this->h)) ? $this->h : null)
-                : null
-            );
+            $output->{'h'} = ($this->h !== null ? $this->h : null);
         }
         if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
             $output->{'i'} = ($this->i !== null
-                ? ((is_array($this->i) || is_string($this->i))
-                    ? $this->i
-                    : ((is_array($this->i) || is_object($this->i))
-                        ? json_decode(json_encode($this->i))
-                        : null
-                    )
+                ? ((is_array($this->i) || is_object($this->i))
+                    ? json_decode(json_encode($this->i))
+                    : $this->i
                 )
                 : null
             );

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -372,20 +372,9 @@ class MyClass
             default => throw new \InvalidArgumentException("could not build property 'b' from JSON"),
         };
         $c = ($input->{'c'} !== null ? $input->{'c'} : null);
-        $d = ($input->{'d'} !== null
-            ? match (true) {
-                is_array($input->{'d'}) || is_string($input->{'d'}) => $input->{'d'},
-                default => null,
-            }
-            : null
-        );
+        $d = ($input->{'d'} !== null ? $input->{'d'} : null);
         $e = isset($input->{'e'}) ? $input->{'e'} : null;
-        $f = isset($input->{'f'})
-            ? match (true) {
-                is_array($input->{'f'}) || is_string($input->{'f'}) => $input->{'f'},
-                default => null,
-            }
-            : null;
+        $f = isset($input->{'f'}) ? $input->{'f'} : null;
         $g = null;
         if (property_exists($input, 'g')) {
             $g = ($input->{'g'} !== null ? $input->{'g'} : null);
@@ -393,27 +382,12 @@ class MyClass
         }
         $h = null;
         if (property_exists($input, 'h')) {
-            $h = ($input->{'h'} !== null
-                ? match (true) {
-                    is_array($input->{'h'}) || is_string($input->{'h'}) => $input->{'h'},
-                    default => null,
-                }
-                : null
-            );
+            $h = ($input->{'h'} !== null ? $input->{'h'} : null);
             $_providedOptionals['h'] = true;
         }
         $i = null;
         if (property_exists($input, 'i')) {
-            $i = ($input->{'i'} !== null
-                ? match (true) {
-                    is_array($input->{'i'})
-                        || is_string($input->{'i'})
-                        || is_array($input->{'i'}) || is_object($input->{'i'}) =>
-                        $input->{'i'},
-                    default => null,
-                }
-                : null
-            );
+            $i = ($input->{'i'} !== null ? $input->{'i'} : null);
             $_providedOptionals['i'] = true;
         }
 
@@ -457,20 +431,13 @@ class MyClass
             $output['g'] = ($this->g !== null ? $this->g : null);
         }
         if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
-            $output['h'] = ($this->h !== null
-                ? match (true) {
-                    is_array($this->h) || is_string($this->h) => $this->h,
-                    default => null,
-                }
-                : null
-            );
+            $output['h'] = ($this->h !== null ? $this->h : null);
         }
         if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
             $output['i'] = ($this->i !== null
                 ? match (true) {
-                    is_array($this->i) || is_string($this->i) => $this->i,
                     is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), true),
-                    default => null,
+                    default => $this->i,
                 }
                 : null
             );
@@ -508,20 +475,13 @@ class MyClass
             $output->{'g'} = ($this->g !== null ? $this->g : null);
         }
         if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
-            $output->{'h'} = ($this->h !== null
-                ? match (true) {
-                    is_array($this->h) || is_string($this->h) => $this->h,
-                    default => null,
-                }
-                : null
-            );
+            $output->{'h'} = ($this->h !== null ? $this->h : null);
         }
         if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
             $output->{'i'} = ($this->i !== null
                 ? match (true) {
-                    is_array($this->i) || is_string($this->i) => $this->i,
                     is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i)),
-                    default => null,
+                    default => $this->i,
                 }
                 : null
             );

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -437,13 +437,12 @@ class MyClass
         $grox = isset($input->{'grox'}) ? $input->{'grox'} : null;
         $qwert = isset($input->{'qwert'})
             ? match (true) {
-                is_string($input->{'qwert'}) => $input->{'qwert'},
                 (is_int($input->{'qwert'}) || is_float($input->{'qwert'})) =>
                     (str_contains((string)$input->{'qwert'}, '.')
                         ? (float)$input->{'qwert'}
                         : (int)$input->{'qwert'}
                     ),
-                default => null,
+                default => $input->{'qwert'},
             }
             : null;
         $zyx = isset($input->{'zyx'}) ? $input->{'zyx'} : null;

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
@@ -182,13 +182,13 @@ class BarTest
         }
 
         $exampleProp = isset($input->{'exampleProp'})
-            ? ((FooTest::validateInput($input->{'exampleProp'}, true))
+            ? ((((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && FooTest::validateInput($input->{'exampleProp'}, true)))
                 ? FooTest::fromInput($input->{'exampleProp'}, $validate)
-                : ((MoiKlass::validateInput($input->{'exampleProp'}, true))
+                : ((((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && MoiKlass::validateInput($input->{'exampleProp'}, true)))
                     ? MoiKlass::fromInput($input->{'exampleProp'}, $validate)
-                    : ((FooTest_1::validateInput($input->{'exampleProp'}, true))
+                    : ((((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && FooTest_1::validateInput($input->{'exampleProp'}, true)))
                         ? FooTest_1::fromInput($input->{'exampleProp'}, $validate)
-                        : null
+                        : $input->{'exampleProp'}
                     )
                 )
             )

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -170,13 +170,13 @@ class BarTest
         }
 
         $exampleProp = isset($input->{'exampleProp'})
-            ? ((FooTest::validateInput($input->{'exampleProp'}, true))
+            ? ((((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && FooTest::validateInput($input->{'exampleProp'}, true)))
                 ? FooTest::fromInput($input->{'exampleProp'}, $validate)
-                : ((MoiKlass::validateInput($input->{'exampleProp'}, true))
+                : ((((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && MoiKlass::validateInput($input->{'exampleProp'}, true)))
                     ? MoiKlass::fromInput($input->{'exampleProp'}, $validate)
-                    : ((FooTest_1::validateInput($input->{'exampleProp'}, true))
+                    : ((((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && FooTest_1::validateInput($input->{'exampleProp'}, true)))
                         ? FooTest_1::fromInput($input->{'exampleProp'}, $validate)
-                        : null
+                        : $input->{'exampleProp'}
                     )
                 )
             )

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
@@ -150,10 +150,13 @@ class BarTest
 
         $exampleProp = isset($input->{'exampleProp'})
             ? match (true) {
-                FooTest::validateInput($input->{'exampleProp'}, true) => FooTest::fromInput($input->{'exampleProp'}, $validate),
-                MoiKlass::validateInput($input->{'exampleProp'}, true) => MoiKlass::fromInput($input->{'exampleProp'}, $validate),
-                FooTest_1::validateInput($input->{'exampleProp'}, true) => FooTest_1::fromInput($input->{'exampleProp'}, $validate),
-                default => null,
+                ((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && FooTest::validateInput($input->{'exampleProp'}, true)) =>
+                    FooTest::fromInput($input->{'exampleProp'}, $validate),
+                ((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && MoiKlass::validateInput($input->{'exampleProp'}, true)) =>
+                    MoiKlass::fromInput($input->{'exampleProp'}, $validate),
+                ((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && FooTest_1::validateInput($input->{'exampleProp'}, true)) =>
+                    FooTest_1::fromInput($input->{'exampleProp'}, $validate),
+                default => $input->{'exampleProp'},
             }
             : null;
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -2357,11 +2357,11 @@ class MyClass
             : null;
         $_providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
+            ? ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)))
                 ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
+                : ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : null)
+                    : $input->{'ensureArgs1'}
                 )
             )
             : null;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -1383,11 +1383,11 @@ class MyClass
             : null;
         $_providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
+            ? ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)))
                 ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
+                : ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : null)
+                    : $input->{'ensureArgs1'}
                 )
             )
             : null;

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
@@ -1359,12 +1359,11 @@ class MyClass
         $_providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
             ? match (true) {
-                MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true) =>
+                ((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)) =>
                     MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults),
-                MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true) =>
+                ((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)) =>
                     MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults),
-                is_string($input->{'ensureArgs1'}) => $input->{'ensureArgs1'},
-                default => null,
+                default => $input->{'ensureArgs1'},
             }
             : null;
         $ensureArgs2 = isset($input->{'ensureArgs2'})

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -2357,11 +2357,11 @@ class MyClass
             : null;
         $__providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
+            ? ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)))
                 ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
+                : ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : null)
+                    : $input->{'ensureArgs1'}
                 )
             )
             : null;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -1383,11 +1383,11 @@ class MyClass
             : null;
         $__providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
+            ? ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)))
                 ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
+                : ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : null)
+                    : $input->{'ensureArgs1'}
                 )
             )
             : null;

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
@@ -1359,12 +1359,11 @@ class MyClass
         $__providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
             ? match (true) {
-                MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true) =>
+                ((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)) =>
                     MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults),
-                MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true) =>
+                ((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)) =>
                     MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults),
-                is_string($input->{'ensureArgs1'}) => $input->{'ensureArgs1'},
-                default => null,
+                default => $input->{'ensureArgs1'},
             }
             : null;
         $ensureArgs2 = isset($input->{'ensureArgs2'})

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -806,49 +806,34 @@ class MyClass
         }
         $xyyz = isset($input->{'xyyz'})
             ? match (true) {
-                is_string($input->{'xyyz'}) || is_array($input->{'xyyz'}) => $input->{'xyyz'},
-                ObjDef::validateInput($input->{'xyyz'}, true) => ObjDef::fromInput($input->{'xyyz'}, $validate, $materializeDefaults),
-                default => null,
+                (is_object($input->{'xyyz'}) && ObjDef::validateInput($input->{'xyyz'}, true)) =>
+                    ObjDef::fromInput($input->{'xyyz'}, $validate, $materializeDefaults),
+                default => $input->{'xyyz'},
             }
             : null;
         $buux = isset($input->{'buux'})
             ? match (true) {
-                is_string($input->{'buux'}) || is_array($input->{'buux'}) => $input->{'buux'},
-                ObjDef::validateInput($input->{'buux'}, true) => ObjDef::fromInput($input->{'buux'}, $validate, $materializeDefaults),
-                default => null,
+                (is_object($input->{'buux'}) && ObjDef::validateInput($input->{'buux'}, true)) =>
+                    ObjDef::fromInput($input->{'buux'}, $validate, $materializeDefaults),
+                default => $input->{'buux'},
             }
             : null;
         $boic = isset($input->{'boic'})
             ? match (true) {
-                is_string($input->{'boic'}) || is_array($input->{'boic'}) => $input->{'boic'},
-                ObjDef::validateInput($input->{'boic'}, true) => ObjDef::fromInput($input->{'boic'}, $validate, $materializeDefaults),
-                default => null,
+                (is_object($input->{'boic'}) && ObjDef::validateInput($input->{'boic'}, true)) =>
+                    ObjDef::fromInput($input->{'boic'}, $validate, $materializeDefaults),
+                default => $input->{'boic'},
             }
             : null;
         $poox = isset($input->{'poox'})
             ? match (true) {
-                is_string($input->{'poox'}) => $input->{'poox'},
-                NumericKeysObj::validateInput($input->{'poox'}, true) =>
+                ((is_object($input->{'poox'}) || is_array($input->{'poox'})) && NumericKeysObj::validateInput($input->{'poox'}, true)) =>
                     NumericKeysObj::fromInput($input->{'poox'}, $validate, $materializeDefaults),
-                default => null,
+                default => $input->{'poox'},
             }
             : null;
-        $arrObjUnion = isset($input->{'arrObjUnion'})
-            ? match (true) {
-                is_array($input->{'arrObjUnion'})
-                    || is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) =>
-                    $input->{'arrObjUnion'},
-                default => null,
-            }
-            : null;
-        $objArrUnion = isset($input->{'objArrUnion'})
-            ? match (true) {
-                is_array($input->{'objArrUnion'})
-                    || is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) =>
-                    $input->{'objArrUnion'},
-                default => null,
-            }
-            : null;
+        $arrObjUnion = isset($input->{'arrObjUnion'}) ? $input->{'arrObjUnion'} : null;
+        $objArrUnion = isset($input->{'objArrUnion'}) ? $input->{'objArrUnion'} : null;
         $numKeysDefaults = isset($input->{'numKeysDefaults'})
             ? MyClassNumKeysDefaults::fromInput($input->{'numKeysDefaults'}, $validate, $materializeDefaults)
             : null;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
@@ -182,11 +182,11 @@ class Baz
         }
 
         $grox = isset($input->{'grox'})
-            ? ((Foo::validateInput($input->{'grox'}, true))
+            ? ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Foo::validateInput($input->{'grox'}, true)))
                 ? Foo::fromInput($input->{'grox'}, $validate)
-                : ((Bar::validateInput($input->{'grox'}, true))
+                : ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Bar::validateInput($input->{'grox'}, true)))
                     ? Bar::fromInput($input->{'grox'}, $validate)
-                    : null
+                    : $input->{'grox'}
                 )
             )
             : null;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -195,18 +195,15 @@ class Qux
         }
 
         $grox = isset($input->{'grox'})
-            ? ((is_string($input->{'grox'}) || is_array($input->{'grox'}))
-                ? $input->{'grox'}
-                : (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
-                    ? ((Foo::validateInput($input->{'grox'}, true))
-                        ? Foo::fromInput($input->{'grox'}, $validate)
-                        : ((Bar::validateInput($input->{'grox'}, true))
-                            ? Bar::fromInput($input->{'grox'}, $validate)
-                            : null
-                        )
+            ? (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
+                ? ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Foo::validateInput($input->{'grox'}, true)))
+                    ? Foo::fromInput($input->{'grox'}, $validate)
+                    : ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Bar::validateInput($input->{'grox'}, true)))
+                        ? Bar::fromInput($input->{'grox'}, $validate)
+                        : $input->{'grox'}
                     )
-                    : null
                 )
+                : $input->{'grox'}
             )
             : null;
 
@@ -235,7 +232,7 @@ class Qux
             } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
                 $output['grox'] = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toArray()
-                    : null
+                    : $this->grox
                 );
             }
         }
@@ -258,7 +255,7 @@ class Qux
             } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
                 $output->{'grox'} = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toStdClass()
-                    : null
+                    : $this->grox
                 );
             }
         }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -170,11 +170,11 @@ class Baz
         }
 
         $grox = isset($input->{'grox'})
-            ? ((Foo::validateInput($input->{'grox'}, true))
+            ? ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Foo::validateInput($input->{'grox'}, true)))
                 ? Foo::fromInput($input->{'grox'}, $validate)
-                : ((Bar::validateInput($input->{'grox'}, true))
+                : ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Bar::validateInput($input->{'grox'}, true)))
                     ? Bar::fromInput($input->{'grox'}, $validate)
-                    : null
+                    : $input->{'grox'}
                 )
             )
             : null;

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -183,18 +183,15 @@ class Qux
         }
 
         $grox = isset($input->{'grox'})
-            ? ((is_string($input->{'grox'}) || is_array($input->{'grox'}))
-                ? $input->{'grox'}
-                : (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
-                    ? ((Foo::validateInput($input->{'grox'}, true))
-                        ? Foo::fromInput($input->{'grox'}, $validate)
-                        : ((Bar::validateInput($input->{'grox'}, true))
-                            ? Bar::fromInput($input->{'grox'}, $validate)
-                            : null
-                        )
+            ? (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
+                ? ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Foo::validateInput($input->{'grox'}, true)))
+                    ? Foo::fromInput($input->{'grox'}, $validate)
+                    : ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Bar::validateInput($input->{'grox'}, true)))
+                        ? Bar::fromInput($input->{'grox'}, $validate)
+                        : $input->{'grox'}
                     )
-                    : null
                 )
+                : $input->{'grox'}
             )
             : null;
 
@@ -223,7 +220,7 @@ class Qux
             } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
                 $output['grox'] = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toArray()
-                    : null
+                    : $this->grox
                 );
             }
         }
@@ -246,7 +243,7 @@ class Qux
             } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
                 $output->{'grox'} = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toStdClass()
-                    : null
+                    : $this->grox
                 );
             }
         }

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
@@ -150,9 +150,11 @@ class Baz
 
         $grox = isset($input->{'grox'})
             ? match (true) {
-                Foo::validateInput($input->{'grox'}, true) => Foo::fromInput($input->{'grox'}, $validate),
-                Bar::validateInput($input->{'grox'}, true) => Bar::fromInput($input->{'grox'}, $validate),
-                default => null,
+                ((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Foo::validateInput($input->{'grox'}, true)) =>
+                    Foo::fromInput($input->{'grox'}, $validate),
+                ((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Bar::validateInput($input->{'grox'}, true)) =>
+                    Bar::fromInput($input->{'grox'}, $validate),
+                default => $input->{'grox'},
             }
             : null;
 

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
@@ -177,14 +177,15 @@ class Qux
 
         $grox = isset($input->{'grox'})
             ? match (true) {
-                is_string($input->{'grox'}) || is_array($input->{'grox'}) => $input->{'grox'},
                 (Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)) =>
                     match (true) {
-                        Foo::validateInput($input->{'grox'}, true) => Foo::fromInput($input->{'grox'}, $validate),
-                        Bar::validateInput($input->{'grox'}, true) => Bar::fromInput($input->{'grox'}, $validate),
-                        default => null,
+                        ((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Foo::validateInput($input->{'grox'}, true)) =>
+                            Foo::fromInput($input->{'grox'}, $validate),
+                        ((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Bar::validateInput($input->{'grox'}, true)) =>
+                            Bar::fromInput($input->{'grox'}, $validate),
+                        default => $input->{'grox'},
                     },
-                default => null,
+                default => $input->{'grox'},
             }
             : null;
 
@@ -213,7 +214,7 @@ class Qux
                 ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
                     match (true) {
                         $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toArray(),
-                        default => null,
+                        default => $this->grox,
                     },
             };
         }
@@ -236,7 +237,7 @@ class Qux
                 ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
                     match (true) {
                         $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toStdClass(),
-                        default => null,
+                        default => $this->grox,
                     },
             };
         }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -200,12 +200,7 @@ class MyClass
         }
 
         $foo = $input->{'foo'};
-        $bar = isset($input->{'bar'})
-            ? ((is_string($input->{'bar'}) || is_array($input->{'bar'}) || is_object($input->{'bar'}))
-                ? $input->{'bar'}
-                : null
-            )
-            : null;
+        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
 
         $obj = new self($foo, $bar);
 

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -186,12 +186,7 @@ class MyClass
         }
 
         $foo = $input->{'foo'};
-        $bar = isset($input->{'bar'})
-            ? ((is_string($input->{'bar'}) || is_array($input->{'bar'}) || is_object($input->{'bar'}))
-                ? $input->{'bar'}
-                : null
-            )
-            : null;
+        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
 
         $obj = new self($foo, $bar);
 

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
@@ -144,12 +144,7 @@ class MyClass
             is_string($input->{'foo'}) || is_array($input->{'foo'}) || is_object($input->{'foo'}) => $input->{'foo'},
             default => throw new \InvalidArgumentException("could not build property 'foo' from JSON"),
         };
-        $bar = isset($input->{'bar'})
-            ? match (true) {
-                is_string($input->{'bar'}) || is_array($input->{'bar'}) || is_object($input->{'bar'}) => $input->{'bar'},
-                default => null,
-            }
-            : null;
+        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
 
         $obj = new self($foo, $bar);
 

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -432,86 +432,71 @@ class MyClass
         };
         $thud = ($input->{'thud'} !== null
             ? match (true) {
-                is_string($input->{'thud'})
-                    || is_array($input->{'thud'})
-                    || is_array($input->{'thud'}) || is_object($input->{'thud'}) =>
-                    $input->{'thud'},
                 (is_int($input->{'thud'}) || is_float($input->{'thud'})) =>
                     (str_contains((string)$input->{'thud'}, '.')
                         ? (float)$input->{'thud'}
                         : (int)$input->{'thud'}
                     ),
                 is_bool($input->{'thud'}) => (bool)$input->{'thud'},
-                default => null,
+                default => $input->{'thud'},
             }
             : null
         );
         $optFoo = isset($input->{'optFoo'})
             ? match (true) {
-                is_string($input->{'optFoo'}) => $input->{'optFoo'},
                 (is_int($input->{'optFoo'}) || is_float($input->{'optFoo'})) =>
                     (str_contains((string)$input->{'optFoo'}, '.')
                         ? (float)$input->{'optFoo'}
                         : (int)$input->{'optFoo'}
                     ),
                 is_bool($input->{'optFoo'}) => (bool)$input->{'optFoo'},
-                default => null,
+                default => $input->{'optFoo'},
             }
             : null;
         $optBar = isset($input->{'optBar'})
             ? match (true) {
-                is_string($input->{'optBar'}) || is_array($input->{'optBar'}) => $input->{'optBar'},
                 (is_int($input->{'optBar'}) || is_float($input->{'optBar'})) =>
                     (str_contains((string)$input->{'optBar'}, '.')
                         ? (float)$input->{'optBar'}
                         : (int)$input->{'optBar'}
                     ),
                 is_bool($input->{'optBar'}) => (bool)$input->{'optBar'},
-                default => null,
+                default => $input->{'optBar'},
             }
             : null;
         $optBaz = isset($input->{'optBaz'})
             ? match (true) {
-                is_string($input->{'optBaz'}) || is_array($input->{'optBaz'}) || is_object($input->{'optBaz'}) => $input->{'optBaz'},
                 (is_int($input->{'optBaz'}) || is_float($input->{'optBaz'})) =>
                     (str_contains((string)$input->{'optBaz'}, '.')
                         ? (float)$input->{'optBaz'}
                         : (int)$input->{'optBaz'}
                     ),
                 is_bool($input->{'optBaz'}) => (bool)$input->{'optBaz'},
-                default => null,
+                default => $input->{'optBaz'},
             }
             : null;
         $optQux = isset($input->{'optQux'})
             ? match (true) {
-                is_string($input->{'optQux'})
-                    || is_array($input->{'optQux'})
-                    || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) =>
-                    $input->{'optQux'},
                 (is_int($input->{'optQux'}) || is_float($input->{'optQux'})) =>
                     (str_contains((string)$input->{'optQux'}, '.')
                         ? (float)$input->{'optQux'}
                         : (int)$input->{'optQux'}
                     ),
                 is_bool($input->{'optQux'}) => (bool)$input->{'optQux'},
-                default => null,
+                default => $input->{'optQux'},
             }
             : null;
         $optThud = null;
         if (property_exists($input, 'optThud')) {
             $optThud = ($input->{'optThud'} !== null
                 ? match (true) {
-                    is_string($input->{'optThud'})
-                        || is_array($input->{'optThud'})
-                        || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) =>
-                        $input->{'optThud'},
                     (is_int($input->{'optThud'}) || is_float($input->{'optThud'})) =>
                         (str_contains((string)$input->{'optThud'}, '.')
                             ? (float)$input->{'optThud'}
                             : (int)$input->{'optThud'}
                         ),
                     is_bool($input->{'optThud'}) => (bool)$input->{'optThud'},
-                    default => null,
+                    default => $input->{'optThud'},
                 }
                 : null
             );
@@ -618,13 +603,8 @@ class MyClass
         if (isset($this->optThud) || array_key_exists('optThud', $this->_providedOptionals)) {
             $output['optThud'] = ($this->optThud !== null
                 ? match (true) {
-                    is_string($this->optThud)
-                        || (is_int($this->optThud) || is_float($this->optThud))
-                        || is_bool($this->optThud)
-                        || is_array($this->optThud) =>
-                        $this->optThud,
                     is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud), true),
-                    default => null,
+                    default => $this->optThud,
                 }
                 : null
             );
@@ -711,13 +691,8 @@ class MyClass
         if (isset($this->optThud) || array_key_exists('optThud', $this->_providedOptionals)) {
             $output->{'optThud'} = ($this->optThud !== null
                 ? match (true) {
-                    is_string($this->optThud)
-                        || (is_int($this->optThud) || is_float($this->optThud))
-                        || is_bool($this->optThud)
-                        || is_array($this->optThud) =>
-                        $this->optThud,
                     is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud)),
-                    default => null,
+                    default => $this->optThud,
                 }
                 : null
             );

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-5.6/MyClass.php
@@ -153,7 +153,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        if (MyClassFooAlternative2::validateInput($input->{'foo'}, true)) {
+        if (((is_object($input->{'foo'}) || is_array($input->{'foo'})) && MyClassFooAlternative2::validateInput($input->{'foo'}, true))) {
             $foo = MyClassFooAlternative2::fromInput($input->{'foo'}, $validate);
         } else {
             $foo = $input->{'foo'};

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClass.php
@@ -144,7 +144,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        if (MyClassFooAlternative2::validateInput($input->{'foo'}, true)) {
+        if (((is_object($input->{'foo'}) || is_array($input->{'foo'})) && MyClassFooAlternative2::validateInput($input->{'foo'}, true))) {
             $foo = MyClassFooAlternative2::fromInput($input->{'foo'}, $validate);
         } else {
             $foo = $input->{'foo'};

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-8.4/MyClass.php
@@ -119,7 +119,7 @@ class MyClass
 
         $foo = match (true) {
             is_string($input->{'foo'}) => $input->{'foo'},
-            MyClassFooAlternative2::validateInput($input->{'foo'}, true) =>
+            ((is_object($input->{'foo'}) || is_array($input->{'foo'})) && MyClassFooAlternative2::validateInput($input->{'foo'}, true)) =>
                 MyClassFooAlternative2::fromInput($input->{'foo'}, $validate),
             default => throw new \InvalidArgumentException("could not build property 'foo' from JSON"),
         };

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-5.6/Record.php
@@ -355,18 +355,24 @@ class Record
             : null;
         $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'})
             ? array_map(function($i) use ($validate) {
-                return ((Phone::validateInput($i, true))
+                return ((((is_object($i) || is_array($i)) && Phone::validateInput($i, true)))
                     ? Phone::fromInput($i, $validate)
-                    : ((Fio::validateInput($i, true)) ? Fio::fromInput($i, $validate) : null)
+                    : ((((is_object($i) || is_array($i)) && Fio::validateInput($i, true)))
+                        ? Fio::fromInput($i, $validate)
+                        : $i
+                    )
                 );
             }, $input->{'dataArrayAnyOf'})
             : null;
         $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'})
             ? array_map(function($i) use ($validate) {
                 return array_map(function($i) use ($validate) {
-                    return ((Phone::validateInput($i, true))
+                    return ((((is_object($i) || is_array($i)) && Phone::validateInput($i, true)))
                         ? Phone::fromInput($i, $validate)
-                        : ((Fio::validateInput($i, true)) ? Fio::fromInput($i, $validate) : null)
+                        : ((((is_object($i) || is_array($i)) && Fio::validateInput($i, true)))
+                            ? Fio::fromInput($i, $validate)
+                            : $i
+                        )
                     );
                 }, $i);
             }, $input->{'dataArrayNestedAnyOf'})
@@ -407,13 +413,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output['dataArrayAnyOf'] = array_map(function($i) {
-                return (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : null);
+                return (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : $i);
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output['dataArrayNestedAnyOf'] = array_map(function($i) {
                 return array_map(function($i) {
-                    return (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : null);
+                    return (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : $i);
                 }, $i);
             }, $this->dataArrayNestedAnyOf);
         }
@@ -446,13 +452,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output->{'dataArrayAnyOf'} = array_map(function($i) {
-                return (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : null);
+                return (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : $i);
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output->{'dataArrayNestedAnyOf'} = array_map(function($i) {
                 return array_map(function($i) {
-                    return (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : null);
+                    return (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : $i);
                 }, $i);
             }, $this->dataArrayNestedAnyOf);
         }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-7.4/Record.php
@@ -324,16 +324,22 @@ class Record
             )
             : null;
         $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'})
-            ? array_map(fn ($i) => ((Phone::validateInput($i, true))
+            ? array_map(fn ($i) => ((((is_object($i) || is_array($i)) && Phone::validateInput($i, true)))
                 ? Phone::fromInput($i, $validate)
-                : ((Fio::validateInput($i, true)) ? Fio::fromInput($i, $validate) : null)
+                : ((((is_object($i) || is_array($i)) && Fio::validateInput($i, true)))
+                    ? Fio::fromInput($i, $validate)
+                    : $i
+                )
             ), $input->{'dataArrayAnyOf'})
             : null;
         $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'})
             ? array_map(
-                fn ($i) => array_map(fn ($i) => ((Phone::validateInput($i, true))
+                fn ($i) => array_map(fn ($i) => ((((is_object($i) || is_array($i)) && Phone::validateInput($i, true)))
                     ? Phone::fromInput($i, $validate)
-                    : ((Fio::validateInput($i, true)) ? Fio::fromInput($i, $validate) : null)
+                    : ((((is_object($i) || is_array($i)) && Fio::validateInput($i, true)))
+                        ? Fio::fromInput($i, $validate)
+                        : $i
+                    )
                 ), $i),
                 $input->{'dataArrayNestedAnyOf'},
             )
@@ -366,13 +372,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output['dataArrayAnyOf'] = array_map(
-                fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : null),
+                fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : $i),
                 $this->dataArrayAnyOf,
             );
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output['dataArrayNestedAnyOf'] = array_map(
-                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : null), $i),
+                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : $i), $i),
                 $this->dataArrayNestedAnyOf,
             );
         }
@@ -400,13 +406,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output->{'dataArrayAnyOf'} = array_map(
-                fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : null),
+                fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : $i),
                 $this->dataArrayAnyOf,
             );
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output->{'dataArrayNestedAnyOf'} = array_map(
-                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : null), $i),
+                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : $i), $i),
                 $this->dataArrayNestedAnyOf,
             );
         }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-8.4/Record.php
@@ -318,17 +318,17 @@ class Record
             : null;
         $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'})
             ? array_map(fn ($i) => match (true) {
-                Phone::validateInput($i, true) => Phone::fromInput($i, $validate),
-                Fio::validateInput($i, true) => Fio::fromInput($i, $validate),
-                default => null,
+                ((is_object($i) || is_array($i)) && Phone::validateInput($i, true)) => Phone::fromInput($i, $validate),
+                ((is_object($i) || is_array($i)) && Fio::validateInput($i, true)) => Fio::fromInput($i, $validate),
+                default => $i,
             }, $input->{'dataArrayAnyOf'})
             : null;
         $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'})
             ? array_map(
                 fn ($i) => array_map(fn ($i) => match (true) {
-                    Phone::validateInput($i, true) => Phone::fromInput($i, $validate),
-                    Fio::validateInput($i, true) => Fio::fromInput($i, $validate),
-                    default => null,
+                    ((is_object($i) || is_array($i)) && Phone::validateInput($i, true)) => Phone::fromInput($i, $validate),
+                    ((is_object($i) || is_array($i)) && Fio::validateInput($i, true)) => Fio::fromInput($i, $validate),
+                    default => $i,
                 }, $i),
                 $input->{'dataArrayNestedAnyOf'},
             )
@@ -362,14 +362,14 @@ class Record
         if (isset($this->dataArrayAnyOf)) {
             $output['dataArrayAnyOf'] = array_map(fn ($i) => match (true) {
                 $i instanceof Phone || $i instanceof Fio => $i->toArray(),
-                default => null,
+                default => $i,
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output['dataArrayNestedAnyOf'] = array_map(
                 fn ($i) => array_map(fn ($i) => match (true) {
                     $i instanceof Phone || $i instanceof Fio => $i->toArray(),
-                    default => null,
+                    default => $i,
                 }, $i),
                 $this->dataArrayNestedAnyOf,
             );
@@ -399,14 +399,14 @@ class Record
         if (isset($this->dataArrayAnyOf)) {
             $output->{'dataArrayAnyOf'} = array_map(fn ($i) => match (true) {
                 $i instanceof Phone || $i instanceof Fio => $i->toStdClass(),
-                default => null,
+                default => $i,
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output->{'dataArrayNestedAnyOf'} = array_map(
                 fn ($i) => array_map(fn ($i) => match (true) {
                     $i instanceof Phone || $i instanceof Fio => $i->toStdClass(),
-                    default => null,
+                    default => $i,
                 }, $i),
                 $this->dataArrayNestedAnyOf,
             );

--- a/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
+++ b/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
@@ -221,12 +221,7 @@ class RefValidation
         }
 
         $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
-        $bar = isset($input->{'bar'})
-            ? match (true) {
-                is_string($input->{'bar'}) || in_array($input->{'bar'}, [1, 2], true) => $input->{'bar'},
-                default => null,
-            }
-            : null;
+        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
         $baz = isset($input->{'baz'})
             ? RefValidationBaz::fromInput($input->{'baz'}, $validate)
             : null;

--- a/tests/Generator/Fixtures/SettersValidation/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-5.6/Foo.php
@@ -345,12 +345,7 @@ class Foo
         }
 
         $_providedOptionals = [];
-        $a = isset($input->{'a'})
-            ? ((in_array($input->{'a'}, ['a', 'b'], true) || is_array($input->{'a'}))
-                ? $input->{'a'}
-                : null
-            )
-            : null;
+        $a = isset($input->{'a'}) ? $input->{'a'} : null;
         $b = isset($input->{'b'}) ? $input->{'b'} : null;
         $c = null;
         if (property_exists($input, 'c')) {

--- a/tests/Generator/Fixtures/SettersValidation/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-7.4/Foo.php
@@ -306,12 +306,7 @@ class Foo
         }
 
         $_providedOptionals = [];
-        $a = isset($input->{'a'})
-            ? ((in_array($input->{'a'}, ['a', 'b'], true) || is_array($input->{'a'}))
-                ? $input->{'a'}
-                : null
-            )
-            : null;
+        $a = isset($input->{'a'}) ? $input->{'a'} : null;
         $b = isset($input->{'b'}) ? $input->{'b'} : null;
         $c = null;
         if (property_exists($input, 'c')) {

--- a/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
@@ -283,12 +283,7 @@ class Foo
         }
 
         $_providedOptionals = [];
-        $a = isset($input->{'a'})
-            ? match (true) {
-                in_array($input->{'a'}, ['a', 'b'], true) || is_array($input->{'a'}) => $input->{'a'},
-                default => null,
-            }
-            : null;
+        $a = isset($input->{'a'}) ? $input->{'a'} : null;
         $b = isset($input->{'b'}) ? $input->{'b'} : null;
         $c = null;
         if (property_exists($input, 'c')) {

--- a/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
@@ -155,15 +155,12 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'})
-            ? ((is_string($input->{'foo'}))
-                ? $input->{'foo'}
-                : (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
-                    ? (str_contains((string)$input->{'foo'}, '.')
-                        ? (float)$input->{'foo'}
-                        : (int)$input->{'foo'}
-                    )
-                    : null
+            ? (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
+                ? (str_contains((string)$input->{'foo'}, '.')
+                    ? (float)$input->{'foo'}
+                    : (int)$input->{'foo'}
                 )
+                : $input->{'foo'}
             )
             : null;
 

--- a/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
@@ -143,15 +143,12 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'})
-            ? ((is_string($input->{'foo'}))
-                ? $input->{'foo'}
-                : (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
-                    ? (str_contains((string)$input->{'foo'}, '.')
-                        ? (float)$input->{'foo'}
-                        : (int)$input->{'foo'}
-                    )
-                    : null
+            ? (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
+                ? (str_contains((string)$input->{'foo'}, '.')
+                    ? (float)$input->{'foo'}
+                    : (int)$input->{'foo'}
                 )
+                : $input->{'foo'}
             )
             : null;
 

--- a/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
@@ -117,13 +117,12 @@ class MyClass
 
         $foo = isset($input->{'foo'})
             ? match (true) {
-                is_string($input->{'foo'}) => $input->{'foo'},
                 (is_int($input->{'foo'}) || is_float($input->{'foo'})) =>
                     (str_contains((string)$input->{'foo'}, '.')
                         ? (float)$input->{'foo'}
                         : (int)$input->{'foo'}
                     ),
-                default => null,
+                default => $input->{'foo'},
             }
             : null;
 

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
@@ -449,42 +449,33 @@ class MyClass
             ? array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i))
-                    ? $i
-                    : (((is_int($i) || is_float($i)))
-                        ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
-                        : null
-                    )
+                ? array_map(fn ($i) => (((is_int($i) || is_float($i)))
+                    ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
+                    : $i
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : $i
             ), $input->{'arrayOfUnions'})
             : null;
         $arrayOfRefUnions = isset($input->{'arrayOfRefUnions'})
             ? array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i))
-                    ? $i
-                    : (((is_int($i) || is_float($i)))
-                        ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
-                        : null
-                    )
+                ? array_map(fn ($i) => (((is_int($i) || is_float($i)))
+                    ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
+                    : $i
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : $i
             ), $input->{'arrayOfRefUnions'})
             : null;
         $arrayOfRefAndNotRefUnions = isset($input->{'arrayOfRefAndNotRefUnions'})
             ? array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i))
-                    ? $i
-                    : (((is_int($i) || is_float($i)))
-                        ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
-                        : null
-                    )
+                ? array_map(fn ($i) => (((is_int($i) || is_float($i)))
+                    ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
+                    : $i
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : $i
             ), $input->{'arrayOfRefAndNotRefUnions'})
             : null;
         $arrayOfUnionOfStringAndArray = isset($input->{'arrayOfUnionOfStringAndArray'})
@@ -492,7 +483,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => is_array($i))))
             )
                 ? array_map(fn ($i) => $i, $i)
-                : ((is_string($i)) ? $i : null)
+                : $i
             ), $input->{'arrayOfUnionOfStringAndArray'})
             : null;
         $arrayOfUnionWithOneType = isset($input->{'arrayOfUnionWithOneType'})
@@ -528,24 +519,24 @@ class MyClass
             $output['arrayOfUnions'] = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $output['arrayOfRefUnions'] = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $output['arrayOfRefAndNotRefUnions'] = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
@@ -553,7 +544,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => is_array($i))))
             )
                 ? array_map(fn ($i) => $i, $i)
-                : ((is_string($i)) ? $i : null)
+                : $i
             ), $this->arrayOfUnionOfStringAndArray);
         }
         if (isset($this->arrayOfUnionWithOneType)) {
@@ -576,24 +567,24 @@ class MyClass
             $output->{'arrayOfUnions'} = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $output->{'arrayOfRefUnions'} = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $output->{'arrayOfRefAndNotRefUnions'} = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
@@ -601,7 +592,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => is_array($i))))
             )
                 ? array_map(fn ($i) => $i, $i)
-                : ((is_string($i)) ? $i : null)
+                : $i
             ), $this->arrayOfUnionOfStringAndArray);
         }
         if (isset($this->arrayOfUnionWithOneType)) {

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
@@ -443,15 +443,10 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) => $i,
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
-                        default => null,
+                        default => $i,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
-                },
-                default => null,
+                default => $i,
             }, $input->{'arrayOfUnions'})
             : null;
         $arrayOfRefUnions = isset($input->{'arrayOfRefUnions'})
@@ -459,15 +454,10 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) => $i,
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
-                        default => null,
+                        default => $i,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
-                },
-                default => null,
+                default => $i,
             }, $input->{'arrayOfRefUnions'})
             : null;
         $arrayOfRefAndNotRefUnions = isset($input->{'arrayOfRefAndNotRefUnions'})
@@ -475,23 +465,17 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) => $i,
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
-                        default => null,
+                        default => $i,
                     }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
-                },
-                default => null,
+                default => $i,
             }, $input->{'arrayOfRefAndNotRefUnions'})
             : null;
         $arrayOfUnionOfStringAndArray = isset($input->{'arrayOfUnionOfStringAndArray'})
             ? array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => is_array($i)))) => array_map(fn ($i) => $i, $i),
-                is_string($i) => $i,
-                default => null,
+                default => $i,
             }, $input->{'arrayOfUnionOfStringAndArray'})
             : null;
         $arrayOfUnionWithOneType = isset($input->{'arrayOfUnionWithOneType'})
@@ -527,53 +511,31 @@ class MyClass
             $output['arrayOfUnions'] = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                        default => null,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
-                },
-                default => null,
+                    array_map(fn ($i) => $i, $i),
+                default => $i,
             }, $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $output['arrayOfRefUnions'] = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                        default => null,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
-                },
-                default => null,
+                    array_map(fn ($i) => $i, $i),
+                default => $i,
             }, $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $output['arrayOfRefAndNotRefUnions'] = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                        default => null,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
-                },
-                default => null,
+                    array_map(fn ($i) => $i, $i),
+                default => $i,
             }, $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
             $output['arrayOfUnionOfStringAndArray'] = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => is_array($i)))) => array_map(fn ($i) => $i, $i),
-                is_string($i) => $i,
-                default => null,
+                default => $i,
             }, $this->arrayOfUnionOfStringAndArray);
         }
         if (isset($this->arrayOfUnionWithOneType)) {
@@ -596,53 +558,31 @@ class MyClass
             $output->{'arrayOfUnions'} = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                        default => null,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
-                },
-                default => null,
+                    array_map(fn ($i) => $i, $i),
+                default => $i,
             }, $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $output->{'arrayOfRefUnions'} = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                        default => null,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
-                },
-                default => null,
+                    array_map(fn ($i) => $i, $i),
+                default => $i,
             }, $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $output->{'arrayOfRefAndNotRefUnions'} = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
-                    array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                        default => null,
-                    }, $i),
-                (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
-                },
-                default => null,
+                    array_map(fn ($i) => $i, $i),
+                default => $i,
             }, $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
             $output->{'arrayOfUnionOfStringAndArray'} = array_map(fn ($i) => match (true) {
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => is_array($i)))) => array_map(fn ($i) => $i, $i),
-                is_string($i) => $i,
-                default => null,
+                default => $i,
             }, $this->arrayOfUnionOfStringAndArray);
         }
         if (isset($this->arrayOfUnionWithOneType)) {

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
@@ -433,7 +433,7 @@ class MyClass
                         fn ($i): MyClassArrayOfObjectsUnionAlternative2Item => MyClassArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'arrayOfObjectsUnion'},
                     )
-                    : null
+                    : $input->{'arrayOfObjectsUnion'}
                 )
             )
             : null;
@@ -458,7 +458,7 @@ class MyClass
                         fn ($i): MyClassRefArrayOfObjectsUnionAlternative2Item => MyClassRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'refArrayOfObjectsUnion'},
                     )
-                    : null
+                    : $input->{'refArrayOfObjectsUnion'}
                 )
             )
             : null;
@@ -503,7 +503,7 @@ class MyClass
                                 fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::fromInput($i, $validate),
                                 $input->{'refAndNotRefArrayOfObjectsUnion'},
                             )
-                            : null
+                            : $input->{'refAndNotRefArrayOfObjectsUnion'}
                         )
                     )
                 )
@@ -520,10 +520,7 @@ class MyClass
                     fn ($i): MyClassArrayOfObjAndStringUnionAlternative1Item => MyClassArrayOfObjAndStringUnionAlternative1Item::fromInput($i, $validate),
                     $input->{'arrayOfObjAndStringUnion'},
                 )
-                : ((is_string($input->{'arrayOfObjAndStringUnion'}))
-                    ? $input->{'arrayOfObjAndStringUnion'}
-                    : null
-                )
+                : $input->{'arrayOfObjAndStringUnion'}
             )
             : null;
         $unionOfOneArrayOfObjects = isset($input->{'unionOfOneArrayOfObjects'})

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClass.php
@@ -425,7 +425,7 @@ class MyClass
                         fn (object|array $i): MyClassArrayOfObjectsUnionAlternative2Item => MyClassArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'arrayOfObjectsUnion'},
                     ),
-                default => null,
+                default => $input->{'arrayOfObjectsUnion'},
             }
             : null;
         $refArrayOfObjectsUnion = isset($input->{'refArrayOfObjectsUnion'})
@@ -448,7 +448,7 @@ class MyClass
                         fn (object|array $i): MyClassRefArrayOfObjectsUnionAlternative2Item => MyClassRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'refArrayOfObjectsUnion'},
                     ),
-                default => null,
+                default => $input->{'refArrayOfObjectsUnion'},
             }
             : null;
         $refAndNotRefArrayOfObjectsUnion = isset($input->{'refAndNotRefArrayOfObjectsUnion'})
@@ -489,7 +489,7 @@ class MyClass
                         fn (object|array $i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::fromInput($i, $validate),
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                     ),
-                default => null,
+                default => $input->{'refAndNotRefArrayOfObjectsUnion'},
             }
             : null;
         $arrayOfObjAndStringUnion = isset($input->{'arrayOfObjAndStringUnion'})
@@ -503,8 +503,7 @@ class MyClass
                         fn (object|array $i): MyClassArrayOfObjAndStringUnionAlternative1Item => MyClassArrayOfObjAndStringUnionAlternative1Item::fromInput($i, $validate),
                         $input->{'arrayOfObjAndStringUnion'},
                     ),
-                is_string($input->{'arrayOfObjAndStringUnion'}) => $input->{'arrayOfObjAndStringUnion'},
-                default => null,
+                default => $input->{'arrayOfObjAndStringUnion'},
             }
             : null;
         $unionOfOneArrayOfObjects = isset($input->{'unionOfOneArrayOfObjects'})

--- a/tests/Generator/Fixtures/UnionArrayTyped/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayTyped/Output-7.4/MyClass.php
@@ -380,28 +380,13 @@ class MyClass
             static::validateInput($input);
         }
 
-        $unionOfTypedArrays = isset($input->{'unionOfTypedArrays'})
-            ? ((is_array($input->{'unionOfTypedArrays'})) ? $input->{'unionOfTypedArrays'} : null)
-            : null;
-        $refUnionOfTypedArrays = isset($input->{'refUnionOfTypedArrays'})
-            ? ((is_array($input->{'refUnionOfTypedArrays'}))
-                ? $input->{'refUnionOfTypedArrays'}
-                : null
-            )
-            : null;
+        $unionOfTypedArrays = isset($input->{'unionOfTypedArrays'}) ? $input->{'unionOfTypedArrays'} : null;
+        $refUnionOfTypedArrays = isset($input->{'refUnionOfTypedArrays'}) ? $input->{'refUnionOfTypedArrays'} : null;
         $refAndNotRefUnionOfTypedArrays = isset($input->{'refAndNotRefUnionOfTypedArrays'})
-            ? ((is_array($input->{'refAndNotRefUnionOfTypedArrays'}))
-                ? $input->{'refAndNotRefUnionOfTypedArrays'}
-                : null
-            )
+            ? $input->{'refAndNotRefUnionOfTypedArrays'}
             : null;
         $unionOfTypedArrayAndString = isset($input->{'unionOfTypedArrayAndString'})
-            ? ((is_array($input->{'unionOfTypedArrayAndString'})
-                || is_string($input->{'unionOfTypedArrayAndString'})
-            )
-                ? $input->{'unionOfTypedArrayAndString'}
-                : null
-            )
+            ? $input->{'unionOfTypedArrayAndString'}
             : null;
         $unionOfOneTypedArray = isset($input->{'unionOfOneTypedArray'}) ? $input->{'unionOfOneTypedArray'} : null;
 

--- a/tests/Generator/Fixtures/UnionArrayTyped/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayTyped/Output-8.4/MyClass.php
@@ -373,31 +373,13 @@ class MyClass
             static::validateInput($input);
         }
 
-        $unionOfTypedArrays = isset($input->{'unionOfTypedArrays'})
-            ? match (true) {
-                is_array($input->{'unionOfTypedArrays'}) => $input->{'unionOfTypedArrays'},
-                default => null,
-            }
-            : null;
-        $refUnionOfTypedArrays = isset($input->{'refUnionOfTypedArrays'})
-            ? match (true) {
-                is_array($input->{'refUnionOfTypedArrays'}) => $input->{'refUnionOfTypedArrays'},
-                default => null,
-            }
-            : null;
+        $unionOfTypedArrays = isset($input->{'unionOfTypedArrays'}) ? $input->{'unionOfTypedArrays'} : null;
+        $refUnionOfTypedArrays = isset($input->{'refUnionOfTypedArrays'}) ? $input->{'refUnionOfTypedArrays'} : null;
         $refAndNotRefUnionOfTypedArrays = isset($input->{'refAndNotRefUnionOfTypedArrays'})
-            ? match (true) {
-                is_array($input->{'refAndNotRefUnionOfTypedArrays'}) => $input->{'refAndNotRefUnionOfTypedArrays'},
-                default => null,
-            }
+            ? $input->{'refAndNotRefUnionOfTypedArrays'}
             : null;
         $unionOfTypedArrayAndString = isset($input->{'unionOfTypedArrayAndString'})
-            ? match (true) {
-                is_array($input->{'unionOfTypedArrayAndString'})
-                    || is_string($input->{'unionOfTypedArrayAndString'}) =>
-                    $input->{'unionOfTypedArrayAndString'},
-                default => null,
-            }
+            ? $input->{'unionOfTypedArrayAndString'}
             : null;
         $unionOfOneTypedArray = isset($input->{'unionOfOneTypedArray'}) ? $input->{'unionOfOneTypedArray'} : null;
 

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
@@ -310,10 +310,7 @@ class MyClass
         $foo = $input->{'foo'};
         $bar = $input->{'bar'};
         $baz = $input->{'baz'};
-        $qux = ($input->{'qux'} !== null
-            ? ((is_string($input->{'qux'})) ? $input->{'qux'} : null)
-            : null
-        );
+        $qux = ($input->{'qux'} !== null ? $input->{'qux'} : null);
 
         $obj = new self($foo, $bar, $baz, $qux);
 

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -253,10 +253,7 @@ class MyClass
         $foo = $input->{'foo'};
         $bar = $input->{'bar'};
         $baz = $input->{'baz'};
-        $qux = ($input->{'qux'} !== null
-            ? ((is_string($input->{'qux'})) ? $input->{'qux'} : null)
-            : null
-        );
+        $qux = ($input->{'qux'} !== null ? $input->{'qux'} : null);
 
         $obj = new self($foo, $bar, $baz, $qux);
 

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -255,13 +255,7 @@ class MyClass
             is_string($input->{'baz'}) => $input->{'baz'},
             default => throw new \InvalidArgumentException("could not build property 'baz' from JSON"),
         };
-        $qux = ($input->{'qux'} !== null
-            ? match (true) {
-                is_string($input->{'qux'}) => $input->{'qux'},
-                default => null,
-            }
-            : null
-        );
+        $qux = ($input->{'qux'} !== null ? $input->{'qux'} : null);
 
         $obj = new self($foo, $bar, $baz, $qux);
 

--- a/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
@@ -434,42 +434,42 @@ class MyClass
 
         $_providedOptionals = [];
         $objectsUnion = isset($input->{'objectsUnion'})
-            ? ((MyClassObjectsUnionAlternative1::validateInput($input->{'objectsUnion'}, true))
+            ? ((((is_object($input->{'objectsUnion'}) || is_array($input->{'objectsUnion'})) && MyClassObjectsUnionAlternative1::validateInput($input->{'objectsUnion'}, true)))
                 ? MyClassObjectsUnionAlternative1::fromInput($input->{'objectsUnion'}, $validate)
-                : ((MyClassObjectsUnionAlternative2::validateInput($input->{'objectsUnion'}, true))
+                : ((((is_object($input->{'objectsUnion'}) || is_array($input->{'objectsUnion'})) && MyClassObjectsUnionAlternative2::validateInput($input->{'objectsUnion'}, true)))
                     ? MyClassObjectsUnionAlternative2::fromInput($input->{'objectsUnion'}, $validate)
-                    : null
+                    : $input->{'objectsUnion'}
                 )
             )
             : null;
         $refObjectsUnion = isset($input->{'refObjectsUnion'})
-            ? ((SomeObj1::validateInput($input->{'refObjectsUnion'}, true))
+            ? ((((is_object($input->{'refObjectsUnion'}) || is_array($input->{'refObjectsUnion'})) && SomeObj1::validateInput($input->{'refObjectsUnion'}, true)))
                 ? SomeObj1::fromInput($input->{'refObjectsUnion'}, $validate)
-                : ((SomeObj2::validateInput($input->{'refObjectsUnion'}, true))
+                : ((((is_object($input->{'refObjectsUnion'}) || is_array($input->{'refObjectsUnion'})) && SomeObj2::validateInput($input->{'refObjectsUnion'}, true)))
                     ? SomeObj2::fromInput($input->{'refObjectsUnion'}, $validate)
-                    : null
+                    : $input->{'refObjectsUnion'}
                 )
             )
             : null;
         $refAndNotRefObjectsUnion = isset($input->{'refAndNotRefObjectsUnion'})
-            ? ((SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
+            ? ((((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true)))
                 ? SomeObj1::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                : ((MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
+                : ((((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)))
                     ? MyClassRefAndNotRefObjectsUnionAlternative2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                    : ((SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
+                    : ((((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)))
                         ? SomeObj2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                        : ((MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
+                        : ((((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true)))
                             ? MyClassRefAndNotRefObjectsUnionAlternative4::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                            : null
+                            : $input->{'refAndNotRefObjectsUnion'}
                         )
                     )
                 )
             )
             : null;
         $objAndStringUnion = isset($input->{'objAndStringUnion'})
-            ? ((MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true))
+            ? ((((is_object($input->{'objAndStringUnion'}) || is_array($input->{'objAndStringUnion'})) && MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true)))
                 ? MyClassObjAndStringUnionAlternative1::fromInput($input->{'objAndStringUnion'}, $validate)
-                : ((is_string($input->{'objAndStringUnion'})) ? $input->{'objAndStringUnion'} : null)
+                : $input->{'objAndStringUnion'}
             )
             : null;
         $unionOfOneObj = isset($input->{'unionOfOneObj'})

--- a/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
@@ -368,39 +368,40 @@ class MyClass
         $_providedOptionals = [];
         $objectsUnion = isset($input->{'objectsUnion'})
             ? match (true) {
-                MyClassObjectsUnionAlternative1::validateInput($input->{'objectsUnion'}, true) =>
+                ((is_object($input->{'objectsUnion'}) || is_array($input->{'objectsUnion'})) && MyClassObjectsUnionAlternative1::validateInput($input->{'objectsUnion'}, true)) =>
                     MyClassObjectsUnionAlternative1::fromInput($input->{'objectsUnion'}, $validate),
-                MyClassObjectsUnionAlternative2::validateInput($input->{'objectsUnion'}, true) =>
+                ((is_object($input->{'objectsUnion'}) || is_array($input->{'objectsUnion'})) && MyClassObjectsUnionAlternative2::validateInput($input->{'objectsUnion'}, true)) =>
                     MyClassObjectsUnionAlternative2::fromInput($input->{'objectsUnion'}, $validate),
-                default => null,
+                default => $input->{'objectsUnion'},
             }
             : null;
         $refObjectsUnion = isset($input->{'refObjectsUnion'})
             ? match (true) {
-                SomeObj1::validateInput($input->{'refObjectsUnion'}, true) => SomeObj1::fromInput($input->{'refObjectsUnion'}, $validate),
-                SomeObj2::validateInput($input->{'refObjectsUnion'}, true) => SomeObj2::fromInput($input->{'refObjectsUnion'}, $validate),
-                default => null,
+                ((is_object($input->{'refObjectsUnion'}) || is_array($input->{'refObjectsUnion'})) && SomeObj1::validateInput($input->{'refObjectsUnion'}, true)) =>
+                    SomeObj1::fromInput($input->{'refObjectsUnion'}, $validate),
+                ((is_object($input->{'refObjectsUnion'}) || is_array($input->{'refObjectsUnion'})) && SomeObj2::validateInput($input->{'refObjectsUnion'}, true)) =>
+                    SomeObj2::fromInput($input->{'refObjectsUnion'}, $validate),
+                default => $input->{'refObjectsUnion'},
             }
             : null;
         $refAndNotRefObjectsUnion = isset($input->{'refAndNotRefObjectsUnion'})
             ? match (true) {
-                SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true) =>
+                ((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) =>
                     SomeObj1::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate),
-                MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true) =>
+                ((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) =>
                     MyClassRefAndNotRefObjectsUnionAlternative2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate),
-                SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true) =>
+                ((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) =>
                     SomeObj2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate),
-                MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true) =>
+                ((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) =>
                     MyClassRefAndNotRefObjectsUnionAlternative4::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate),
-                default => null,
+                default => $input->{'refAndNotRefObjectsUnion'},
             }
             : null;
         $objAndStringUnion = isset($input->{'objAndStringUnion'})
             ? match (true) {
-                MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true) =>
+                ((is_object($input->{'objAndStringUnion'}) || is_array($input->{'objAndStringUnion'})) && MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true)) =>
                     MyClassObjAndStringUnionAlternative1::fromInput($input->{'objAndStringUnion'}, $validate),
-                is_string($input->{'objAndStringUnion'}) => $input->{'objAndStringUnion'},
-                default => null,
+                default => $input->{'objAndStringUnion'},
             }
             : null;
         $unionOfOneObj = isset($input->{'unionOfOneObj'})

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -168,13 +168,12 @@ class Cat
                     ) =>
                         ($input->{'hasFur'} !== null
                             ? match (true) {
-                                is_string($input->{'hasFur'}) => $input->{'hasFur'},
                                 (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})) =>
                                     (str_contains((string)$input->{'hasFur'}, '.')
                                         ? (float)$input->{'hasFur'}
                                         : (int)$input->{'hasFur'}
                                     ),
-                                default => null,
+                                default => $input->{'hasFur'},
                             }
                             : null
                         ),
@@ -183,16 +182,15 @@ class Cat
                         || is_bool($input->{'hasFur'})
                     ) =>
                         match (true) {
-                            is_string($input->{'hasFur'}) => $input->{'hasFur'},
                             (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})) =>
                                 (str_contains((string)$input->{'hasFur'}, '.')
                                     ? (float)$input->{'hasFur'}
                                     : (int)$input->{'hasFur'}
                                 ),
                             is_bool($input->{'hasFur'}) => (bool)$input->{'hasFur'},
-                            default => null,
+                            default => $input->{'hasFur'},
                         },
-                    default => null,
+                    default => $input->{'hasFur'},
                 }
                 : null
             );
@@ -222,29 +220,12 @@ class Cat
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
             $output['hasFur'] = ($this->hasFur !== null
                 ? match (true) {
-                    ($this->hasFur === null || is_bool($this->hasFur)) => ($this->hasFur !== null ? $this->hasFur : null),
-                    ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
-                        ($this->hasFur !== null
-                            ? match (true) {
-                                is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
-                                default => null,
-                            }
-                            : null
-                        ),
-                    (is_string($this->hasFur)
-                        || (is_int($this->hasFur) || is_float($this->hasFur))
-                        || is_bool($this->hasFur)
-                    ) =>
-                        match (true) {
-                            is_string($this->hasFur)
-                                || (is_int($this->hasFur) || is_float($this->hasFur))
-                                || is_bool($this->hasFur) =>
-                                $this->hasFur,
-                            default => null,
-                        },
-                    default => null,
+                    ($this->hasFur === null || is_bool($this->hasFur))
+                        || ($this->hasFur === null
+                            || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
+                        ) =>
+                        ($this->hasFur !== null ? $this->hasFur : null),
+                    default => $this->hasFur,
                 }
                 : null
             );
@@ -265,29 +246,12 @@ class Cat
         if (isset($this->hasFur) || array_key_exists('hasFur', $this->_providedOptionals)) {
             $output->{'hasFur'} = ($this->hasFur !== null
                 ? match (true) {
-                    ($this->hasFur === null || is_bool($this->hasFur)) => ($this->hasFur !== null ? $this->hasFur : null),
-                    ($this->hasFur === null
-                        || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
-                    ) =>
-                        ($this->hasFur !== null
-                            ? match (true) {
-                                is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
-                                default => null,
-                            }
-                            : null
-                        ),
-                    (is_string($this->hasFur)
-                        || (is_int($this->hasFur) || is_float($this->hasFur))
-                        || is_bool($this->hasFur)
-                    ) =>
-                        match (true) {
-                            is_string($this->hasFur)
-                                || (is_int($this->hasFur) || is_float($this->hasFur))
-                                || is_bool($this->hasFur) =>
-                                $this->hasFur,
-                            default => null,
-                        },
-                    default => null,
+                    ($this->hasFur === null || is_bool($this->hasFur))
+                        || ($this->hasFur === null
+                            || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
+                        ) =>
+                        ($this->hasFur !== null ? $this->hasFur : null),
+                    default => $this->hasFur,
                 }
                 : null
             );

--- a/tests/Generator/Property/UnionPropertyTest.php
+++ b/tests/Generator/Property/UnionPropertyTest.php
@@ -56,9 +56,9 @@ class UnionPropertyTest extends TestCase
 
         $expected = <<<'EOCODE'
 $myPropertyName = match (true) {
-    FooMyPropertyNameAlternative1::validateInput($input->{'myPropertyName'}, true) =>
+    ((is_object($input->{'myPropertyName'}) || is_array($input->{'myPropertyName'})) && FooMyPropertyNameAlternative1::validateInput($input->{'myPropertyName'}, true)) =>
         FooMyPropertyNameAlternative1::fromInput($input->{'myPropertyName'}, $validate),
-    FooMyPropertyNameAlternative2::validateInput($input->{'myPropertyName'}, true) =>
+    ((is_object($input->{'myPropertyName'}) || is_array($input->{'myPropertyName'})) && FooMyPropertyNameAlternative2::validateInput($input->{'myPropertyName'}, true)) =>
         FooMyPropertyNameAlternative2::fromInput($input->{'myPropertyName'}, $validate),
     default => throw new \InvalidArgumentException("could not build property 'myPropertyName' from JSON"),
 };


### PR DESCRIPTION
## Summary
- ensure union properties keep unmatched values instead of null
- avoid type errors by guarding validator calls
- update tests and fixtures

## Testing
- `vendor/bin/phpstan --memory-limit=512M`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a2daffe270832d8a82e383587bc987