### PR TITLE
Preserve unmatched union values instead of null

### DIFF
--- a/src/Generator/Property/PropertyQuery.php
+++ b/src/Generator/Property/PropertyQuery.php
@@ -16,6 +16,18 @@ class PropertyQuery
     public static function isDeprecated(PropertyInterface $property): bool
     {
         $schema = $property->schema();
-        return isset($schema["deprecated"]) && $schema["deprecated"];
+        if (isset($schema["deprecated"]) && $schema["deprecated"]) {
+            return true;
+        }
+
+        if (isset($schema["allOf"])) {
+            foreach ($schema["allOf"] as $subSchema) {
+                if (isset($subSchema["deprecated"]) && $subSchema["deprecated"]) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Generator/Property/Type/Composite/UnionProperty.php
+++ b/src/Generator/Property/Type/Composite/UnionProperty.php
@@ -67,22 +67,7 @@ class UnionProperty extends AbstractProperty
 
         $arms = $this->collectArms(
             mappingFn: fn(PropertyInterface $sub): string => $sub->inputMappingExpr($accessor, asserted: true),
-            assertFn: function (PropertyInterface $sub) use ($accessor): string {
-                $discriminator = $sub->inputAssertionExpr($accessor);
-
-                if (
-                    $sub instanceof ReferenceArrayProperty
-                    || $sub instanceof ObjectArrayProperty
-                    || $sub instanceof PrimitiveArrayProperty
-                ) {
-                    $isArrayCheck = "is_array({$accessor})";
-                    if (!str_contains($discriminator, $isArrayCheck)) {
-                        $discriminator = "({$isArrayCheck} && {$discriminator})";
-                    }
-                }
-
-                return $discriminator;
-            }
+            assertFn: fn(PropertyInterface $sub) => $this->guardInputAssertion($sub, $accessor)
         );
 
         $assignmentTemplate = "\${$name} = %s;";
@@ -106,14 +91,19 @@ class UnionProperty extends AbstractProperty
         $keyStr     = $this->keyStr();
         $outputVar  = VariableNames::OUTPUT;
 
+        $valueExpr = '$this->' . $name;
+        $skipMap   = $this->request->isAtLeastPHP('8.0') ? null : fn(string $map): bool => $map === $valueExpr;
         $arms = $this->collectArms(
-            mappingFn: fn(PropertyInterface $sub): string => $sub->outputMappingExpr("\$this->{$name}"),
-            assertFn: fn(PropertyInterface $sub): string => $sub->typeAssertionExpr("\$this->{$name}")
+            mappingFn: fn(PropertyInterface $sub): string => $sub->outputMappingExpr($valueExpr),
+            assertFn: fn(PropertyInterface $sub): string => $sub->typeAssertionExpr($valueExpr),
+            skipMapFn: $skipMap,
         );
 
         $assignmentTemplate = "\${$outputVar}[{$keyStr}] = %s;";
+        $matchDefault       = $valueExpr;
+        $fallback           = sprintf($assignmentTemplate, $valueExpr);
 
-        return $this->renderAssignments($arms, $assignmentTemplate, null, null);
+        return $this->renderAssignments($arms, $assignmentTemplate, $matchDefault, $fallback);
     }
 
     public function convertTypeToStdClass(): string
@@ -122,14 +112,19 @@ class UnionProperty extends AbstractProperty
         $keyStr     = $this->keyStr();
         $outputVar  = VariableNames::OUTPUT;
 
+        $valueExpr = '$this->' . $name;
+        $skipMap   = $this->request->isAtLeastPHP('8.0') ? null : fn(string $map): bool => $map === $valueExpr;
         $arms = $this->collectArms(
-            mappingFn: fn(PropertyInterface $sub): string => $sub->outputMappingExprStdClass("\$this->{$name}"),
-            assertFn: fn(PropertyInterface $sub): string => $sub->typeAssertionExpr("\$this->{$name}")
+            mappingFn: fn(PropertyInterface $sub): string => $sub->outputMappingExprStdClass($valueExpr),
+            assertFn: fn(PropertyInterface $sub): string => $sub->typeAssertionExpr($valueExpr),
+            skipMapFn: $skipMap,
         );
 
         $assignmentTemplate = "\${$outputVar}->{{$keyStr}} = %s;";
+        $matchDefault       = $valueExpr;
+        $fallback           = sprintf($assignmentTemplate, $valueExpr);
 
-        return $this->renderAssignments($arms, $assignmentTemplate, null, null);
+        return $this->renderAssignments($arms, $assignmentTemplate, $matchDefault, $fallback);
     }
 
     /**
@@ -252,44 +247,73 @@ class UnionProperty extends AbstractProperty
 
     public function inputMappingExpr(string $expr, bool $asserted = false): string
     {
+        $skipMap = $this->request->isAtLeastPHP('8.0') ? null : fn(string $map): bool => $map === $expr;
         $arms = $this->collectArms(
             mappingFn: fn(PropertyInterface $sub): string => $sub->inputMappingExpr($expr),
-            assertFn: fn(PropertyInterface $sub): string => $sub->inputAssertionExpr($expr)
+            assertFn: fn(PropertyInterface $sub) => $this->guardInputAssertion($sub, $expr),
+            skipMapFn: $skipMap,
         );
 
-        return $this->renderConditionalExpr($arms, 'null');
+        if ($arms === []) {
+            return $expr;
+        }
+
+        if ($this->request->isAtLeastPHP('8.0')) {
+            if (count($arms) === 1) {
+                $only = array_key_first($arms);
+                if ($only !== $expr) {
+                    return $only;
+                }
+            }
+        }
+
+        return $this->renderConditionalExpr($arms, $expr);
     }
 
     public function outputMappingExpr(string $expr): string
     {
+        $skipMap = $this->request->isAtLeastPHP('8.0') ? null : fn(string $map): bool => $map === $expr;
         $arms = $this->collectArms(
             mappingFn: fn(PropertyInterface $sub): string => $sub->outputMappingExpr($expr),
-            assertFn: fn(PropertyInterface $sub): string => $sub->typeAssertionExpr($expr)
+            assertFn: fn(PropertyInterface $sub): string => $sub->typeAssertionExpr($expr),
+            skipMapFn: $skipMap,
         );
 
-        return $this->renderConditionalExpr($arms, 'null');
+        if ($arms === []) {
+            return $expr;
+        }
+
+        if ($this->request->isAtLeastPHP('8.0')) {
+            if (count($arms) === 1) {
+                $only = array_key_first($arms);
+                if ($only !== $expr) {
+                    return $only;
+                }
+            }
+        }
+
+        return $this->renderConditionalExpr($arms, $expr);
     }
 
     public function outputMappingExprStdClass(string $expr): string
     {
+        $skipMap = $this->request->isAtLeastPHP('8.0') ? null : fn(string $map): bool => $map === $expr;
         $arms = $this->collectArms(
             mappingFn: fn(PropertyInterface $sub): string => $sub->outputMappingExprStdClass($expr),
             assertFn: fn(PropertyInterface $sub): string => $sub->typeAssertionExpr($expr),
-            skipMapFn: fn(string $map) => $map === 'null'
+            skipMapFn: $skipMap,
         );
 
         if ($arms === []) {
-            return 'null';
+            return $expr;
         }
 
-        return $this->renderConditionalExpr($arms, 'null');
+        return $this->renderConditionalExpr($arms, $expr);
     }
 
     public function cloneExpr(string $expr): string
     {
-        $skipMap = $this->request->isAtLeastPHP('8.0')
-            ? null
-            : fn(string $map): bool => $map === $expr;
+        $skipMap = $this->request->isAtLeastPHP('8.0') ? null : fn(string $map): bool => $map === $expr;
 
         $arms = $this->collectArms(
             mappingFn: fn(PropertyInterface $sub): string => $sub->cloneExpr($expr),
@@ -302,10 +326,38 @@ class UnionProperty extends AbstractProperty
         }
 
         if ($this->request->isAtLeastPHP('8.0') && count($arms) === 1) {
-            return array_key_first($arms);
+            $only = array_key_first($arms);
+            if ($only === $expr) {
+                return $expr;
+            }
+            return $only;
         }
 
-        return $this->renderConditionalExpr($arms, $expr, false);
+        return $this->renderConditionalExpr($arms, $expr);
+    }
+
+    private function guardInputAssertion(PropertyInterface $sub, string $expr): string
+    {
+        $assertion = $sub->inputAssertionExpr($expr);
+
+        if (
+            $sub instanceof ReferenceArrayProperty
+            || $sub instanceof ObjectArrayProperty
+            || $sub instanceof PrimitiveArrayProperty
+        ) {
+            $isArrayCheck = "is_array({$expr})";
+            if (!str_contains($assertion, $isArrayCheck)) {
+                $assertion = "({$isArrayCheck} && {$assertion})";
+            }
+        } elseif (
+            $sub instanceof NestedObjectProperty
+            || ($sub instanceof ReferenceProperty && $sub->getRefType() instanceof ReferencedTypeClass)
+        ) {
+            $isObjCheck = "(is_object({$expr}) || is_array({$expr}))";
+            $assertion  = "({$isObjCheck} && {$assertion})";
+        }
+
+        return $assertion;
     }
 
     /**
@@ -370,6 +422,12 @@ class UnionProperty extends AbstractProperty
     private function renderConditionalExpr(array $arms, string $default, bool $includeMatchDefault = true): string
     {
         if ($this->request->isAtLeastPHP('8.0')) {
+            if ($includeMatchDefault && array_key_exists($default, $arms)) {
+                $wrapped = '(' . $default . ')';
+                $condArms = $arms[$default];
+                unset($arms[$default]);
+                $arms = [$wrapped => $condArms] + $arms;
+            }
             return $this->renderMatch($arms, $includeMatchDefault ? $default : null);
         }
 

--- a/src/Spec/Specification.php
+++ b/src/Spec/Specification.php
@@ -8,8 +8,6 @@ class Specification
 {
     /**
      * Schema used to validate input for creating instances of this class
-     *
-     * @var array
      */
     private static array $_schema = ['properties' => ['options' => ['$ref' => '#/definitions/SpecificationOptions'], 'files' => ['type' => 'array', 'items' => ['properties' => ['input' => ['type' => ['string', 'object']], 'className' => ['type' => 'string'], 'options' => ['$ref' => '#/definitions/SpecificationOptions']], 'additionalProperties' => false, 'required' => ['input']]]], 'additionalProperties' => false, 'required' => ['files'], 'definitions' => ['SpecificationOptions' => ['additionalProperties' => false, 'properties' => ['targetDirectory' => ['type' => 'string'], 'targetNamespace' => ['type' => 'string'], 'targetPHPVersion' => ['oneOf' => [['type' => 'integer', 'enum' => [5, 7, 8]], ['type' => 'string']]], 'cleanTargetDirectory' => ['type' => 'boolean'], 'disableStrictTypes' => ['type' => 'boolean'], 'inlineAllofReferences' => ['type' => 'boolean'], 'newValidatorExpr' => ['type' => 'string'], 'arrayToObjectExpr' => ['type' => 'string'], 'preservePropertyNames' => ['type' => 'boolean'], 'noGetters' => ['type' => 'boolean'], 'noSetters' => ['type' => 'boolean'], 'mutableSetters' => ['oneOf' => [['type' => 'boolean', 'enum' => [true]], ['type' => 'string', 'enum' => ['chainable']]]], 'noSchemaMetadata' => ['type' => 'boolean'], 'singleLineSchema' => ['type' => 'boolean'], 'noEnums' => ['type' => 'boolean']]]]];
 
@@ -63,17 +61,11 @@ class Specification
      */
     public function withFiles(array $files, bool $validate = true): self
     {
-        if ($validate) {
-            $validator = new \JsonSchema\Validator();
-            $validator->validate($files, self::$_schema['properties']['files']);
-            if (!$validator->isValid()) {
-                throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
-            }
-        }
-
         $clone = clone $this;
         $clone->files = $files;
-
+        if ($validate) {
+            $clone->validate();
+        }
         return $clone;
     }
 
@@ -92,15 +84,21 @@ class Specification
             static::validateInput($input);
         }
 
-        $files = array_map(fn (array|object $i): SpecificationFilesItem => SpecificationFilesItem::fromInput($i, $validate), $input->{'files'});
-        $options = isset($input->{'options'}) ? SpecificationOptions::fromInput($input->{'options'}, $validate) : null;
+        $files = array_map(
+            fn (object|array $i): SpecificationFilesItem => SpecificationFilesItem::fromInput($i, $validate),
+            $input->{'files'},
+        );
+        $options = isset($input->{'options'})
+            ? SpecificationOptions::fromInput($input->{'options'}, $validate)
+            : null;
 
         $obj = new self($files, $options);
+
         return $obj;
     }
 
     /**
-     * Converts this object back to a simple array that can be JSON-serialized
+     * Converts this object to array that can be JSON-serialized
      *
      * @return array Converted array
      */
@@ -132,11 +130,23 @@ class Specification
     }
 
     /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data
      * @param bool $return Return instead of throwing errors
-     * @return bool Validation result
+     * @return bool Validation result if `$return` is `true`
      * @throws \InvalidArgumentException
      */
     public static function validateInput(array|object $input, bool $return = false): bool
@@ -146,9 +156,10 @@ class Specification
         $validator->validate($input, self::$_schema);
 
         if (!$validator->isValid() && !$return) {
-            $errors = array_map(function(array $e): string {
-                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
-            }, $validator->getErrors());
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
             throw new \InvalidArgumentException(join(".\n", $errors));
         }
 
@@ -157,6 +168,9 @@ class Specification
 
     public function __clone()
     {
+        if (isset($this->options)) {
+            $this->options = clone $this->options;
+        }
         $this->files = array_map(fn (SpecificationFilesItem $i) => clone $i, $this->files);
     }
 }

--- a/src/Spec/SpecificationFilesItem.php
+++ b/src/Spec/SpecificationFilesItem.php
@@ -8,8 +8,6 @@ class SpecificationFilesItem
 {
     /**
      * Schema used to validate input for creating instances of this class
-     *
-     * @var array
      */
     private static array $_schema = ['properties' => ['input' => ['type' => ['string', 'object']], 'className' => ['type' => 'string'], 'options' => ['$ref' => '#/definitions/SpecificationOptions']], 'additionalProperties' => false, 'required' => ['input'], 'definitions' => ['SpecificationOptions' => ['additionalProperties' => false, 'properties' => ['targetDirectory' => ['type' => 'string'], 'targetNamespace' => ['type' => 'string'], 'targetPHPVersion' => ['oneOf' => [['type' => 'integer', 'enum' => [5, 7, 8]], ['type' => 'string']]], 'cleanTargetDirectory' => ['type' => 'boolean'], 'disableStrictTypes' => ['type' => 'boolean'], 'inlineAllofReferences' => ['type' => 'boolean'], 'newValidatorExpr' => ['type' => 'string'], 'arrayToObjectExpr' => ['type' => 'string'], 'preservePropertyNames' => ['type' => 'boolean'], 'noGetters' => ['type' => 'boolean'], 'noSetters' => ['type' => 'boolean'], 'mutableSetters' => ['oneOf' => [['type' => 'boolean', 'enum' => [true]], ['type' => 'string', 'enum' => ['chainable']]]], 'noSchemaMetadata' => ['type' => 'boolean'], 'singleLineSchema' => ['type' => 'boolean'], 'noEnums' => ['type' => 'boolean']]]]];
 
@@ -97,19 +95,21 @@ class SpecificationFilesItem
         }
 
         $_input = match (true) {
-            is_string($input->{'input'}),
-            is_array($input->{'input'}) || is_object($input->{'input'}) => $input->{'input'},
+            is_string($input->{'input'}) || is_array($input->{'input'}) || is_object($input->{'input'}) => $input->{'input'},
             default => throw new \InvalidArgumentException("could not build property 'input' from JSON"),
         };
         $className = isset($input->{'className'}) ? $input->{'className'} : null;
-        $options = isset($input->{'options'}) ? SpecificationOptions::fromInput($input->{'options'}, $validate) : null;
+        $options = isset($input->{'options'})
+            ? SpecificationOptions::fromInput($input->{'options'}, $validate)
+            : null;
 
         $obj = new self($_input, $className, $options);
+
         return $obj;
     }
 
     /**
-     * Converts this object back to a simple array that can be JSON-serialized
+     * Converts this object to array that can be JSON-serialized
      *
      * @return array Converted array
      */
@@ -117,7 +117,7 @@ class SpecificationFilesItem
     {
         $output = [];
         $output['input'] = match (true) {
-            is_string($this->input) => $this->input,
+            default => $this->input,
             is_array($this->input) || is_object($this->input) => json_decode(json_encode($this->input), true),
         };
         if (isset($this->className)) {
@@ -139,7 +139,7 @@ class SpecificationFilesItem
     {
         $output = new \stdClass();
         $output->{'input'} = match (true) {
-            is_string($this->input) => $this->input,
+            default => $this->input,
             is_array($this->input) || is_object($this->input) => json_decode(json_encode($this->input)),
         };
         if (isset($this->className)) {
@@ -153,11 +153,23 @@ class SpecificationFilesItem
     }
 
     /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data
      * @param bool $return Return instead of throwing errors
-     * @return bool Validation result
+     * @return bool Validation result if `$return` is `true`
      * @throws \InvalidArgumentException
      */
     public static function validateInput(array|object $input, bool $return = false): bool
@@ -167,9 +179,10 @@ class SpecificationFilesItem
         $validator->validate($input, self::$_schema);
 
         if (!$validator->isValid() && !$return) {
-            $errors = array_map(function(array $e): string {
-                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
-            }, $validator->getErrors());
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
             throw new \InvalidArgumentException(join(".\n", $errors));
         }
 
@@ -179,9 +192,13 @@ class SpecificationFilesItem
     public function __clone()
     {
         $this->input = match (true) {
-            is_string($this->input),
-            is_array($this->input) || is_object($this->input) => $this->input,
+            is_string($this->input) => ($this->input),
+            is_array($this->input) || is_object($this->input) => json_decode(json_encode($this->input), is_array($this->input)),
+            default => $this->input,
         };
+        if (isset($this->options)) {
+            $this->options = clone $this->options;
+        }
     }
 }
 

--- a/src/Spec/SpecificationOptions.php
+++ b/src/Spec/SpecificationOptions.php
@@ -8,8 +8,6 @@ class SpecificationOptions
 {
     /**
      * Schema used to validate input for creating instances of this class
-     *
-     * @var array
      */
     private static array $_schema = ['additionalProperties' => false, 'properties' => ['targetDirectory' => ['type' => 'string'], 'targetNamespace' => ['type' => 'string'], 'targetPHPVersion' => ['oneOf' => [['type' => 'integer', 'enum' => [5, 7, 8]], ['type' => 'string']]], 'cleanTargetDirectory' => ['type' => 'boolean'], 'disableStrictTypes' => ['type' => 'boolean'], 'inlineAllofReferences' => ['type' => 'boolean'], 'newValidatorExpr' => ['type' => 'string'], 'arrayToObjectExpr' => ['type' => 'string'], 'preservePropertyNames' => ['type' => 'boolean'], 'noGetters' => ['type' => 'boolean'], 'noSetters' => ['type' => 'boolean'], 'mutableSetters' => ['oneOf' => [['type' => 'boolean', 'enum' => [true]], ['type' => 'string', 'enum' => ['chainable']]]], 'noSchemaMetadata' => ['type' => 'boolean'], 'singleLineSchema' => ['type' => 'boolean'], 'noEnums' => ['type' => 'boolean']]];
 
@@ -119,7 +117,7 @@ class SpecificationOptions
      */
     public function getTargetPHPVersion(): int|string|null
     {
-        return $this->targetPHPVersion;
+        return $this->targetPHPVersion ?? null;
     }
 
     /**
@@ -367,7 +365,7 @@ class SpecificationOptions
      */
     public function getMutableSetters(): bool|string|null
     {
-        return $this->mutableSetters;
+        return $this->mutableSetters ?? null;
     }
 
     /**
@@ -502,18 +500,15 @@ class SpecificationOptions
             static::validateInput($input);
         }
 
-
         $targetDirectory = isset($input->{'targetDirectory'}) ? $input->{'targetDirectory'} : null;
         $targetNamespace = isset($input->{'targetNamespace'}) ? $input->{'targetNamespace'} : null;
-        $targetPHPVersion = isset($input->{'targetPHPVersion'}) ? match (true) {
-            in_array($input->{'targetPHPVersion'}, array (
-          0 => 5,
-          1 => 7,
-          2 => 8,
-        ), true) => (int)$input->{'targetPHPVersion'},
-            is_string($input->{'targetPHPVersion'}) => $input->{'targetPHPVersion'},
-            default => null,
-        } : null;
+        $targetPHPVersion = isset($input->{'targetPHPVersion'})
+            ? match (true) {
+                is_string($input->{'targetPHPVersion'}) => ($input->{'targetPHPVersion'}),
+                in_array($input->{'targetPHPVersion'}, [5, 7, 8], true) => (int)$input->{'targetPHPVersion'},
+                default => $input->{'targetPHPVersion'},
+            }
+            : null;
         $cleanTargetDirectory = isset($input->{'cleanTargetDirectory'}) ? $input->{'cleanTargetDirectory'} : null;
         $disableStrictTypes = isset($input->{'disableStrictTypes'}) ? $input->{'disableStrictTypes'} : null;
         $inlineAllofReferences = isset($input->{'inlineAllofReferences'}) ? $input->{'inlineAllofReferences'} : null;
@@ -522,15 +517,13 @@ class SpecificationOptions
         $preservePropertyNames = isset($input->{'preservePropertyNames'}) ? $input->{'preservePropertyNames'} : null;
         $noGetters = isset($input->{'noGetters'}) ? $input->{'noGetters'} : null;
         $noSetters = isset($input->{'noSetters'}) ? $input->{'noSetters'} : null;
-        $mutableSetters = isset($input->{'mutableSetters'}) ? match (true) {
-            in_array($input->{'mutableSetters'}, array (
-          0 => true,
-        ), true) => (bool)$input->{'mutableSetters'},
-            in_array($input->{'mutableSetters'}, array (
-          0 => 'chainable',
-        ), true) => $input->{'mutableSetters'},
-            default => null,
-        } : null;
+        $mutableSetters = isset($input->{'mutableSetters'})
+            ? match (true) {
+                in_array($input->{'mutableSetters'}, ['chainable'], true) => ($input->{'mutableSetters'}),
+                in_array($input->{'mutableSetters'}, [true], true) => (bool)$input->{'mutableSetters'},
+                default => $input->{'mutableSetters'},
+            }
+            : null;
         $noSchemaMetadata = isset($input->{'noSchemaMetadata'}) ? $input->{'noSchemaMetadata'} : null;
         $singleLineSchema = isset($input->{'singleLineSchema'}) ? $input->{'singleLineSchema'} : null;
         $noEnums = isset($input->{'noEnums'}) ? $input->{'noEnums'} : null;
@@ -552,11 +545,12 @@ class SpecificationOptions
             $singleLineSchema,
             $noEnums
         );
+
         return $obj;
     }
 
     /**
-     * Converts this object back to a simple array that can be JSON-serialized
+     * Converts this object to array that can be JSON-serialized
      *
      * @return array Converted array
      */
@@ -571,12 +565,7 @@ class SpecificationOptions
         }
         if (isset($this->targetPHPVersion)) {
             $output['targetPHPVersion'] = match (true) {
-                in_array($this->targetPHPVersion, array (
-              0 => 5,
-              1 => 7,
-              2 => 8,
-            ), true),
-                is_string($this->targetPHPVersion) => $this->targetPHPVersion,
+                default => $this->targetPHPVersion,
             };
         }
         if (isset($this->cleanTargetDirectory)) {
@@ -605,12 +594,7 @@ class SpecificationOptions
         }
         if (isset($this->mutableSetters)) {
             $output['mutableSetters'] = match (true) {
-                in_array($this->mutableSetters, array (
-              0 => true,
-            ), true),
-                in_array($this->mutableSetters, array (
-              0 => 'chainable',
-            ), true) => $this->mutableSetters,
+                default => $this->mutableSetters,
             };
         }
         if (isset($this->noSchemaMetadata)) {
@@ -642,12 +626,7 @@ class SpecificationOptions
         }
         if (isset($this->targetPHPVersion)) {
             $output->{'targetPHPVersion'} = match (true) {
-                in_array($this->targetPHPVersion, array (
-              0 => 5,
-              1 => 7,
-              2 => 8,
-            ), true),
-                is_string($this->targetPHPVersion) => $this->targetPHPVersion,
+                default => $this->targetPHPVersion,
             };
         }
         if (isset($this->cleanTargetDirectory)) {
@@ -676,12 +655,7 @@ class SpecificationOptions
         }
         if (isset($this->mutableSetters)) {
             $output->{'mutableSetters'} = match (true) {
-                in_array($this->mutableSetters, array (
-              0 => true,
-            ), true),
-                in_array($this->mutableSetters, array (
-              0 => 'chainable',
-            ), true) => $this->mutableSetters,
+                default => $this->mutableSetters,
             };
         }
         if (isset($this->noSchemaMetadata)) {
@@ -698,11 +672,23 @@ class SpecificationOptions
     }
 
     /**
+     * Validates the current instance against its schema
+     *
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result if `$return` is `true`
+     * @throws \InvalidArgumentException
+     */
+    public function validate(bool $return = false): bool
+    {
+        return self::validateInput($this->toStdClass(), $return);
+    }
+
+    /**
      * Validates an input array
      *
      * @param array|object $input Input data
      * @param bool $return Return instead of throwing errors
-     * @return bool Validation result
+     * @return bool Validation result if `$return` is `true`
      * @throws \InvalidArgumentException
      */
     public static function validateInput(array|object $input, bool $return = false): bool
@@ -712,37 +698,14 @@ class SpecificationOptions
         $validator->validate($input, self::$_schema);
 
         if (!$validator->isValid() && !$return) {
-            $errors = array_map(function(array $e): string {
-                return ($e["property"] ? $e["property"] . ": " : "") . $e["message"];
-            }, $validator->getErrors());
+            $errors = array_map(
+                fn (array $e): string => ($e["property"] ? $e["property"] . ": " : "") . $e["message"],
+                $validator->getErrors(),
+            );
             throw new \InvalidArgumentException(join(".\n", $errors));
         }
 
         return $validator->isValid();
-    }
-
-    public function __clone()
-    {
-        if (isset($this->targetPHPVersion)) {
-            $this->targetPHPVersion = match (true) {
-                in_array($this->targetPHPVersion, array (
-              0 => 5,
-              1 => 7,
-              2 => 8,
-            ), true),
-                is_string($this->targetPHPVersion) => $this->targetPHPVersion,
-            };
-        }
-        if (isset($this->mutableSetters)) {
-            $this->mutableSetters = match (true) {
-                in_array($this->mutableSetters, array (
-              0 => true,
-            ), true),
-                in_array($this->mutableSetters, array (
-              0 => 'chainable',
-            ), true) => $this->mutableSetters,
-            };
-        }
     }
 }
 

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-5.6/MyClass.php
@@ -186,10 +186,7 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'})
-            ? ((is_string($input->{'foo'}))
-                ? $input->{'foo'}
-                : ((is_int($input->{'foo'})) ? (int)$input->{'foo'} : null)
-            )
+            ? ((is_int($input->{'foo'})) ? (int)$input->{'foo'} : $input->{'foo'})
             : null;
 
         $obj = new self($foo);
@@ -213,9 +210,7 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->foo)) {
-            if (is_string($this->foo) || is_int($this->foo)) {
-                $output['foo'] = $this->foo;
-            }
+            $output['foo'] = $this->foo;
         }
 
         if ($includeDefaults) {
@@ -240,9 +235,7 @@ class MyClass
         $output = $this->_additionalProperties;
 
         if (isset($this->foo)) {
-            if (is_string($this->foo) || is_int($this->foo)) {
-                $output->{'foo'} = $this->foo;
-            }
+            $output->{'foo'} = $this->foo;
         }
 
         if ($includeDefaults) {

--- a/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/AnyOfDefault/Output-8.4/MyClass.php
@@ -146,9 +146,9 @@ class MyClass
 
         $foo = isset($input->{'foo'})
             ? match (true) {
-                is_string($input->{'foo'}) => $input->{'foo'},
+                is_string($input->{'foo'}) => ($input->{'foo'}),
                 is_int($input->{'foo'}) => (int)$input->{'foo'},
-                default => null,
+                default => $input->{'foo'},
             }
             : null;
 
@@ -174,7 +174,7 @@ class MyClass
 
         if (isset($this->foo)) {
             $output['foo'] = match (true) {
-                is_string($this->foo) || is_int($this->foo) => $this->foo,
+                default => $this->foo,
             };
         }
 
@@ -201,7 +201,7 @@ class MyClass
 
         if (isset($this->foo)) {
             $output->{'foo'} = match (true) {
-                is_string($this->foo) || is_int($this->foo) => $this->foo,
+                default => $this->foo,
             };
         }
 

--- a/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/AnyOfSetterValidation/Output-8.4/Cat.php
@@ -149,8 +149,8 @@ class Cat
 
         $hasFur = isset($input->{'hasFur'})
             ? match (true) {
-                in_array($input->{'hasFur'}, ['a', 'b'], true) || is_array($input->{'hasFur'}) => $input->{'hasFur'},
-                default => null,
+                in_array($input->{'hasFur'}, ['a', 'b'], true) || is_array($input->{'hasFur'}) => ($input->{'hasFur'}),
+                default => $input->{'hasFur'},
             }
             : null;
 
@@ -175,7 +175,7 @@ class Cat
 
         if (isset($this->hasFur)) {
             $output['hasFur'] = match (true) {
-                in_array($this->hasFur, ['a', 'b'], true) || is_array($this->hasFur) => $this->hasFur,
+                default => $this->hasFur,
             };
         }
 
@@ -193,7 +193,7 @@ class Cat
 
         if (isset($this->hasFur)) {
             $output->{'hasFur'} = match (true) {
-                in_array($this->hasFur, ['a', 'b'], true) || is_array($this->hasFur) => $this->hasFur,
+                default => $this->hasFur,
             };
         }
 

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-7.4/MyClass.php
@@ -468,14 +468,9 @@ class MyClass
         $a = $input->{'a'};
         $b = $input->{'b'};
         $c = ($input->{'c'} !== null ? $input->{'c'} : null);
-        $d = ($input->{'d'} !== null
-            ? ((is_array($input->{'d'}) || is_string($input->{'d'})) ? $input->{'d'} : null)
-            : null
-        );
+        $d = ($input->{'d'} !== null ? $input->{'d'} : null);
         $e = isset($input->{'e'}) ? $input->{'e'} : null;
-        $f = isset($input->{'f'})
-            ? ((is_array($input->{'f'}) || is_string($input->{'f'})) ? $input->{'f'} : null)
-            : null;
+        $f = isset($input->{'f'}) ? $input->{'f'} : null;
         $g = null;
         if (property_exists($input, 'g')) {
             $g = ($input->{'g'} !== null ? $input->{'g'} : null);
@@ -483,24 +478,12 @@ class MyClass
         }
         $h = null;
         if (property_exists($input, 'h')) {
-            $h = ($input->{'h'} !== null
-                ? ((is_array($input->{'h'}) || is_string($input->{'h'})) ? $input->{'h'} : null)
-                : null
-            );
+            $h = ($input->{'h'} !== null ? $input->{'h'} : null);
             $_providedOptionals['h'] = true;
         }
         $i = null;
         if (property_exists($input, 'i')) {
-            $i = ($input->{'i'} !== null
-                ? ((is_array($input->{'i'})
-                    || is_string($input->{'i'})
-                    || is_array($input->{'i'}) || is_object($input->{'i'})
-                )
-                    ? $input->{'i'}
-                    : null
-                )
-                : null
-            );
+            $i = ($input->{'i'} !== null ? $input->{'i'} : null);
             $_providedOptionals['i'] = true;
         }
 
@@ -525,38 +508,26 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         $output['a'] = $this->a;
-        if (is_array($this->b) || is_string($this->b)) {
-            $output['b'] = $this->b;
-        }
+        $output['b'] = $this->b;
         $output['c'] = $this->c;
-        if (is_array($this->d) || is_string($this->d)) {
-            $output['d'] = $this->d;
-        }
+        $output['d'] = $this->d;
         if (isset($this->e)) {
             $output['e'] = $this->e;
         }
         if (isset($this->f)) {
-            if (is_array($this->f) || is_string($this->f)) {
-                $output['f'] = $this->f;
-            }
+            $output['f'] = $this->f;
         }
         if (isset($this->g) || array_key_exists('g', $this->_providedOptionals)) {
             $output['g'] = ($this->g !== null ? $this->g : null);
         }
         if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
-            $output['h'] = ($this->h !== null
-                ? ((is_array($this->h) || is_string($this->h)) ? $this->h : null)
-                : null
-            );
+            $output['h'] = ($this->h !== null ? $this->h : null);
         }
         if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
             $output['i'] = ($this->i !== null
-                ? ((is_array($this->i) || is_string($this->i))
-                    ? $this->i
-                    : ((is_array($this->i) || is_object($this->i))
-                        ? json_decode(json_encode($this->i), true)
-                        : null
-                    )
+                ? ((is_array($this->i) || is_object($this->i))
+                    ? json_decode(json_encode($this->i), true)
+                    : $this->i
                 )
                 : null
             );
@@ -575,38 +546,26 @@ class MyClass
         $output = $this->_additionalProperties;
 
         $output->{'a'} = $this->a;
-        if (is_array($this->b) || is_string($this->b)) {
-            $output->{'b'} = $this->b;
-        }
+        $output->{'b'} = $this->b;
         $output->{'c'} = $this->c;
-        if (is_array($this->d) || is_string($this->d)) {
-            $output->{'d'} = $this->d;
-        }
+        $output->{'d'} = $this->d;
         if (isset($this->e)) {
             $output->{'e'} = $this->e;
         }
         if (isset($this->f)) {
-            if (is_array($this->f) || is_string($this->f)) {
-                $output->{'f'} = $this->f;
-            }
+            $output->{'f'} = $this->f;
         }
         if (isset($this->g) || array_key_exists('g', $this->_providedOptionals)) {
             $output->{'g'} = ($this->g !== null ? $this->g : null);
         }
         if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
-            $output->{'h'} = ($this->h !== null
-                ? ((is_array($this->h) || is_string($this->h)) ? $this->h : null)
-                : null
-            );
+            $output->{'h'} = ($this->h !== null ? $this->h : null);
         }
         if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
             $output->{'i'} = ($this->i !== null
-                ? ((is_array($this->i) || is_string($this->i))
-                    ? $this->i
-                    : ((is_array($this->i) || is_object($this->i))
-                        ? json_decode(json_encode($this->i))
-                        : null
-                    )
+                ? ((is_array($this->i) || is_object($this->i))
+                    ? json_decode(json_encode($this->i))
+                    : $this->i
                 )
                 : null
             );

--- a/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ArrayWithoutItems/Output-8.4/MyClass.php
@@ -374,16 +374,16 @@ class MyClass
         $c = ($input->{'c'} !== null ? $input->{'c'} : null);
         $d = ($input->{'d'} !== null
             ? match (true) {
-                is_array($input->{'d'}) || is_string($input->{'d'}) => $input->{'d'},
-                default => null,
+                is_array($input->{'d'}) || is_string($input->{'d'}) => ($input->{'d'}),
+                default => $input->{'d'},
             }
             : null
         );
         $e = isset($input->{'e'}) ? $input->{'e'} : null;
         $f = isset($input->{'f'})
             ? match (true) {
-                is_array($input->{'f'}) || is_string($input->{'f'}) => $input->{'f'},
-                default => null,
+                is_array($input->{'f'}) || is_string($input->{'f'}) => ($input->{'f'}),
+                default => $input->{'f'},
             }
             : null;
         $g = null;
@@ -395,8 +395,8 @@ class MyClass
         if (property_exists($input, 'h')) {
             $h = ($input->{'h'} !== null
                 ? match (true) {
-                    is_array($input->{'h'}) || is_string($input->{'h'}) => $input->{'h'},
-                    default => null,
+                    is_array($input->{'h'}) || is_string($input->{'h'}) => ($input->{'h'}),
+                    default => $input->{'h'},
                 }
                 : null
             );
@@ -409,8 +409,8 @@ class MyClass
                     is_array($input->{'i'})
                         || is_string($input->{'i'})
                         || is_array($input->{'i'}) || is_object($input->{'i'}) =>
-                        $input->{'i'},
-                    default => null,
+                        ($input->{'i'}),
+                    default => $input->{'i'},
                 }
                 : null
             );
@@ -439,18 +439,18 @@ class MyClass
 
         $output['a'] = $this->a;
         $output['b'] = match (true) {
-            is_array($this->b) || is_string($this->b) => $this->b,
+            default => $this->b,
         };
         $output['c'] = $this->c;
         $output['d'] = match (true) {
-            is_array($this->d) || is_string($this->d) => $this->d,
+            default => $this->d,
         };
         if (isset($this->e)) {
             $output['e'] = $this->e;
         }
         if (isset($this->f)) {
             $output['f'] = match (true) {
-                is_array($this->f) || is_string($this->f) => $this->f,
+                default => $this->f,
             };
         }
         if (isset($this->g) || array_key_exists('g', $this->_providedOptionals)) {
@@ -459,8 +459,8 @@ class MyClass
         if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
             $output['h'] = ($this->h !== null
                 ? match (true) {
-                    is_array($this->h) || is_string($this->h) => $this->h,
-                    default => null,
+                    is_array($this->h) || is_string($this->h) => ($this->h),
+                    default => $this->h,
                 }
                 : null
             );
@@ -468,9 +468,9 @@ class MyClass
         if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
             $output['i'] = ($this->i !== null
                 ? match (true) {
-                    is_array($this->i) || is_string($this->i) => $this->i,
+                    is_array($this->i) || is_string($this->i) => ($this->i),
                     is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), true),
-                    default => null,
+                    default => $this->i,
                 }
                 : null
             );
@@ -490,18 +490,18 @@ class MyClass
 
         $output->{'a'} = $this->a;
         $output->{'b'} = match (true) {
-            is_array($this->b) || is_string($this->b) => $this->b,
+            default => $this->b,
         };
         $output->{'c'} = $this->c;
         $output->{'d'} = match (true) {
-            is_array($this->d) || is_string($this->d) => $this->d,
+            default => $this->d,
         };
         if (isset($this->e)) {
             $output->{'e'} = $this->e;
         }
         if (isset($this->f)) {
             $output->{'f'} = match (true) {
-                is_array($this->f) || is_string($this->f) => $this->f,
+                default => $this->f,
             };
         }
         if (isset($this->g) || array_key_exists('g', $this->_providedOptionals)) {
@@ -510,8 +510,8 @@ class MyClass
         if (isset($this->h) || array_key_exists('h', $this->_providedOptionals)) {
             $output->{'h'} = ($this->h !== null
                 ? match (true) {
-                    is_array($this->h) || is_string($this->h) => $this->h,
-                    default => null,
+                    is_array($this->h) || is_string($this->h) => ($this->h),
+                    default => $this->h,
                 }
                 : null
             );
@@ -519,9 +519,9 @@ class MyClass
         if (isset($this->i) || array_key_exists('i', $this->_providedOptionals)) {
             $output->{'i'} = ($this->i !== null
                 ? match (true) {
-                    is_array($this->i) || is_string($this->i) => $this->i,
+                    is_array($this->i) || is_string($this->i) => ($this->i),
                     is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i)),
-                    default => null,
+                    default => $this->i,
                 }
                 : null
             );
@@ -571,8 +571,9 @@ class MyClass
     {
         if (isset($this->i)) {
             $this->i = match (true) {
-                is_array($this->i) || is_string($this->i) => $this->i,
+                is_array($this->i) || is_string($this->i) => ($this->i),
                 is_array($this->i) || is_object($this->i) => json_decode(json_encode($this->i), is_array($this->i)),
+                default => $this->i,
             };
         }
     }

--- a/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/DefaultValue/Output-8.4/MyClass.php
@@ -437,13 +437,13 @@ class MyClass
         $grox = isset($input->{'grox'}) ? $input->{'grox'} : null;
         $qwert = isset($input->{'qwert'})
             ? match (true) {
-                is_string($input->{'qwert'}) => $input->{'qwert'},
+                is_string($input->{'qwert'}) => ($input->{'qwert'}),
                 (is_int($input->{'qwert'}) || is_float($input->{'qwert'})) =>
                     (str_contains((string)$input->{'qwert'}, '.')
                         ? (float)$input->{'qwert'}
                         : (int)$input->{'qwert'}
                     ),
-                default => null,
+                default => $input->{'qwert'},
             }
             : null;
         $zyx = isset($input->{'zyx'}) ? $input->{'zyx'} : null;
@@ -489,7 +489,7 @@ class MyClass
         }
         if (isset($this->qwert)) {
             $output['qwert'] = match (true) {
-                is_string($this->qwert) || (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
+                default => $this->qwert,
             };
         }
         if (isset($this->zyx)) {
@@ -537,7 +537,7 @@ class MyClass
         }
         if (isset($this->qwert)) {
             $output->{'qwert'} = match (true) {
-                is_string($this->qwert) || (is_int($this->qwert) || is_float($this->qwert)) => $this->qwert,
+                default => $this->qwert,
             };
         }
         if (isset($this->zyx)) {

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-5.6/BarTest.php
@@ -182,13 +182,13 @@ class BarTest
         }
 
         $exampleProp = isset($input->{'exampleProp'})
-            ? ((FooTest::validateInput($input->{'exampleProp'}, true))
+            ? ((((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && FooTest::validateInput($input->{'exampleProp'}, true)))
                 ? FooTest::fromInput($input->{'exampleProp'}, $validate)
-                : ((MoiKlass::validateInput($input->{'exampleProp'}, true))
+                : ((((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && MoiKlass::validateInput($input->{'exampleProp'}, true)))
                     ? MoiKlass::fromInput($input->{'exampleProp'}, $validate)
-                    : ((FooTest_1::validateInput($input->{'exampleProp'}, true))
+                    : ((((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && FooTest_1::validateInput($input->{'exampleProp'}, true)))
                         ? FooTest_1::fromInput($input->{'exampleProp'}, $validate)
-                        : null
+                        : $input->{'exampleProp'}
                     )
                 )
             )
@@ -219,6 +219,8 @@ class BarTest
                 || $this->exampleProp instanceof FooTest_1
             ) {
                 $output['exampleProp'] = $this->exampleProp->toArray();
+            } else {
+                $output['exampleProp'] = $this->exampleProp;
             }
         }
 
@@ -240,6 +242,8 @@ class BarTest
                 || $this->exampleProp instanceof FooTest_1
             ) {
                 $output->{'exampleProp'} = $this->exampleProp->toStdClass();
+            } else {
+                $output->{'exampleProp'} = $this->exampleProp;
             }
         }
 

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-7.4/BarTest.php
@@ -170,13 +170,13 @@ class BarTest
         }
 
         $exampleProp = isset($input->{'exampleProp'})
-            ? ((FooTest::validateInput($input->{'exampleProp'}, true))
+            ? ((((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && FooTest::validateInput($input->{'exampleProp'}, true)))
                 ? FooTest::fromInput($input->{'exampleProp'}, $validate)
-                : ((MoiKlass::validateInput($input->{'exampleProp'}, true))
+                : ((((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && MoiKlass::validateInput($input->{'exampleProp'}, true)))
                     ? MoiKlass::fromInput($input->{'exampleProp'}, $validate)
-                    : ((FooTest_1::validateInput($input->{'exampleProp'}, true))
+                    : ((((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && FooTest_1::validateInput($input->{'exampleProp'}, true)))
                         ? FooTest_1::fromInput($input->{'exampleProp'}, $validate)
-                        : null
+                        : $input->{'exampleProp'}
                     )
                 )
             )
@@ -207,6 +207,8 @@ class BarTest
                 || $this->exampleProp instanceof FooTest_1
             ) {
                 $output['exampleProp'] = $this->exampleProp->toArray();
+            } else {
+                $output['exampleProp'] = $this->exampleProp;
             }
         }
 
@@ -228,6 +230,8 @@ class BarTest
                 || $this->exampleProp instanceof FooTest_1
             ) {
                 $output->{'exampleProp'} = $this->exampleProp->toStdClass();
+            } else {
+                $output->{'exampleProp'} = $this->exampleProp;
             }
         }
 

--- a/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
+++ b/tests/Generator/Fixtures/EscapeDefinitionName/Output-8.4/BarTest.php
@@ -150,10 +150,13 @@ class BarTest
 
         $exampleProp = isset($input->{'exampleProp'})
             ? match (true) {
-                FooTest::validateInput($input->{'exampleProp'}, true) => FooTest::fromInput($input->{'exampleProp'}, $validate),
-                MoiKlass::validateInput($input->{'exampleProp'}, true) => MoiKlass::fromInput($input->{'exampleProp'}, $validate),
-                FooTest_1::validateInput($input->{'exampleProp'}, true) => FooTest_1::fromInput($input->{'exampleProp'}, $validate),
-                default => null,
+                ((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && FooTest::validateInput($input->{'exampleProp'}, true)) =>
+                    FooTest::fromInput($input->{'exampleProp'}, $validate),
+                ((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && MoiKlass::validateInput($input->{'exampleProp'}, true)) =>
+                    MoiKlass::fromInput($input->{'exampleProp'}, $validate),
+                ((is_object($input->{'exampleProp'}) || is_array($input->{'exampleProp'})) && FooTest_1::validateInput($input->{'exampleProp'}, true)) =>
+                    FooTest_1::fromInput($input->{'exampleProp'}, $validate),
+                default => $input->{'exampleProp'},
             }
             : null;
 
@@ -182,6 +185,7 @@ class BarTest
                     || $this->exampleProp instanceof MoiKlass
                     || $this->exampleProp instanceof FooTest_1 =>
                     $this->exampleProp->toArray(),
+                default => $this->exampleProp,
             };
         }
 
@@ -203,6 +207,7 @@ class BarTest
                     || $this->exampleProp instanceof MoiKlass
                     || $this->exampleProp instanceof FooTest_1 =>
                     $this->exampleProp->toStdClass(),
+                default => $this->exampleProp,
             };
         }
 

--- a/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-5.6/MyClass.php
@@ -2357,11 +2357,11 @@ class MyClass
             : null;
         $_providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
+            ? ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)))
                 ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
+                : ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : null)
+                    : $input->{'ensureArgs1'}
                 )
             )
             : null;
@@ -2506,7 +2506,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             ) {
                 $output['ensureArgs1'] = $this->ensureArgs1->toArray($includeDefaults);
-            } elseif (is_string($this->ensureArgs1)) {
+            } else {
                 $output['ensureArgs1'] = $this->ensureArgs1;
             }
         }
@@ -2600,7 +2600,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             ) {
                 $output->{'ensureArgs1'} = $this->ensureArgs1->toStdClass($includeDefaults);
-            } elseif (is_string($this->ensureArgs1)) {
+            } else {
                 $output->{'ensureArgs1'} = $this->ensureArgs1;
             }
         }

--- a/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-7.4/MyClass.php
@@ -1383,11 +1383,11 @@ class MyClass
             : null;
         $_providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
+            ? ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)))
                 ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
+                : ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : null)
+                    : $input->{'ensureArgs1'}
                 )
             )
             : null;
@@ -1533,7 +1533,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             ) {
                 $output['ensureArgs1'] = $this->ensureArgs1->toArray($includeDefaults);
-            } elseif (is_string($this->ensureArgs1)) {
+            } else {
                 $output['ensureArgs1'] = $this->ensureArgs1;
             }
         }
@@ -1625,7 +1625,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             ) {
                 $output->{'ensureArgs1'} = $this->ensureArgs1->toStdClass($includeDefaults);
-            } elseif (is_string($this->ensureArgs1)) {
+            } else {
                 $output->{'ensureArgs1'} = $this->ensureArgs1;
             }
         }

--- a/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNaming/Output-8.4/MyClass.php
@@ -1359,12 +1359,12 @@ class MyClass
         $_providedOptionals_1 = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
             ? match (true) {
-                MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true) =>
+                is_string($input->{'ensureArgs1'}) => ($input->{'ensureArgs1'}),
+                ((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)) =>
                     MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults),
-                MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true) =>
+                ((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)) =>
                     MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults),
-                is_string($input->{'ensureArgs1'}) => $input->{'ensureArgs1'},
-                default => null,
+                default => $input->{'ensureArgs1'},
             }
             : null;
         $ensureArgs2 = isset($input->{'ensureArgs2'})
@@ -1509,7 +1509,7 @@ class MyClass
                 $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
                     || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 =>
                     $this->ensureArgs1->toArray($includeDefaults),
-                is_string($this->ensureArgs1) => $this->ensureArgs1,
+                default => $this->ensureArgs1,
             };
         }
         if (isset($this->ensureArgs2)) {
@@ -1600,7 +1600,7 @@ class MyClass
                 $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
                     || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 =>
                     $this->ensureArgs1->toStdClass($includeDefaults),
-                is_string($this->ensureArgs1) => $this->ensureArgs1,
+                default => $this->ensureArgs1,
             };
         }
         if (isset($this->ensureArgs2)) {
@@ -1667,10 +1667,11 @@ class MyClass
         }
         if (isset($this->ensureArgs1)) {
             $this->ensureArgs1 = match (true) {
+                is_string($this->ensureArgs1) => ($this->ensureArgs1),
                 $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
                     || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 =>
                     clone $this->ensureArgs1,
-                is_string($this->ensureArgs1) => $this->ensureArgs1,
+                default => $this->ensureArgs1,
             };
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-5.6/MyClass.php
@@ -2357,11 +2357,11 @@ class MyClass
             : null;
         $__providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
+            ? ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)))
                 ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
+                : ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : null)
+                    : $input->{'ensureArgs1'}
                 )
             )
             : null;
@@ -2506,7 +2506,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             ) {
                 $output['ensureArgs1'] = $this->ensureArgs1->toArray($includeDefaults);
-            } elseif (is_string($this->ensureArgs1)) {
+            } else {
                 $output['ensureArgs1'] = $this->ensureArgs1;
             }
         }
@@ -2600,7 +2600,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             ) {
                 $output->{'ensureArgs1'} = $this->ensureArgs1->toStdClass($includeDefaults);
-            } elseif (is_string($this->ensureArgs1)) {
+            } else {
                 $output->{'ensureArgs1'} = $this->ensureArgs1;
             }
         }

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-7.4/MyClass.php
@@ -1383,11 +1383,11 @@ class MyClass
             : null;
         $__providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
-            ? ((MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true))
+            ? ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)))
                 ? MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                : ((MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true))
+                : ((((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)))
                     ? MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults)
-                    : ((is_string($input->{'ensureArgs1'})) ? $input->{'ensureArgs1'} : null)
+                    : $input->{'ensureArgs1'}
                 )
             )
             : null;
@@ -1533,7 +1533,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             ) {
                 $output['ensureArgs1'] = $this->ensureArgs1->toArray($includeDefaults);
-            } elseif (is_string($this->ensureArgs1)) {
+            } else {
                 $output['ensureArgs1'] = $this->ensureArgs1;
             }
         }
@@ -1625,7 +1625,7 @@ class MyClass
                 || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2
             ) {
                 $output->{'ensureArgs1'} = $this->ensureArgs1->toStdClass($includeDefaults);
-            } elseif (is_string($this->ensureArgs1)) {
+            } else {
                 $output->{'ensureArgs1'} = $this->ensureArgs1;
             }
         }

--- a/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/FallbackNamingPreserve/Output-8.4/MyClass.php
@@ -1359,12 +1359,12 @@ class MyClass
         $__providedOptionals = isset($input->{'__providedOptionals'}) ? $input->{'__providedOptionals'} : null;
         $ensureArgs1 = isset($input->{'ensureArgs1'})
             ? match (true) {
-                MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true) =>
+                is_string($input->{'ensureArgs1'}) => ($input->{'ensureArgs1'}),
+                ((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative1::validateInput($input->{'ensureArgs1'}, true)) =>
                     MyClassEnsureArgs1Alternative1::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults),
-                MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true) =>
+                ((is_object($input->{'ensureArgs1'}) || is_array($input->{'ensureArgs1'})) && MyClassEnsureArgs1Alternative2::validateInput($input->{'ensureArgs1'}, true)) =>
                     MyClassEnsureArgs1Alternative2::fromInput($input->{'ensureArgs1'}, $validate, $materializeDefaults),
-                is_string($input->{'ensureArgs1'}) => $input->{'ensureArgs1'},
-                default => null,
+                default => $input->{'ensureArgs1'},
             }
             : null;
         $ensureArgs2 = isset($input->{'ensureArgs2'})
@@ -1509,7 +1509,7 @@ class MyClass
                 $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
                     || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 =>
                     $this->ensureArgs1->toArray($includeDefaults),
-                is_string($this->ensureArgs1) => $this->ensureArgs1,
+                default => $this->ensureArgs1,
             };
         }
         if (isset($this->ensureArgs2)) {
@@ -1600,7 +1600,7 @@ class MyClass
                 $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
                     || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 =>
                     $this->ensureArgs1->toStdClass($includeDefaults),
-                is_string($this->ensureArgs1) => $this->ensureArgs1,
+                default => $this->ensureArgs1,
             };
         }
         if (isset($this->ensureArgs2)) {
@@ -1667,10 +1667,11 @@ class MyClass
         }
         if (isset($this->ensureArgs1)) {
             $this->ensureArgs1 = match (true) {
+                is_string($this->ensureArgs1) => ($this->ensureArgs1),
                 $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative1
                     || $this->ensureArgs1 instanceof MyClassEnsureArgs1Alternative2 =>
                     clone $this->ensureArgs1,
-                is_string($this->ensureArgs1) => $this->ensureArgs1,
+                default => $this->ensureArgs1,
             };
         }
         if (isset($this->ensureArgs2)) {

--- a/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/MaterializeDefaults/Output-8.4/MyClass.php
@@ -806,47 +806,50 @@ class MyClass
         }
         $xyyz = isset($input->{'xyyz'})
             ? match (true) {
-                is_string($input->{'xyyz'}) || is_array($input->{'xyyz'}) => $input->{'xyyz'},
-                ObjDef::validateInput($input->{'xyyz'}, true) => ObjDef::fromInput($input->{'xyyz'}, $validate, $materializeDefaults),
-                default => null,
+                is_string($input->{'xyyz'}) || is_array($input->{'xyyz'}) => ($input->{'xyyz'}),
+                ((is_object($input->{'xyyz'}) || is_array($input->{'xyyz'})) && ObjDef::validateInput($input->{'xyyz'}, true)) =>
+                    ObjDef::fromInput($input->{'xyyz'}, $validate, $materializeDefaults),
+                default => $input->{'xyyz'},
             }
             : null;
         $buux = isset($input->{'buux'})
             ? match (true) {
-                is_string($input->{'buux'}) || is_array($input->{'buux'}) => $input->{'buux'},
-                ObjDef::validateInput($input->{'buux'}, true) => ObjDef::fromInput($input->{'buux'}, $validate, $materializeDefaults),
-                default => null,
+                is_string($input->{'buux'}) || is_array($input->{'buux'}) => ($input->{'buux'}),
+                ((is_object($input->{'buux'}) || is_array($input->{'buux'})) && ObjDef::validateInput($input->{'buux'}, true)) =>
+                    ObjDef::fromInput($input->{'buux'}, $validate, $materializeDefaults),
+                default => $input->{'buux'},
             }
             : null;
         $boic = isset($input->{'boic'})
             ? match (true) {
-                is_string($input->{'boic'}) || is_array($input->{'boic'}) => $input->{'boic'},
-                ObjDef::validateInput($input->{'boic'}, true) => ObjDef::fromInput($input->{'boic'}, $validate, $materializeDefaults),
-                default => null,
+                is_string($input->{'boic'}) || is_array($input->{'boic'}) => ($input->{'boic'}),
+                ((is_object($input->{'boic'}) || is_array($input->{'boic'})) && ObjDef::validateInput($input->{'boic'}, true)) =>
+                    ObjDef::fromInput($input->{'boic'}, $validate, $materializeDefaults),
+                default => $input->{'boic'},
             }
             : null;
         $poox = isset($input->{'poox'})
             ? match (true) {
-                is_string($input->{'poox'}) => $input->{'poox'},
-                NumericKeysObj::validateInput($input->{'poox'}, true) =>
+                is_string($input->{'poox'}) => ($input->{'poox'}),
+                ((is_object($input->{'poox'}) || is_array($input->{'poox'})) && NumericKeysObj::validateInput($input->{'poox'}, true)) =>
                     NumericKeysObj::fromInput($input->{'poox'}, $validate, $materializeDefaults),
-                default => null,
+                default => $input->{'poox'},
             }
             : null;
         $arrObjUnion = isset($input->{'arrObjUnion'})
             ? match (true) {
                 is_array($input->{'arrObjUnion'})
                     || is_array($input->{'arrObjUnion'}) || is_object($input->{'arrObjUnion'}) =>
-                    $input->{'arrObjUnion'},
-                default => null,
+                    ($input->{'arrObjUnion'}),
+                default => $input->{'arrObjUnion'},
             }
             : null;
         $objArrUnion = isset($input->{'objArrUnion'})
             ? match (true) {
                 is_array($input->{'objArrUnion'})
                     || is_array($input->{'objArrUnion'}) || is_object($input->{'objArrUnion'}) =>
-                    $input->{'objArrUnion'},
-                default => null,
+                    ($input->{'objArrUnion'}),
+                default => $input->{'objArrUnion'},
             }
             : null;
         $numKeysDefaults = isset($input->{'numKeysDefaults'})
@@ -904,37 +907,37 @@ class MyClass
         }
         if (isset($this->xyyz)) {
             $output['xyyz'] = match (true) {
-                is_string($this->xyyz) || is_array($this->xyyz) => $this->xyyz,
+                default => $this->xyyz,
                 $this->xyyz instanceof ObjDef => $this->xyyz->toArray($includeDefaults),
             };
         }
         if (isset($this->buux)) {
             $output['buux'] = match (true) {
-                is_string($this->buux) || is_array($this->buux) => $this->buux,
+                default => $this->buux,
                 $this->buux instanceof ObjDef => $this->buux->toArray($includeDefaults),
             };
         }
         if (isset($this->boic)) {
             $output['boic'] = match (true) {
-                is_string($this->boic) || is_array($this->boic) => $this->boic,
+                default => $this->boic,
                 $this->boic instanceof ObjDef => $this->boic->toArray($includeDefaults),
             };
         }
         if (isset($this->poox)) {
             $output['poox'] = match (true) {
-                is_string($this->poox) => $this->poox,
+                default => $this->poox,
                 $this->poox instanceof NumericKeysObj => $this->poox->toArray($includeDefaults),
             };
         }
         if (isset($this->arrObjUnion)) {
             $output['arrObjUnion'] = match (true) {
-                is_array($this->arrObjUnion) => $this->arrObjUnion,
+                default => $this->arrObjUnion,
                 is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion), true),
             };
         }
         if (isset($this->objArrUnion)) {
             $output['objArrUnion'] = match (true) {
-                is_array($this->objArrUnion) => $this->objArrUnion,
+                default => $this->objArrUnion,
                 is_array($this->objArrUnion) || is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion), true),
             };
         }
@@ -979,37 +982,37 @@ class MyClass
         }
         if (isset($this->xyyz)) {
             $output->{'xyyz'} = match (true) {
-                is_string($this->xyyz) || is_array($this->xyyz) => $this->xyyz,
+                default => $this->xyyz,
                 $this->xyyz instanceof ObjDef => $this->xyyz->toStdClass($includeDefaults),
             };
         }
         if (isset($this->buux)) {
             $output->{'buux'} = match (true) {
-                is_string($this->buux) || is_array($this->buux) => $this->buux,
+                default => $this->buux,
                 $this->buux instanceof ObjDef => $this->buux->toStdClass($includeDefaults),
             };
         }
         if (isset($this->boic)) {
             $output->{'boic'} = match (true) {
-                is_string($this->boic) || is_array($this->boic) => $this->boic,
+                default => $this->boic,
                 $this->boic instanceof ObjDef => $this->boic->toStdClass($includeDefaults),
             };
         }
         if (isset($this->poox)) {
             $output->{'poox'} = match (true) {
-                is_string($this->poox) => $this->poox,
+                default => $this->poox,
                 $this->poox instanceof NumericKeysObj => $this->poox->toStdClass($includeDefaults),
             };
         }
         if (isset($this->arrObjUnion)) {
             $output->{'arrObjUnion'} = match (true) {
-                is_array($this->arrObjUnion) => $this->arrObjUnion,
+                default => $this->arrObjUnion,
                 is_array($this->arrObjUnion) || is_object($this->arrObjUnion) => json_decode(json_encode($this->arrObjUnion)),
             };
         }
         if (isset($this->objArrUnion)) {
             $output->{'objArrUnion'} = match (true) {
-                is_array($this->objArrUnion) => $this->objArrUnion,
+                default => $this->objArrUnion,
                 is_array($this->objArrUnion) || is_object($this->objArrUnion) => json_decode(json_encode($this->objArrUnion)),
             };
         }
@@ -1084,40 +1087,46 @@ class MyClass
         }
         if (isset($this->xyyz)) {
             $this->xyyz = match (true) {
-                is_string($this->xyyz) || is_array($this->xyyz) => $this->xyyz,
+                is_string($this->xyyz) || is_array($this->xyyz) => ($this->xyyz),
                 $this->xyyz instanceof ObjDef => clone $this->xyyz,
+                default => $this->xyyz,
             };
         }
         if (isset($this->buux)) {
             $this->buux = match (true) {
-                is_string($this->buux) || is_array($this->buux) => $this->buux,
+                is_string($this->buux) || is_array($this->buux) => ($this->buux),
                 $this->buux instanceof ObjDef => clone $this->buux,
+                default => $this->buux,
             };
         }
         if (isset($this->boic)) {
             $this->boic = match (true) {
-                is_string($this->boic) || is_array($this->boic) => $this->boic,
+                is_string($this->boic) || is_array($this->boic) => ($this->boic),
                 $this->boic instanceof ObjDef => clone $this->boic,
+                default => $this->boic,
             };
         }
         if (isset($this->poox)) {
             $this->poox = match (true) {
-                is_string($this->poox) => $this->poox,
+                is_string($this->poox) => ($this->poox),
                 $this->poox instanceof NumericKeysObj => clone $this->poox,
+                default => $this->poox,
             };
         }
         if (isset($this->arrObjUnion)) {
             $this->arrObjUnion = match (true) {
-                is_array($this->arrObjUnion) => $this->arrObjUnion,
+                is_array($this->arrObjUnion) => ($this->arrObjUnion),
                 is_array($this->arrObjUnion) || is_object($this->arrObjUnion) =>
                     json_decode(json_encode($this->arrObjUnion), is_array($this->arrObjUnion)),
+                default => $this->arrObjUnion,
             };
         }
         if (isset($this->objArrUnion)) {
             $this->objArrUnion = match (true) {
-                is_array($this->objArrUnion) => $this->objArrUnion,
+                is_array($this->objArrUnion) => ($this->objArrUnion),
                 is_array($this->objArrUnion) || is_object($this->objArrUnion) =>
                     json_decode(json_encode($this->objArrUnion), is_array($this->objArrUnion)),
+                default => $this->objArrUnion,
             };
         }
         if (isset($this->numKeysDefaults)) {

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Baz.php
@@ -182,11 +182,11 @@ class Baz
         }
 
         $grox = isset($input->{'grox'})
-            ? ((Foo::validateInput($input->{'grox'}, true))
+            ? ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Foo::validateInput($input->{'grox'}, true)))
                 ? Foo::fromInput($input->{'grox'}, $validate)
-                : ((Bar::validateInput($input->{'grox'}, true))
+                : ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Bar::validateInput($input->{'grox'}, true)))
                     ? Bar::fromInput($input->{'grox'}, $validate)
-                    : null
+                    : $input->{'grox'}
                 )
             )
             : null;
@@ -213,6 +213,8 @@ class Baz
         if (isset($this->grox)) {
             if ($this->grox instanceof Foo || $this->grox instanceof Bar) {
                 $output['grox'] = $this->grox->toArray();
+            } else {
+                $output['grox'] = $this->grox;
             }
         }
 
@@ -231,6 +233,8 @@ class Baz
         if (isset($this->grox)) {
             if ($this->grox instanceof Foo || $this->grox instanceof Bar) {
                 $output->{'grox'} = $this->grox->toStdClass();
+            } else {
+                $output->{'grox'} = $this->grox;
             }
         }
 

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-5.6/Qux.php
@@ -195,18 +195,15 @@ class Qux
         }
 
         $grox = isset($input->{'grox'})
-            ? ((is_string($input->{'grox'}) || is_array($input->{'grox'}))
-                ? $input->{'grox'}
-                : (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
-                    ? ((Foo::validateInput($input->{'grox'}, true))
-                        ? Foo::fromInput($input->{'grox'}, $validate)
-                        : ((Bar::validateInput($input->{'grox'}, true))
-                            ? Bar::fromInput($input->{'grox'}, $validate)
-                            : null
-                        )
+            ? (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
+                ? ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Foo::validateInput($input->{'grox'}, true)))
+                    ? Foo::fromInput($input->{'grox'}, $validate)
+                    : ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Bar::validateInput($input->{'grox'}, true)))
+                        ? Bar::fromInput($input->{'grox'}, $validate)
+                        : $input->{'grox'}
                     )
-                    : null
                 )
+                : $input->{'grox'}
             )
             : null;
 
@@ -230,13 +227,13 @@ class Qux
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->grox)) {
-            if (is_string($this->grox) || is_array($this->grox)) {
-                $output['grox'] = $this->grox;
-            } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
+            if (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
                 $output['grox'] = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toArray()
-                    : null
+                    : $this->grox
                 );
+            } else {
+                $output['grox'] = $this->grox;
             }
         }
 
@@ -253,13 +250,13 @@ class Qux
         $output = $this->_additionalProperties;
 
         if (isset($this->grox)) {
-            if (is_string($this->grox) || is_array($this->grox)) {
-                $output->{'grox'} = $this->grox;
-            } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
+            if (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
                 $output->{'grox'} = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toStdClass()
-                    : null
+                    : $this->grox
                 );
+            } else {
+                $output->{'grox'} = $this->grox;
             }
         }
 

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Baz.php
@@ -170,11 +170,11 @@ class Baz
         }
 
         $grox = isset($input->{'grox'})
-            ? ((Foo::validateInput($input->{'grox'}, true))
+            ? ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Foo::validateInput($input->{'grox'}, true)))
                 ? Foo::fromInput($input->{'grox'}, $validate)
-                : ((Bar::validateInput($input->{'grox'}, true))
+                : ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Bar::validateInput($input->{'grox'}, true)))
                     ? Bar::fromInput($input->{'grox'}, $validate)
-                    : null
+                    : $input->{'grox'}
                 )
             )
             : null;
@@ -201,6 +201,8 @@ class Baz
         if (isset($this->grox)) {
             if ($this->grox instanceof Foo || $this->grox instanceof Bar) {
                 $output['grox'] = $this->grox->toArray();
+            } else {
+                $output['grox'] = $this->grox;
             }
         }
 
@@ -219,6 +221,8 @@ class Baz
         if (isset($this->grox)) {
             if ($this->grox instanceof Foo || $this->grox instanceof Bar) {
                 $output->{'grox'} = $this->grox->toStdClass();
+            } else {
+                $output->{'grox'} = $this->grox;
             }
         }
 

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-7.4/Qux.php
@@ -183,18 +183,15 @@ class Qux
         }
 
         $grox = isset($input->{'grox'})
-            ? ((is_string($input->{'grox'}) || is_array($input->{'grox'}))
-                ? $input->{'grox'}
-                : (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
-                    ? ((Foo::validateInput($input->{'grox'}, true))
-                        ? Foo::fromInput($input->{'grox'}, $validate)
-                        : ((Bar::validateInput($input->{'grox'}, true))
-                            ? Bar::fromInput($input->{'grox'}, $validate)
-                            : null
-                        )
+            ? (((Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)))
+                ? ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Foo::validateInput($input->{'grox'}, true)))
+                    ? Foo::fromInput($input->{'grox'}, $validate)
+                    : ((((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Bar::validateInput($input->{'grox'}, true)))
+                        ? Bar::fromInput($input->{'grox'}, $validate)
+                        : $input->{'grox'}
                     )
-                    : null
                 )
+                : $input->{'grox'}
             )
             : null;
 
@@ -218,13 +215,13 @@ class Qux
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->grox)) {
-            if (is_string($this->grox) || is_array($this->grox)) {
-                $output['grox'] = $this->grox;
-            } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
+            if (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
                 $output['grox'] = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toArray()
-                    : null
+                    : $this->grox
                 );
+            } else {
+                $output['grox'] = $this->grox;
             }
         }
 
@@ -241,13 +238,13 @@ class Qux
         $output = $this->_additionalProperties;
 
         if (isset($this->grox)) {
-            if (is_string($this->grox) || is_array($this->grox)) {
-                $output->{'grox'} = $this->grox;
-            } elseif (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
+            if (($this->grox instanceof Foo || $this->grox instanceof Bar)) {
                 $output->{'grox'} = (($this->grox instanceof Foo || $this->grox instanceof Bar)
                     ? $this->grox->toStdClass()
-                    : null
+                    : $this->grox
                 );
+            } else {
+                $output->{'grox'} = $this->grox;
             }
         }
 

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Baz.php
@@ -150,9 +150,11 @@ class Baz
 
         $grox = isset($input->{'grox'})
             ? match (true) {
-                Foo::validateInput($input->{'grox'}, true) => Foo::fromInput($input->{'grox'}, $validate),
-                Bar::validateInput($input->{'grox'}, true) => Bar::fromInput($input->{'grox'}, $validate),
-                default => null,
+                ((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Foo::validateInput($input->{'grox'}, true)) =>
+                    Foo::fromInput($input->{'grox'}, $validate),
+                ((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Bar::validateInput($input->{'grox'}, true)) =>
+                    Bar::fromInput($input->{'grox'}, $validate),
+                default => $input->{'grox'},
             }
             : null;
 
@@ -178,6 +180,7 @@ class Baz
         if (isset($this->grox)) {
             $output['grox'] = match (true) {
                 $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toArray(),
+                default => $this->grox,
             };
         }
 
@@ -196,6 +199,7 @@ class Baz
         if (isset($this->grox)) {
             $output->{'grox'} = match (true) {
                 $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toStdClass(),
+                default => $this->grox,
             };
         }
 

--- a/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
+++ b/tests/Generator/Fixtures/NonObjectDefs/Output-8.4/Qux.php
@@ -177,14 +177,16 @@ class Qux
 
         $grox = isset($input->{'grox'})
             ? match (true) {
-                is_string($input->{'grox'}) || is_array($input->{'grox'}) => $input->{'grox'},
+                is_string($input->{'grox'}) || is_array($input->{'grox'}) => ($input->{'grox'}),
                 (Foo::validateInput($input->{'grox'}, true) || Bar::validateInput($input->{'grox'}, true)) =>
                     match (true) {
-                        Foo::validateInput($input->{'grox'}, true) => Foo::fromInput($input->{'grox'}, $validate),
-                        Bar::validateInput($input->{'grox'}, true) => Bar::fromInput($input->{'grox'}, $validate),
-                        default => null,
+                        ((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Foo::validateInput($input->{'grox'}, true)) =>
+                            Foo::fromInput($input->{'grox'}, $validate),
+                        ((is_object($input->{'grox'}) || is_array($input->{'grox'})) && Bar::validateInput($input->{'grox'}, true)) =>
+                            Bar::fromInput($input->{'grox'}, $validate),
+                        default => $input->{'grox'},
                     },
-                default => null,
+                default => $input->{'grox'},
             }
             : null;
 
@@ -209,12 +211,8 @@ class Qux
 
         if (isset($this->grox)) {
             $output['grox'] = match (true) {
-                is_string($this->grox) || is_array($this->grox) => $this->grox,
-                ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
-                    match (true) {
-                        $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toArray(),
-                        default => null,
-                    },
+                default => $this->grox,
+                ($this->grox instanceof Foo || $this->grox instanceof Bar) => $this->grox->toArray(),
             };
         }
 
@@ -232,11 +230,11 @@ class Qux
 
         if (isset($this->grox)) {
             $output->{'grox'} = match (true) {
-                is_string($this->grox) || is_array($this->grox) => $this->grox,
+                default => $this->grox,
                 ($this->grox instanceof Foo || $this->grox instanceof Bar) =>
                     match (true) {
                         $this->grox instanceof Foo || $this->grox instanceof Bar => $this->grox->toStdClass(),
-                        default => null,
+                        default => $this->grox,
                     },
             };
         }
@@ -285,8 +283,9 @@ class Qux
     {
         if (isset($this->grox)) {
             $this->grox = match (true) {
-                is_string($this->grox) || is_array($this->grox) => $this->grox,
+                is_string($this->grox) || is_array($this->grox) => ($this->grox),
                 ($this->grox instanceof Foo || $this->grox instanceof Bar) => clone $this->grox,
+                default => $this->grox,
             };
         }
     }

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-5.6/MyClass.php
@@ -200,12 +200,7 @@ class MyClass
         }
 
         $foo = $input->{'foo'};
-        $bar = isset($input->{'bar'})
-            ? ((is_string($input->{'bar'}) || is_array($input->{'bar'}) || is_object($input->{'bar'}))
-                ? $input->{'bar'}
-                : null
-            )
-            : null;
+        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
 
         $obj = new self($foo, $bar);
 
@@ -226,16 +221,16 @@ class MyClass
     {
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
-        if (is_string($this->foo)) {
-            $output['foo'] = $this->foo;
-        } elseif (is_array($this->foo) || is_object($this->foo)) {
+        if (is_array($this->foo) || is_object($this->foo)) {
             $output['foo'] = json_decode(json_encode($this->foo), true);
+        } else {
+            $output['foo'] = $this->foo;
         }
         if (isset($this->bar)) {
-            if (is_string($this->bar)) {
-                $output['bar'] = $this->bar;
-            } elseif (is_array($this->bar) || is_object($this->bar)) {
+            if (is_array($this->bar) || is_object($this->bar)) {
                 $output['bar'] = json_decode(json_encode($this->bar), true);
+            } else {
+                $output['bar'] = $this->bar;
             }
         }
 
@@ -251,16 +246,16 @@ class MyClass
     {
         $output = $this->_additionalProperties;
 
-        if (is_string($this->foo)) {
-            $output->{'foo'} = $this->foo;
-        } elseif (is_array($this->foo) || is_object($this->foo)) {
+        if (is_array($this->foo) || is_object($this->foo)) {
             $output->{'foo'} = json_decode(json_encode($this->foo));
+        } else {
+            $output->{'foo'} = $this->foo;
         }
         if (isset($this->bar)) {
-            if (is_string($this->bar)) {
-                $output->{'bar'} = $this->bar;
-            } elseif (is_array($this->bar) || is_object($this->bar)) {
+            if (is_array($this->bar) || is_object($this->bar)) {
                 $output->{'bar'} = json_decode(json_encode($this->bar));
+            } else {
+                $output->{'bar'} = $this->bar;
             }
         }
 

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-7.4/MyClass.php
@@ -186,12 +186,7 @@ class MyClass
         }
 
         $foo = $input->{'foo'};
-        $bar = isset($input->{'bar'})
-            ? ((is_string($input->{'bar'}) || is_array($input->{'bar'}) || is_object($input->{'bar'}))
-                ? $input->{'bar'}
-                : null
-            )
-            : null;
+        $bar = isset($input->{'bar'}) ? $input->{'bar'} : null;
 
         $obj = new self($foo, $bar);
 
@@ -212,16 +207,16 @@ class MyClass
     {
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
-        if (is_string($this->foo)) {
-            $output['foo'] = $this->foo;
-        } elseif (is_array($this->foo) || is_object($this->foo)) {
+        if (is_array($this->foo) || is_object($this->foo)) {
             $output['foo'] = json_decode(json_encode($this->foo), true);
+        } else {
+            $output['foo'] = $this->foo;
         }
         if (isset($this->bar)) {
-            if (is_string($this->bar)) {
-                $output['bar'] = $this->bar;
-            } elseif (is_array($this->bar) || is_object($this->bar)) {
+            if (is_array($this->bar) || is_object($this->bar)) {
                 $output['bar'] = json_decode(json_encode($this->bar), true);
+            } else {
+                $output['bar'] = $this->bar;
             }
         }
 
@@ -237,16 +232,16 @@ class MyClass
     {
         $output = $this->_additionalProperties;
 
-        if (is_string($this->foo)) {
-            $output->{'foo'} = $this->foo;
-        } elseif (is_array($this->foo) || is_object($this->foo)) {
+        if (is_array($this->foo) || is_object($this->foo)) {
             $output->{'foo'} = json_decode(json_encode($this->foo));
+        } else {
+            $output->{'foo'} = $this->foo;
         }
         if (isset($this->bar)) {
-            if (is_string($this->bar)) {
-                $output->{'bar'} = $this->bar;
-            } elseif (is_array($this->bar) || is_object($this->bar)) {
+            if (is_array($this->bar) || is_object($this->bar)) {
                 $output->{'bar'} = json_decode(json_encode($this->bar));
+            } else {
+                $output->{'bar'} = $this->bar;
             }
         }
 

--- a/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/ObjectWithoutPropsUnion/Output-8.4/MyClass.php
@@ -146,8 +146,8 @@ class MyClass
         };
         $bar = isset($input->{'bar'})
             ? match (true) {
-                is_string($input->{'bar'}) || is_array($input->{'bar'}) || is_object($input->{'bar'}) => $input->{'bar'},
-                default => null,
+                is_string($input->{'bar'}) || is_array($input->{'bar'}) || is_object($input->{'bar'}) => ($input->{'bar'}),
+                default => $input->{'bar'},
             }
             : null;
 
@@ -171,12 +171,12 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         $output['foo'] = match (true) {
-            is_string($this->foo) => $this->foo,
+            default => $this->foo,
             is_array($this->foo) || is_object($this->foo) => json_decode(json_encode($this->foo), true),
         };
         if (isset($this->bar)) {
             $output['bar'] = match (true) {
-                is_string($this->bar) => $this->bar,
+                default => $this->bar,
                 is_array($this->bar) || is_object($this->bar) => json_decode(json_encode($this->bar), true),
             };
         }
@@ -194,12 +194,12 @@ class MyClass
         $output = $this->_additionalProperties;
 
         $output->{'foo'} = match (true) {
-            is_string($this->foo) => $this->foo,
+            default => $this->foo,
             is_array($this->foo) || is_object($this->foo) => json_decode(json_encode($this->foo)),
         };
         if (isset($this->bar)) {
             $output->{'bar'} = match (true) {
-                is_string($this->bar) => $this->bar,
+                default => $this->bar,
                 is_array($this->bar) || is_object($this->bar) => json_decode(json_encode($this->bar)),
             };
         }
@@ -247,13 +247,15 @@ class MyClass
     public function __clone()
     {
         $this->foo = match (true) {
-            is_string($this->foo) => $this->foo,
+            is_string($this->foo) => ($this->foo),
             is_array($this->foo) || is_object($this->foo) => json_decode(json_encode($this->foo), is_array($this->foo)),
+            default => $this->foo,
         };
         if (isset($this->bar)) {
             $this->bar = match (true) {
-                is_string($this->bar) => $this->bar,
+                is_string($this->bar) => ($this->bar),
                 is_array($this->bar) || is_object($this->bar) => json_decode(json_encode($this->bar), is_array($this->bar)),
+                default => $this->bar,
             };
         }
     }

--- a/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionOfPrimitives/Output-8.4/MyClass.php
@@ -435,51 +435,51 @@ class MyClass
                 is_string($input->{'thud'})
                     || is_array($input->{'thud'})
                     || is_array($input->{'thud'}) || is_object($input->{'thud'}) =>
-                    $input->{'thud'},
+                    ($input->{'thud'}),
                 (is_int($input->{'thud'}) || is_float($input->{'thud'})) =>
                     (str_contains((string)$input->{'thud'}, '.')
                         ? (float)$input->{'thud'}
                         : (int)$input->{'thud'}
                     ),
                 is_bool($input->{'thud'}) => (bool)$input->{'thud'},
-                default => null,
+                default => $input->{'thud'},
             }
             : null
         );
         $optFoo = isset($input->{'optFoo'})
             ? match (true) {
-                is_string($input->{'optFoo'}) => $input->{'optFoo'},
+                is_string($input->{'optFoo'}) => ($input->{'optFoo'}),
                 (is_int($input->{'optFoo'}) || is_float($input->{'optFoo'})) =>
                     (str_contains((string)$input->{'optFoo'}, '.')
                         ? (float)$input->{'optFoo'}
                         : (int)$input->{'optFoo'}
                     ),
                 is_bool($input->{'optFoo'}) => (bool)$input->{'optFoo'},
-                default => null,
+                default => $input->{'optFoo'},
             }
             : null;
         $optBar = isset($input->{'optBar'})
             ? match (true) {
-                is_string($input->{'optBar'}) || is_array($input->{'optBar'}) => $input->{'optBar'},
+                is_string($input->{'optBar'}) || is_array($input->{'optBar'}) => ($input->{'optBar'}),
                 (is_int($input->{'optBar'}) || is_float($input->{'optBar'})) =>
                     (str_contains((string)$input->{'optBar'}, '.')
                         ? (float)$input->{'optBar'}
                         : (int)$input->{'optBar'}
                     ),
                 is_bool($input->{'optBar'}) => (bool)$input->{'optBar'},
-                default => null,
+                default => $input->{'optBar'},
             }
             : null;
         $optBaz = isset($input->{'optBaz'})
             ? match (true) {
-                is_string($input->{'optBaz'}) || is_array($input->{'optBaz'}) || is_object($input->{'optBaz'}) => $input->{'optBaz'},
+                is_string($input->{'optBaz'}) || is_array($input->{'optBaz'}) || is_object($input->{'optBaz'}) => ($input->{'optBaz'}),
                 (is_int($input->{'optBaz'}) || is_float($input->{'optBaz'})) =>
                     (str_contains((string)$input->{'optBaz'}, '.')
                         ? (float)$input->{'optBaz'}
                         : (int)$input->{'optBaz'}
                     ),
                 is_bool($input->{'optBaz'}) => (bool)$input->{'optBaz'},
-                default => null,
+                default => $input->{'optBaz'},
             }
             : null;
         $optQux = isset($input->{'optQux'})
@@ -487,14 +487,14 @@ class MyClass
                 is_string($input->{'optQux'})
                     || is_array($input->{'optQux'})
                     || is_array($input->{'optQux'}) || is_object($input->{'optQux'}) =>
-                    $input->{'optQux'},
+                    ($input->{'optQux'}),
                 (is_int($input->{'optQux'}) || is_float($input->{'optQux'})) =>
                     (str_contains((string)$input->{'optQux'}, '.')
                         ? (float)$input->{'optQux'}
                         : (int)$input->{'optQux'}
                     ),
                 is_bool($input->{'optQux'}) => (bool)$input->{'optQux'},
-                default => null,
+                default => $input->{'optQux'},
             }
             : null;
         $optThud = null;
@@ -504,14 +504,14 @@ class MyClass
                     is_string($input->{'optThud'})
                         || is_array($input->{'optThud'})
                         || is_array($input->{'optThud'}) || is_object($input->{'optThud'}) =>
-                        $input->{'optThud'},
+                        ($input->{'optThud'}),
                     (is_int($input->{'optThud'}) || is_float($input->{'optThud'})) =>
                         (str_contains((string)$input->{'optThud'}, '.')
                             ? (float)$input->{'optThud'}
                             : (int)$input->{'optThud'}
                         ),
                     is_bool($input->{'optThud'}) => (bool)$input->{'optThud'},
-                    default => null,
+                    default => $input->{'optThud'},
                 }
                 : null
             );
@@ -550,68 +550,42 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         $output['foo'] = match (true) {
-            is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) || is_bool($this->foo) => $this->foo,
+            default => $this->foo,
         };
         $output['bar'] = match (true) {
-            is_string($this->bar)
-                || (is_int($this->bar) || is_float($this->bar))
-                || is_bool($this->bar)
-                || is_array($this->bar) =>
-                $this->bar,
+            default => $this->bar,
         };
         $output['baz'] = match (true) {
-            is_string($this->baz) || (is_int($this->baz) || is_float($this->baz)) || is_bool($this->baz) => $this->baz,
+            default => $this->baz,
             is_array($this->baz) || is_object($this->baz) => json_decode(json_encode($this->baz), true),
         };
         $output['qux'] = match (true) {
-            is_string($this->qux)
-                || (is_int($this->qux) || is_float($this->qux))
-                || is_bool($this->qux)
-                || is_array($this->qux) =>
-                $this->qux,
+            default => $this->qux,
             is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux), true),
         };
         $output['thud'] = match (true) {
-            is_string($this->thud)
-                || (is_int($this->thud) || is_float($this->thud))
-                || is_bool($this->thud)
-                || is_array($this->thud) =>
-                $this->thud,
+            default => $this->thud,
             is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud), true),
         };
         if (isset($this->optFoo)) {
             $output['optFoo'] = match (true) {
-                is_string($this->optFoo)
-                    || (is_int($this->optFoo) || is_float($this->optFoo))
-                    || is_bool($this->optFoo) =>
-                    $this->optFoo,
+                default => $this->optFoo,
             };
         }
         if (isset($this->optBar)) {
             $output['optBar'] = match (true) {
-                is_string($this->optBar)
-                    || (is_int($this->optBar) || is_float($this->optBar))
-                    || is_bool($this->optBar)
-                    || is_array($this->optBar) =>
-                    $this->optBar,
+                default => $this->optBar,
             };
         }
         if (isset($this->optBaz)) {
             $output['optBaz'] = match (true) {
-                is_string($this->optBaz)
-                    || (is_int($this->optBaz) || is_float($this->optBaz))
-                    || is_bool($this->optBaz) =>
-                    $this->optBaz,
+                default => $this->optBaz,
                 is_array($this->optBaz) || is_object($this->optBaz) => json_decode(json_encode($this->optBaz), true),
             };
         }
         if (isset($this->optQux)) {
             $output['optQux'] = match (true) {
-                is_string($this->optQux)
-                    || (is_int($this->optQux) || is_float($this->optQux))
-                    || is_bool($this->optQux)
-                    || is_array($this->optQux) =>
-                    $this->optQux,
+                default => $this->optQux,
                 is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux), true),
             };
         }
@@ -622,9 +596,9 @@ class MyClass
                         || (is_int($this->optThud) || is_float($this->optThud))
                         || is_bool($this->optThud)
                         || is_array($this->optThud) =>
-                        $this->optThud,
+                        ($this->optThud),
                     is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud), true),
-                    default => null,
+                    default => $this->optThud,
                 }
                 : null
             );
@@ -643,68 +617,42 @@ class MyClass
         $output = $this->_additionalProperties;
 
         $output->{'foo'} = match (true) {
-            is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) || is_bool($this->foo) => $this->foo,
+            default => $this->foo,
         };
         $output->{'bar'} = match (true) {
-            is_string($this->bar)
-                || (is_int($this->bar) || is_float($this->bar))
-                || is_bool($this->bar)
-                || is_array($this->bar) =>
-                $this->bar,
+            default => $this->bar,
         };
         $output->{'baz'} = match (true) {
-            is_string($this->baz) || (is_int($this->baz) || is_float($this->baz)) || is_bool($this->baz) => $this->baz,
+            default => $this->baz,
             is_array($this->baz) || is_object($this->baz) => json_decode(json_encode($this->baz)),
         };
         $output->{'qux'} = match (true) {
-            is_string($this->qux)
-                || (is_int($this->qux) || is_float($this->qux))
-                || is_bool($this->qux)
-                || is_array($this->qux) =>
-                $this->qux,
+            default => $this->qux,
             is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux)),
         };
         $output->{'thud'} = match (true) {
-            is_string($this->thud)
-                || (is_int($this->thud) || is_float($this->thud))
-                || is_bool($this->thud)
-                || is_array($this->thud) =>
-                $this->thud,
+            default => $this->thud,
             is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud)),
         };
         if (isset($this->optFoo)) {
             $output->{'optFoo'} = match (true) {
-                is_string($this->optFoo)
-                    || (is_int($this->optFoo) || is_float($this->optFoo))
-                    || is_bool($this->optFoo) =>
-                    $this->optFoo,
+                default => $this->optFoo,
             };
         }
         if (isset($this->optBar)) {
             $output->{'optBar'} = match (true) {
-                is_string($this->optBar)
-                    || (is_int($this->optBar) || is_float($this->optBar))
-                    || is_bool($this->optBar)
-                    || is_array($this->optBar) =>
-                    $this->optBar,
+                default => $this->optBar,
             };
         }
         if (isset($this->optBaz)) {
             $output->{'optBaz'} = match (true) {
-                is_string($this->optBaz)
-                    || (is_int($this->optBaz) || is_float($this->optBaz))
-                    || is_bool($this->optBaz) =>
-                    $this->optBaz,
+                default => $this->optBaz,
                 is_array($this->optBaz) || is_object($this->optBaz) => json_decode(json_encode($this->optBaz)),
             };
         }
         if (isset($this->optQux)) {
             $output->{'optQux'} = match (true) {
-                is_string($this->optQux)
-                    || (is_int($this->optQux) || is_float($this->optQux))
-                    || is_bool($this->optQux)
-                    || is_array($this->optQux) =>
-                    $this->optQux,
+                default => $this->optQux,
                 is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux)),
             };
         }
@@ -715,9 +663,9 @@ class MyClass
                         || (is_int($this->optThud) || is_float($this->optThud))
                         || is_bool($this->optThud)
                         || is_array($this->optThud) =>
-                        $this->optThud,
+                        ($this->optThud),
                     is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud)),
-                    default => null,
+                    default => $this->optThud,
                 }
                 : null
             );
@@ -766,32 +714,36 @@ class MyClass
     public function __clone()
     {
         $this->baz = match (true) {
-            is_string($this->baz) || (is_int($this->baz) || is_float($this->baz)) || is_bool($this->baz) => $this->baz,
+            is_string($this->baz) || (is_int($this->baz) || is_float($this->baz)) || is_bool($this->baz) => ($this->baz),
             is_array($this->baz) || is_object($this->baz) => json_decode(json_encode($this->baz), is_array($this->baz)),
+            default => $this->baz,
         };
         $this->qux = match (true) {
             is_string($this->qux)
                 || (is_int($this->qux) || is_float($this->qux))
                 || is_bool($this->qux)
                 || is_array($this->qux) =>
-                $this->qux,
+                ($this->qux),
             is_array($this->qux) || is_object($this->qux) => json_decode(json_encode($this->qux), is_array($this->qux)),
+            default => $this->qux,
         };
         $this->thud = match (true) {
             is_string($this->thud)
                 || (is_int($this->thud) || is_float($this->thud))
                 || is_bool($this->thud)
                 || is_array($this->thud) =>
-                $this->thud,
+                ($this->thud),
             is_array($this->thud) || is_object($this->thud) => json_decode(json_encode($this->thud), is_array($this->thud)),
+            default => $this->thud,
         };
         if (isset($this->optBaz)) {
             $this->optBaz = match (true) {
                 is_string($this->optBaz)
                     || (is_int($this->optBaz) || is_float($this->optBaz))
                     || is_bool($this->optBaz) =>
-                    $this->optBaz,
+                    ($this->optBaz),
                 is_array($this->optBaz) || is_object($this->optBaz) => json_decode(json_encode($this->optBaz), is_array($this->optBaz)),
+                default => $this->optBaz,
             };
         }
         if (isset($this->optQux)) {
@@ -800,8 +752,9 @@ class MyClass
                     || (is_int($this->optQux) || is_float($this->optQux))
                     || is_bool($this->optQux)
                     || is_array($this->optQux) =>
-                    $this->optQux,
+                    ($this->optQux),
                 is_array($this->optQux) || is_object($this->optQux) => json_decode(json_encode($this->optQux), is_array($this->optQux)),
+                default => $this->optQux,
             };
         }
         if (isset($this->optThud)) {
@@ -810,8 +763,9 @@ class MyClass
                     || (is_int($this->optThud) || is_float($this->optThud))
                     || is_bool($this->optThud)
                     || is_array($this->optThud) =>
-                    $this->optThud,
+                    ($this->optThud),
                 is_array($this->optThud) || is_object($this->optThud) => json_decode(json_encode($this->optThud), is_array($this->optThud)),
+                default => $this->optThud,
             };
         }
     }

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-5.6/MyClass.php
@@ -153,7 +153,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        if (MyClassFooAlternative2::validateInput($input->{'foo'}, true)) {
+        if (((is_object($input->{'foo'}) || is_array($input->{'foo'})) && MyClassFooAlternative2::validateInput($input->{'foo'}, true))) {
             $foo = MyClassFooAlternative2::fromInput($input->{'foo'}, $validate);
         } else {
             $foo = $input->{'foo'};
@@ -178,10 +178,10 @@ class MyClass
     {
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
-        if (is_string($this->foo)) {
-            $output['foo'] = $this->foo;
-        } elseif ($this->foo instanceof MyClassFooAlternative2) {
+        if ($this->foo instanceof MyClassFooAlternative2) {
             $output['foo'] = $this->foo->toArray();
+        } else {
+            $output['foo'] = $this->foo;
         }
 
         return $output;
@@ -196,10 +196,10 @@ class MyClass
     {
         $output = $this->_additionalProperties;
 
-        if (is_string($this->foo)) {
-            $output->{'foo'} = $this->foo;
-        } elseif ($this->foo instanceof MyClassFooAlternative2) {
+        if ($this->foo instanceof MyClassFooAlternative2) {
             $output->{'foo'} = $this->foo->toStdClass();
+        } else {
+            $output->{'foo'} = $this->foo;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-7.4/MyClass.php
@@ -144,7 +144,7 @@ class MyClass
             static::validateInput($input);
         }
 
-        if (MyClassFooAlternative2::validateInput($input->{'foo'}, true)) {
+        if (((is_object($input->{'foo'}) || is_array($input->{'foo'})) && MyClassFooAlternative2::validateInput($input->{'foo'}, true))) {
             $foo = MyClassFooAlternative2::fromInput($input->{'foo'}, $validate);
         } else {
             $foo = $input->{'foo'};
@@ -169,10 +169,10 @@ class MyClass
     {
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
-        if (is_string($this->foo)) {
-            $output['foo'] = $this->foo;
-        } elseif ($this->foo instanceof MyClassFooAlternative2) {
+        if ($this->foo instanceof MyClassFooAlternative2) {
             $output['foo'] = $this->foo->toArray();
+        } else {
+            $output['foo'] = $this->foo;
         }
 
         return $output;
@@ -187,10 +187,10 @@ class MyClass
     {
         $output = $this->_additionalProperties;
 
-        if (is_string($this->foo)) {
-            $output->{'foo'} = $this->foo;
-        } elseif ($this->foo instanceof MyClassFooAlternative2) {
+        if ($this->foo instanceof MyClassFooAlternative2) {
             $output->{'foo'} = $this->foo->toStdClass();
+        } else {
+            $output->{'foo'} = $this->foo;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/PropTypeIsUnionWithObject/Output-8.4/MyClass.php
@@ -119,7 +119,7 @@ class MyClass
 
         $foo = match (true) {
             is_string($input->{'foo'}) => $input->{'foo'},
-            MyClassFooAlternative2::validateInput($input->{'foo'}, true) =>
+            ((is_object($input->{'foo'}) || is_array($input->{'foo'})) && MyClassFooAlternative2::validateInput($input->{'foo'}, true)) =>
                 MyClassFooAlternative2::fromInput($input->{'foo'}, $validate),
             default => throw new \InvalidArgumentException("could not build property 'foo' from JSON"),
         };
@@ -144,7 +144,7 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         $output['foo'] = match (true) {
-            is_string($this->foo) => $this->foo,
+            default => $this->foo,
             $this->foo instanceof MyClassFooAlternative2 => $this->foo->toArray(),
         };
 
@@ -161,7 +161,7 @@ class MyClass
         $output = $this->_additionalProperties;
 
         $output->{'foo'} = match (true) {
-            is_string($this->foo) => $this->foo,
+            default => $this->foo,
             $this->foo instanceof MyClassFooAlternative2 => $this->foo->toStdClass(),
         };
 
@@ -208,8 +208,9 @@ class MyClass
     public function __clone()
     {
         $this->foo = match (true) {
-            is_string($this->foo) => $this->foo,
+            is_string($this->foo) => ($this->foo),
             $this->foo instanceof MyClassFooAlternative2 => clone $this->foo,
+            default => $this->foo,
         };
     }
 }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-5.6/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-5.6/Record.php
@@ -355,18 +355,24 @@ class Record
             : null;
         $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'})
             ? array_map(function($i) use ($validate) {
-                return ((Phone::validateInput($i, true))
+                return ((((is_object($i) || is_array($i)) && Phone::validateInput($i, true)))
                     ? Phone::fromInput($i, $validate)
-                    : ((Fio::validateInput($i, true)) ? Fio::fromInput($i, $validate) : null)
+                    : ((((is_object($i) || is_array($i)) && Fio::validateInput($i, true)))
+                        ? Fio::fromInput($i, $validate)
+                        : $i
+                    )
                 );
             }, $input->{'dataArrayAnyOf'})
             : null;
         $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'})
             ? array_map(function($i) use ($validate) {
                 return array_map(function($i) use ($validate) {
-                    return ((Phone::validateInput($i, true))
+                    return ((((is_object($i) || is_array($i)) && Phone::validateInput($i, true)))
                         ? Phone::fromInput($i, $validate)
-                        : ((Fio::validateInput($i, true)) ? Fio::fromInput($i, $validate) : null)
+                        : ((((is_object($i) || is_array($i)) && Fio::validateInput($i, true)))
+                            ? Fio::fromInput($i, $validate)
+                            : $i
+                        )
                     );
                 }, $i);
             }, $input->{'dataArrayNestedAnyOf'})
@@ -407,13 +413,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output['dataArrayAnyOf'] = array_map(function($i) {
-                return (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : null);
+                return (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : $i);
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output['dataArrayNestedAnyOf'] = array_map(function($i) {
                 return array_map(function($i) {
-                    return (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : null);
+                    return (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : $i);
                 }, $i);
             }, $this->dataArrayNestedAnyOf);
         }
@@ -446,13 +452,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output->{'dataArrayAnyOf'} = array_map(function($i) {
-                return (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : null);
+                return (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : $i);
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output->{'dataArrayNestedAnyOf'} = array_map(function($i) {
                 return array_map(function($i) {
-                    return (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : null);
+                    return (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : $i);
                 }, $i);
             }, $this->dataArrayNestedAnyOf);
         }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-7.4/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-7.4/Record.php
@@ -324,16 +324,22 @@ class Record
             )
             : null;
         $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'})
-            ? array_map(fn ($i) => ((Phone::validateInput($i, true))
+            ? array_map(fn ($i) => ((((is_object($i) || is_array($i)) && Phone::validateInput($i, true)))
                 ? Phone::fromInput($i, $validate)
-                : ((Fio::validateInput($i, true)) ? Fio::fromInput($i, $validate) : null)
+                : ((((is_object($i) || is_array($i)) && Fio::validateInput($i, true)))
+                    ? Fio::fromInput($i, $validate)
+                    : $i
+                )
             ), $input->{'dataArrayAnyOf'})
             : null;
         $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'})
             ? array_map(
-                fn ($i) => array_map(fn ($i) => ((Phone::validateInput($i, true))
+                fn ($i) => array_map(fn ($i) => ((((is_object($i) || is_array($i)) && Phone::validateInput($i, true)))
                     ? Phone::fromInput($i, $validate)
-                    : ((Fio::validateInput($i, true)) ? Fio::fromInput($i, $validate) : null)
+                    : ((((is_object($i) || is_array($i)) && Fio::validateInput($i, true)))
+                        ? Fio::fromInput($i, $validate)
+                        : $i
+                    )
                 ), $i),
                 $input->{'dataArrayNestedAnyOf'},
             )
@@ -366,13 +372,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output['dataArrayAnyOf'] = array_map(
-                fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : null),
+                fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : $i),
                 $this->dataArrayAnyOf,
             );
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output['dataArrayNestedAnyOf'] = array_map(
-                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : null), $i),
+                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toArray() : $i), $i),
                 $this->dataArrayNestedAnyOf,
             );
         }
@@ -400,13 +406,13 @@ class Record
         }
         if (isset($this->dataArrayAnyOf)) {
             $output->{'dataArrayAnyOf'} = array_map(
-                fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : null),
+                fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : $i),
                 $this->dataArrayAnyOf,
             );
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output->{'dataArrayNestedAnyOf'} = array_map(
-                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : null), $i),
+                fn ($i) => array_map(fn ($i) => (($i instanceof Phone || $i instanceof Fio) ? $i->toStdClass() : $i), $i),
                 $this->dataArrayNestedAnyOf,
             );
         }

--- a/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-8.4/Record.php
+++ b/tests/Generator/Fixtures/ReferenceArrayPropertyNested/Output-8.4/Record.php
@@ -318,17 +318,17 @@ class Record
             : null;
         $dataArrayAnyOf = isset($input->{'dataArrayAnyOf'})
             ? array_map(fn ($i) => match (true) {
-                Phone::validateInput($i, true) => Phone::fromInput($i, $validate),
-                Fio::validateInput($i, true) => Fio::fromInput($i, $validate),
-                default => null,
+                ((is_object($i) || is_array($i)) && Phone::validateInput($i, true)) => Phone::fromInput($i, $validate),
+                ((is_object($i) || is_array($i)) && Fio::validateInput($i, true)) => Fio::fromInput($i, $validate),
+                default => $i,
             }, $input->{'dataArrayAnyOf'})
             : null;
         $dataArrayNestedAnyOf = isset($input->{'dataArrayNestedAnyOf'})
             ? array_map(
                 fn ($i) => array_map(fn ($i) => match (true) {
-                    Phone::validateInput($i, true) => Phone::fromInput($i, $validate),
-                    Fio::validateInput($i, true) => Fio::fromInput($i, $validate),
-                    default => null,
+                    ((is_object($i) || is_array($i)) && Phone::validateInput($i, true)) => Phone::fromInput($i, $validate),
+                    ((is_object($i) || is_array($i)) && Fio::validateInput($i, true)) => Fio::fromInput($i, $validate),
+                    default => $i,
                 }, $i),
                 $input->{'dataArrayNestedAnyOf'},
             )
@@ -360,19 +360,10 @@ class Record
             $output['dataArrayNested'] = array_map(fn ($i) => array_map(fn (Phone $i): array => $i->toArray(), $i), $this->dataArrayNested);
         }
         if (isset($this->dataArrayAnyOf)) {
-            $output['dataArrayAnyOf'] = array_map(fn ($i) => match (true) {
-                $i instanceof Phone || $i instanceof Fio => $i->toArray(),
-                default => null,
-            }, $this->dataArrayAnyOf);
+            $output['dataArrayAnyOf'] = array_map(fn ($i) => $i->toArray(), $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
-            $output['dataArrayNestedAnyOf'] = array_map(
-                fn ($i) => array_map(fn ($i) => match (true) {
-                    $i instanceof Phone || $i instanceof Fio => $i->toArray(),
-                    default => null,
-                }, $i),
-                $this->dataArrayNestedAnyOf,
-            );
+            $output['dataArrayNestedAnyOf'] = array_map(fn ($i) => array_map(fn ($i) => $i->toArray(), $i), $this->dataArrayNestedAnyOf);
         }
 
         return $output;
@@ -399,14 +390,14 @@ class Record
         if (isset($this->dataArrayAnyOf)) {
             $output->{'dataArrayAnyOf'} = array_map(fn ($i) => match (true) {
                 $i instanceof Phone || $i instanceof Fio => $i->toStdClass(),
-                default => null,
+                default => $i,
             }, $this->dataArrayAnyOf);
         }
         if (isset($this->dataArrayNestedAnyOf)) {
             $output->{'dataArrayNestedAnyOf'} = array_map(
                 fn ($i) => array_map(fn ($i) => match (true) {
                     $i instanceof Phone || $i instanceof Fio => $i->toStdClass(),
-                    default => null,
+                    default => $i,
                 }, $i),
                 $this->dataArrayNestedAnyOf,
             );

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-5.6/MyObject.php
@@ -120,9 +120,7 @@ class MyObject
     public function toArray()
     {
         $output = [];
-        if (in_array($this->foo, ['foo', 'bar'], true) || in_array($this->foo, ['baz', 'quz'], true)) {
-            $output['foo'] = $this->foo;
-        }
+        $output['foo'] = $this->foo;
 
         return $output;
     }
@@ -135,9 +133,7 @@ class MyObject
     public function toStdClass()
     {
         $output = new \stdClass();
-        if (in_array($this->foo, ['foo', 'bar'], true) || in_array($this->foo, ['baz', 'quz'], true)) {
-            $output->{'foo'} = $this->foo;
-        }
+        $output->{'foo'} = $this->foo;
 
         return $output;
     }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-7.4/MyObject.php
@@ -118,9 +118,7 @@ class MyObject
     public function toArray(): array
     {
         $output = [];
-        if (in_array($this->foo, ['foo', 'bar'], true) || in_array($this->foo, ['baz', 'quz'], true)) {
-            $output['foo'] = $this->foo;
-        }
+        $output['foo'] = $this->foo;
 
         return $output;
     }
@@ -133,9 +131,7 @@ class MyObject
     public function toStdClass(): \stdClass
     {
         $output = new \stdClass();
-        if (in_array($this->foo, ['foo', 'bar'], true) || in_array($this->foo, ['baz', 'quz'], true)) {
-            $output->{'foo'} = $this->foo;
-        }
+        $output->{'foo'} = $this->foo;
 
         return $output;
     }

--- a/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
+++ b/tests/Generator/Fixtures/ReferencedUnion/Output-8.4/MyObject.php
@@ -104,6 +104,7 @@ class MyObject
         $output = [];
         $output['foo'] = match (true) {
             $this->foo instanceof A || $this->foo instanceof B => $this->foo->value,
+            default => $this->foo,
         };
 
         return $output;
@@ -119,6 +120,7 @@ class MyObject
         $output = new \stdClass();
         $output->{'foo'} = match (true) {
             $this->foo instanceof A || $this->foo instanceof B => $this->foo->value,
+            default => $this->foo,
         };
 
         return $output;

--- a/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
+++ b/tests/Generator/Fixtures/SettersFullValidation/Output-8.4/RefValidation.php
@@ -223,8 +223,8 @@ class RefValidation
         $foo = isset($input->{'foo'}) ? $input->{'foo'} : null;
         $bar = isset($input->{'bar'})
             ? match (true) {
-                is_string($input->{'bar'}) || in_array($input->{'bar'}, [1, 2], true) => $input->{'bar'},
-                default => null,
+                is_string($input->{'bar'}) || in_array($input->{'bar'}, [1, 2], true) => ($input->{'bar'}),
+                default => $input->{'bar'},
             }
             : null;
         $baz = isset($input->{'baz'})
@@ -255,7 +255,7 @@ class RefValidation
         }
         if (isset($this->bar)) {
             $output['bar'] = match (true) {
-                is_string($this->bar) || in_array($this->bar, [1, 2], true) => $this->bar,
+                default => $this->bar,
             };
         }
         if (isset($this->baz)) {
@@ -279,7 +279,7 @@ class RefValidation
         }
         if (isset($this->bar)) {
             $output->{'bar'} = match (true) {
-                is_string($this->bar) || in_array($this->bar, [1, 2], true) => $this->bar,
+                default => $this->bar,
             };
         }
         if (isset($this->baz)) {

--- a/tests/Generator/Fixtures/SettersValidation/Output-5.6/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-5.6/Foo.php
@@ -345,12 +345,7 @@ class Foo
         }
 
         $_providedOptionals = [];
-        $a = isset($input->{'a'})
-            ? ((in_array($input->{'a'}, ['a', 'b'], true) || is_array($input->{'a'}))
-                ? $input->{'a'}
-                : null
-            )
-            : null;
+        $a = isset($input->{'a'}) ? $input->{'a'} : null;
         $b = isset($input->{'b'}) ? $input->{'b'} : null;
         $c = null;
         if (property_exists($input, 'c')) {
@@ -380,9 +375,7 @@ class Foo
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->a)) {
-            if (in_array($this->a, ['a', 'b'], true) || is_array($this->a)) {
-                $output['a'] = $this->a;
-            }
+            $output['a'] = $this->a;
         }
         if (isset($this->b)) {
             $output['b'] = $this->b;
@@ -407,9 +400,7 @@ class Foo
         $output = $this->_additionalProperties;
 
         if (isset($this->a)) {
-            if (in_array($this->a, ['a', 'b'], true) || is_array($this->a)) {
-                $output->{'a'} = $this->a;
-            }
+            $output->{'a'} = $this->a;
         }
         if (isset($this->b)) {
             $output->{'b'} = $this->b;

--- a/tests/Generator/Fixtures/SettersValidation/Output-7.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-7.4/Foo.php
@@ -306,12 +306,7 @@ class Foo
         }
 
         $_providedOptionals = [];
-        $a = isset($input->{'a'})
-            ? ((in_array($input->{'a'}, ['a', 'b'], true) || is_array($input->{'a'}))
-                ? $input->{'a'}
-                : null
-            )
-            : null;
+        $a = isset($input->{'a'}) ? $input->{'a'} : null;
         $b = isset($input->{'b'}) ? $input->{'b'} : null;
         $c = null;
         if (property_exists($input, 'c')) {
@@ -341,9 +336,7 @@ class Foo
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->a)) {
-            if (in_array($this->a, ['a', 'b'], true) || is_array($this->a)) {
-                $output['a'] = $this->a;
-            }
+            $output['a'] = $this->a;
         }
         if (isset($this->b)) {
             $output['b'] = $this->b;
@@ -368,9 +361,7 @@ class Foo
         $output = $this->_additionalProperties;
 
         if (isset($this->a)) {
-            if (in_array($this->a, ['a', 'b'], true) || is_array($this->a)) {
-                $output->{'a'} = $this->a;
-            }
+            $output->{'a'} = $this->a;
         }
         if (isset($this->b)) {
             $output->{'b'} = $this->b;

--- a/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
+++ b/tests/Generator/Fixtures/SettersValidation/Output-8.4/Foo.php
@@ -285,8 +285,8 @@ class Foo
         $_providedOptionals = [];
         $a = isset($input->{'a'})
             ? match (true) {
-                in_array($input->{'a'}, ['a', 'b'], true) || is_array($input->{'a'}) => $input->{'a'},
-                default => null,
+                in_array($input->{'a'}, ['a', 'b'], true) || is_array($input->{'a'}) => ($input->{'a'}),
+                default => $input->{'a'},
             }
             : null;
         $b = isset($input->{'b'}) ? $input->{'b'} : null;
@@ -319,7 +319,7 @@ class Foo
 
         if (isset($this->a)) {
             $output['a'] = match (true) {
-                in_array($this->a, ['a', 'b'], true) || is_array($this->a) => $this->a,
+                default => $this->a,
             };
         }
         if (isset($this->b)) {
@@ -346,7 +346,7 @@ class Foo
 
         if (isset($this->a)) {
             $output->{'a'} = match (true) {
-                in_array($this->a, ['a', 'b'], true) || is_array($this->a) => $this->a,
+                default => $this->a,
             };
         }
         if (isset($this->b)) {

--- a/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-5.6/MyClass.php
@@ -155,15 +155,12 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'})
-            ? ((is_string($input->{'foo'}))
-                ? $input->{'foo'}
-                : (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
-                    ? (str_contains((string)$input->{'foo'}, '.')
-                        ? (float)$input->{'foo'}
-                        : (int)$input->{'foo'}
-                    )
-                    : null
+            ? (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
+                ? (str_contains((string)$input->{'foo'}, '.')
+                    ? (float)$input->{'foo'}
+                    : (int)$input->{'foo'}
                 )
+                : $input->{'foo'}
             )
             : null;
 
@@ -187,9 +184,7 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->foo)) {
-            if (is_string($this->foo) || (is_int($this->foo) || is_float($this->foo))) {
-                $output['foo'] = $this->foo;
-            }
+            $output['foo'] = $this->foo;
         }
 
         return $output;
@@ -205,9 +200,7 @@ class MyClass
         $output = $this->_additionalProperties;
 
         if (isset($this->foo)) {
-            if (is_string($this->foo) || (is_int($this->foo) || is_float($this->foo))) {
-                $output->{'foo'} = $this->foo;
-            }
+            $output->{'foo'} = $this->foo;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-7.4/MyClass.php
@@ -143,15 +143,12 @@ class MyClass
         }
 
         $foo = isset($input->{'foo'})
-            ? ((is_string($input->{'foo'}))
-                ? $input->{'foo'}
-                : (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
-                    ? (str_contains((string)$input->{'foo'}, '.')
-                        ? (float)$input->{'foo'}
-                        : (int)$input->{'foo'}
-                    )
-                    : null
+            ? (((is_int($input->{'foo'}) || is_float($input->{'foo'})))
+                ? (str_contains((string)$input->{'foo'}, '.')
+                    ? (float)$input->{'foo'}
+                    : (int)$input->{'foo'}
                 )
+                : $input->{'foo'}
             )
             : null;
 
@@ -175,9 +172,7 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->foo)) {
-            if (is_string($this->foo) || (is_int($this->foo) || is_float($this->foo))) {
-                $output['foo'] = $this->foo;
-            }
+            $output['foo'] = $this->foo;
         }
 
         return $output;
@@ -193,9 +188,7 @@ class MyClass
         $output = $this->_additionalProperties;
 
         if (isset($this->foo)) {
-            if (is_string($this->foo) || (is_int($this->foo) || is_float($this->foo))) {
-                $output->{'foo'} = $this->foo;
-            }
+            $output->{'foo'} = $this->foo;
         }
 
         return $output;

--- a/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TopLevelRef/Output-8.4/MyClass.php
@@ -117,13 +117,13 @@ class MyClass
 
         $foo = isset($input->{'foo'})
             ? match (true) {
-                is_string($input->{'foo'}) => $input->{'foo'},
+                is_string($input->{'foo'}) => ($input->{'foo'}),
                 (is_int($input->{'foo'}) || is_float($input->{'foo'})) =>
                     (str_contains((string)$input->{'foo'}, '.')
                         ? (float)$input->{'foo'}
                         : (int)$input->{'foo'}
                     ),
-                default => null,
+                default => $input->{'foo'},
             }
             : null;
 
@@ -148,7 +148,7 @@ class MyClass
 
         if (isset($this->foo)) {
             $output['foo'] = match (true) {
-                is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) => $this->foo,
+                default => $this->foo,
             };
         }
 
@@ -166,7 +166,7 @@ class MyClass
 
         if (isset($this->foo)) {
             $output->{'foo'} = match (true) {
-                is_string($this->foo) || (is_int($this->foo) || is_float($this->foo)) => $this->foo,
+                default => $this->foo,
             };
         }
 

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-7.4/MyClass.php
@@ -449,42 +449,33 @@ class MyClass
             ? array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i))
-                    ? $i
-                    : (((is_int($i) || is_float($i)))
-                        ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
-                        : null
-                    )
+                ? array_map(fn ($i) => (((is_int($i) || is_float($i)))
+                    ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
+                    : $i
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : $i
             ), $input->{'arrayOfUnions'})
             : null;
         $arrayOfRefUnions = isset($input->{'arrayOfRefUnions'})
             ? array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i))
-                    ? $i
-                    : (((is_int($i) || is_float($i)))
-                        ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
-                        : null
-                    )
+                ? array_map(fn ($i) => (((is_int($i) || is_float($i)))
+                    ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
+                    : $i
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : $i
             ), $input->{'arrayOfRefUnions'})
             : null;
         $arrayOfRefAndNotRefUnions = isset($input->{'arrayOfRefAndNotRefUnions'})
             ? array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i))
-                    ? $i
-                    : (((is_int($i) || is_float($i)))
-                        ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
-                        : null
-                    )
+                ? array_map(fn ($i) => (((is_int($i) || is_float($i)))
+                    ? (str_contains((string)$i, '.') ? (float)$i : (int)$i)
+                    : $i
                 ), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                : $i
             ), $input->{'arrayOfRefAndNotRefUnions'})
             : null;
         $arrayOfUnionOfStringAndArray = isset($input->{'arrayOfUnionOfStringAndArray'})
@@ -492,7 +483,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => is_array($i))))
             )
                 ? array_map(fn ($i) => $i, $i)
-                : ((is_string($i)) ? $i : null)
+                : $i
             ), $input->{'arrayOfUnionOfStringAndArray'})
             : null;
         $arrayOfUnionWithOneType = isset($input->{'arrayOfUnionWithOneType'})
@@ -528,24 +519,24 @@ class MyClass
             $output['arrayOfUnions'] = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $output['arrayOfRefUnions'] = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $output['arrayOfRefAndNotRefUnions'] = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
@@ -553,7 +544,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => is_array($i))))
             )
                 ? array_map(fn ($i) => $i, $i)
-                : ((is_string($i)) ? $i : null)
+                : $i
             ), $this->arrayOfUnionOfStringAndArray);
         }
         if (isset($this->arrayOfUnionWithOneType)) {
@@ -576,24 +567,24 @@ class MyClass
             $output->{'arrayOfUnions'} = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $output->{'arrayOfRefUnions'} = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $output->{'arrayOfRefAndNotRefUnions'} = array_map(fn ($i) => (((is_array($i)
                 && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i))))))
             )
-                ? array_map(fn ($i) => ((is_string($i) || (is_int($i) || is_float($i))) ? $i : null), $i)
-                : (((is_array($i) || is_array($i))) ? ((is_array($i)) ? $i : null) : null)
+                ? array_map(fn ($i) => $i, $i)
+                : $i
             ), $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
@@ -601,7 +592,7 @@ class MyClass
                 && count($i) === count(array_filter($i, fn ($i) => is_array($i))))
             )
                 ? array_map(fn ($i) => $i, $i)
-                : ((is_string($i)) ? $i : null)
+                : $i
             ), $this->arrayOfUnionOfStringAndArray);
         }
         if (isset($this->arrayOfUnionWithOneType)) {

--- a/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/TypedArrayOfTypedUnions/Output-8.4/MyClass.php
@@ -443,15 +443,15 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) => $i,
+                        is_string($i) => ($i),
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
-                        default => null,
+                        default => $i,
                     }, $i),
                 (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
+                    is_array($i) => ($i),
+                    default => $i,
                 },
-                default => null,
+                default => $i,
             }, $input->{'arrayOfUnions'})
             : null;
         $arrayOfRefUnions = isset($input->{'arrayOfRefUnions'})
@@ -459,15 +459,15 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) => $i,
+                        is_string($i) => ($i),
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
-                        default => null,
+                        default => $i,
                     }, $i),
                 (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
+                    is_array($i) => ($i),
+                    default => $i,
                 },
-                default => null,
+                default => $i,
             }, $input->{'arrayOfRefUnions'})
             : null;
         $arrayOfRefAndNotRefUnions = isset($input->{'arrayOfRefAndNotRefUnions'})
@@ -475,23 +475,23 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) => $i,
+                        is_string($i) => ($i),
                         (is_int($i) || is_float($i)) => (str_contains((string)$i, '.') ? (float)$i : (int)$i),
-                        default => null,
+                        default => $i,
                     }, $i),
                 (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
+                    is_array($i) => ($i),
+                    default => $i,
                 },
-                default => null,
+                default => $i,
             }, $input->{'arrayOfRefAndNotRefUnions'})
             : null;
         $arrayOfUnionOfStringAndArray = isset($input->{'arrayOfUnionOfStringAndArray'})
             ? array_map(fn ($i) => match (true) {
+                is_string($i) => ($i),
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => is_array($i)))) => array_map(fn ($i) => $i, $i),
-                is_string($i) => $i,
-                default => null,
+                default => $i,
             }, $input->{'arrayOfUnionOfStringAndArray'})
             : null;
         $arrayOfUnionWithOneType = isset($input->{'arrayOfUnionWithOneType'})
@@ -528,14 +528,14 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                        default => null,
+                        is_string($i) || (is_int($i) || is_float($i)) => ($i),
+                        default => $i,
                     }, $i),
                 (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
+                    is_array($i) => ($i),
+                    default => $i,
                 },
-                default => null,
+                default => $i,
             }, $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
@@ -543,14 +543,14 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                        default => null,
+                        is_string($i) || (is_int($i) || is_float($i)) => ($i),
+                        default => $i,
                     }, $i),
                 (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
+                    is_array($i) => ($i),
+                    default => $i,
                 },
-                default => null,
+                default => $i,
             }, $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
@@ -558,22 +558,22 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                        default => null,
+                        is_string($i) || (is_int($i) || is_float($i)) => ($i),
+                        default => $i,
                     }, $i),
                 (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
+                    is_array($i) => ($i),
+                    default => $i,
                 },
-                default => null,
+                default => $i,
             }, $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
             $output['arrayOfUnionOfStringAndArray'] = array_map(fn ($i) => match (true) {
+                is_string($i) => ($i),
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => is_array($i)))) => array_map(fn ($i) => $i, $i),
-                is_string($i) => $i,
-                default => null,
+                default => $i,
             }, $this->arrayOfUnionOfStringAndArray);
         }
         if (isset($this->arrayOfUnionWithOneType)) {
@@ -597,14 +597,14 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                        default => null,
+                        is_string($i) || (is_int($i) || is_float($i)) => ($i),
+                        default => $i,
                     }, $i),
                 (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
+                    is_array($i) => ($i),
+                    default => $i,
                 },
-                default => null,
+                default => $i,
             }, $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
@@ -612,14 +612,14 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                        default => null,
+                        is_string($i) || (is_int($i) || is_float($i)) => ($i),
+                        default => $i,
                     }, $i),
                 (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
+                    is_array($i) => ($i),
+                    default => $i,
                 },
-                default => null,
+                default => $i,
             }, $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
@@ -627,22 +627,22 @@ class MyClass
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => match (true) {
-                        is_string($i) || (is_int($i) || is_float($i)) => $i,
-                        default => null,
+                        is_string($i) || (is_int($i) || is_float($i)) => ($i),
+                        default => $i,
                     }, $i),
                 (is_array($i) || is_array($i)) => match (true) {
-                    is_array($i) => $i,
-                    default => null,
+                    is_array($i) => ($i),
+                    default => $i,
                 },
-                default => null,
+                default => $i,
             }, $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
             $output->{'arrayOfUnionOfStringAndArray'} = array_map(fn ($i) => match (true) {
+                is_string($i) => ($i),
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => is_array($i)))) => array_map(fn ($i) => $i, $i),
-                is_string($i) => $i,
-                default => null,
+                default => $i,
             }, $this->arrayOfUnionOfStringAndArray);
         }
         if (isset($this->arrayOfUnionWithOneType)) {
@@ -693,33 +693,37 @@ class MyClass
     {
         if (isset($this->arrayOfUnions)) {
             $this->arrayOfUnions = array_map(fn ($i) => match (true) {
+                (is_array($i) || is_array($i)) => ($i),
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => $i, $i),
-                (is_array($i) || is_array($i)) => $i,
+                default => $i,
             }, $this->arrayOfUnions);
         }
         if (isset($this->arrayOfRefUnions)) {
             $this->arrayOfRefUnions = array_map(fn ($i) => match (true) {
+                (is_array($i) || is_array($i)) => ($i),
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => $i, $i),
-                (is_array($i) || is_array($i)) => $i,
+                default => $i,
             }, $this->arrayOfRefUnions);
         }
         if (isset($this->arrayOfRefAndNotRefUnions)) {
             $this->arrayOfRefAndNotRefUnions = array_map(fn ($i) => match (true) {
+                (is_array($i) || is_array($i)) => ($i),
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => (is_string($i) || (is_int($i) || is_float($i)))))) =>
                     array_map(fn ($i) => $i, $i),
-                (is_array($i) || is_array($i)) => $i,
+                default => $i,
             }, $this->arrayOfRefAndNotRefUnions);
         }
         if (isset($this->arrayOfUnionOfStringAndArray)) {
             $this->arrayOfUnionOfStringAndArray = array_map(fn ($i) => match (true) {
+                is_string($i) => ($i),
                 (is_array($i)
                     && count($i) === count(array_filter($i, fn ($i) => is_array($i)))) => array_map(fn ($i) => $i, $i),
-                is_string($i) => $i,
+                default => $i,
             }, $this->arrayOfUnionOfStringAndArray);
         }
         if (isset($this->arrayOfUnionWithOneType)) {

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-7.4/MyClass.php
@@ -433,7 +433,7 @@ class MyClass
                         fn ($i): MyClassArrayOfObjectsUnionAlternative2Item => MyClassArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'arrayOfObjectsUnion'},
                     )
-                    : null
+                    : $input->{'arrayOfObjectsUnion'}
                 )
             )
             : null;
@@ -458,7 +458,7 @@ class MyClass
                         fn ($i): MyClassRefArrayOfObjectsUnionAlternative2Item => MyClassRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'refArrayOfObjectsUnion'},
                     )
-                    : null
+                    : $input->{'refArrayOfObjectsUnion'}
                 )
             )
             : null;
@@ -503,7 +503,7 @@ class MyClass
                                 fn ($i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::fromInput($i, $validate),
                                 $input->{'refAndNotRefArrayOfObjectsUnion'},
                             )
-                            : null
+                            : $input->{'refAndNotRefArrayOfObjectsUnion'}
                         )
                     )
                 )
@@ -520,10 +520,7 @@ class MyClass
                     fn ($i): MyClassArrayOfObjAndStringUnionAlternative1Item => MyClassArrayOfObjAndStringUnionAlternative1Item::fromInput($i, $validate),
                     $input->{'arrayOfObjAndStringUnion'},
                 )
-                : ((is_string($input->{'arrayOfObjAndStringUnion'}))
-                    ? $input->{'arrayOfObjAndStringUnion'}
-                    : null
-                )
+                : $input->{'arrayOfObjAndStringUnion'}
             )
             : null;
         $unionOfOneArrayOfObjects = isset($input->{'unionOfOneArrayOfObjects'})
@@ -579,6 +576,8 @@ class MyClass
                     fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => $i->toArray(),
                     $this->arrayOfObjectsUnion,
                 );
+            } else {
+                $output['arrayOfObjectsUnion'] = $this->arrayOfObjectsUnion;
             }
         }
         if (isset($this->refArrayOfObjectsUnion)) {
@@ -602,6 +601,8 @@ class MyClass
                     fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => $i->toArray(),
                     $this->refArrayOfObjectsUnion,
                 );
+            } else {
+                $output['refArrayOfObjectsUnion'] = $this->refArrayOfObjectsUnion;
             }
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
@@ -645,6 +646,8 @@ class MyClass
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => $i->toArray(),
                     $this->refAndNotRefArrayOfObjectsUnion,
                 );
+            } else {
+                $output['refAndNotRefArrayOfObjectsUnion'] = $this->refAndNotRefArrayOfObjectsUnion;
             }
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
@@ -658,7 +661,7 @@ class MyClass
                     fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => $i->toArray(),
                     $this->arrayOfObjAndStringUnion,
                 );
-            } elseif (is_string($this->arrayOfObjAndStringUnion)) {
+            } else {
                 $output['arrayOfObjAndStringUnion'] = $this->arrayOfObjAndStringUnion;
             }
         }
@@ -702,6 +705,8 @@ class MyClass
                     fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => $i->toStdClass(),
                     $this->arrayOfObjectsUnion,
                 );
+            } else {
+                $output->{'arrayOfObjectsUnion'} = $this->arrayOfObjectsUnion;
             }
         }
         if (isset($this->refArrayOfObjectsUnion)) {
@@ -725,6 +730,8 @@ class MyClass
                     fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => $i->toStdClass(),
                     $this->refArrayOfObjectsUnion,
                 );
+            } else {
+                $output->{'refArrayOfObjectsUnion'} = $this->refArrayOfObjectsUnion;
             }
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
@@ -768,6 +775,8 @@ class MyClass
                     fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => $i->toStdClass(),
                     $this->refAndNotRefArrayOfObjectsUnion,
                 );
+            } else {
+                $output->{'refAndNotRefArrayOfObjectsUnion'} = $this->refAndNotRefArrayOfObjectsUnion;
             }
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
@@ -781,7 +790,7 @@ class MyClass
                     fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => $i->toStdClass(),
                     $this->arrayOfObjAndStringUnion,
                 );
-            } elseif (is_string($this->arrayOfObjAndStringUnion)) {
+            } else {
                 $output->{'arrayOfObjAndStringUnion'} = $this->arrayOfObjAndStringUnion;
             }
         }

--- a/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayObject/Output-8.4/MyClass.php
@@ -425,7 +425,7 @@ class MyClass
                         fn (object|array $i): MyClassArrayOfObjectsUnionAlternative2Item => MyClassArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'arrayOfObjectsUnion'},
                     ),
-                default => null,
+                default => $input->{'arrayOfObjectsUnion'},
             }
             : null;
         $refArrayOfObjectsUnion = isset($input->{'refArrayOfObjectsUnion'})
@@ -448,7 +448,7 @@ class MyClass
                         fn (object|array $i): MyClassRefArrayOfObjectsUnionAlternative2Item => MyClassRefArrayOfObjectsUnionAlternative2Item::fromInput($i, $validate),
                         $input->{'refArrayOfObjectsUnion'},
                     ),
-                default => null,
+                default => $input->{'refArrayOfObjectsUnion'},
             }
             : null;
         $refAndNotRefArrayOfObjectsUnion = isset($input->{'refAndNotRefArrayOfObjectsUnion'})
@@ -489,11 +489,12 @@ class MyClass
                         fn (object|array $i): MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item => MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item::fromInput($i, $validate),
                         $input->{'refAndNotRefArrayOfObjectsUnion'},
                     ),
-                default => null,
+                default => $input->{'refAndNotRefArrayOfObjectsUnion'},
             }
             : null;
         $arrayOfObjAndStringUnion = isset($input->{'arrayOfObjAndStringUnion'})
             ? match (true) {
+                is_string($input->{'arrayOfObjAndStringUnion'}) => ($input->{'arrayOfObjAndStringUnion'}),
                 (is_array($input->{'arrayOfObjAndStringUnion'})
                     && count($input->{'arrayOfObjAndStringUnion'}) === count(array_filter(
                         $input->{'arrayOfObjAndStringUnion'},
@@ -503,8 +504,7 @@ class MyClass
                         fn (object|array $i): MyClassArrayOfObjAndStringUnionAlternative1Item => MyClassArrayOfObjAndStringUnionAlternative1Item::fromInput($i, $validate),
                         $input->{'arrayOfObjAndStringUnion'},
                     ),
-                is_string($input->{'arrayOfObjAndStringUnion'}) => $input->{'arrayOfObjAndStringUnion'},
-                default => null,
+                default => $input->{'arrayOfObjAndStringUnion'},
             }
             : null;
         $unionOfOneArrayOfObjects = isset($input->{'unionOfOneArrayOfObjects'})
@@ -559,6 +559,7 @@ class MyClass
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => $i->toArray(),
                         $this->arrayOfObjectsUnion,
                     ),
+                default => $this->arrayOfObjectsUnion,
             };
         }
         if (isset($this->refArrayOfObjectsUnion)) {
@@ -581,6 +582,7 @@ class MyClass
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => $i->toArray(),
                         $this->refArrayOfObjectsUnion,
                     ),
+                default => $this->refArrayOfObjectsUnion,
             };
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
@@ -621,6 +623,7 @@ class MyClass
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => $i->toArray(),
                         $this->refAndNotRefArrayOfObjectsUnion,
                     ),
+                default => $this->refAndNotRefArrayOfObjectsUnion,
             };
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
@@ -634,7 +637,7 @@ class MyClass
                         fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => $i->toArray(),
                         $this->arrayOfObjAndStringUnion,
                     ),
-                is_string($this->arrayOfObjAndStringUnion) => $this->arrayOfObjAndStringUnion,
+                default => $this->arrayOfObjAndStringUnion,
             };
         }
         if (isset($this->unionOfOneArrayOfObjects)) {
@@ -676,6 +679,7 @@ class MyClass
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => $i->toStdClass(),
                         $this->arrayOfObjectsUnion,
                     ),
+                default => $this->arrayOfObjectsUnion,
             };
         }
         if (isset($this->refArrayOfObjectsUnion)) {
@@ -698,6 +702,7 @@ class MyClass
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => $i->toStdClass(),
                         $this->refArrayOfObjectsUnion,
                     ),
+                default => $this->refArrayOfObjectsUnion,
             };
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
@@ -738,6 +743,7 @@ class MyClass
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => $i->toStdClass(),
                         $this->refAndNotRefArrayOfObjectsUnion,
                     ),
+                default => $this->refAndNotRefArrayOfObjectsUnion,
             };
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
@@ -751,7 +757,7 @@ class MyClass
                         fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => $i->toStdClass(),
                         $this->arrayOfObjAndStringUnion,
                     ),
-                is_string($this->arrayOfObjAndStringUnion) => $this->arrayOfObjAndStringUnion,
+                default => $this->arrayOfObjAndStringUnion,
             };
         }
         if (isset($this->unionOfOneArrayOfObjects)) {
@@ -823,6 +829,7 @@ class MyClass
                         fn (MyClassArrayOfObjectsUnionAlternative2Item $i) => clone $i,
                         $this->arrayOfObjectsUnion,
                     ),
+                default => $this->arrayOfObjectsUnion,
             };
         }
         if (isset($this->refArrayOfObjectsUnion)) {
@@ -845,6 +852,7 @@ class MyClass
                         fn (MyClassRefArrayOfObjectsUnionAlternative2Item $i) => clone $i,
                         $this->refArrayOfObjectsUnion,
                     ),
+                default => $this->refArrayOfObjectsUnion,
             };
         }
         if (isset($this->refAndNotRefArrayOfObjectsUnion)) {
@@ -885,10 +893,12 @@ class MyClass
                         fn (MyClassRefAndNotRefArrayOfObjectsUnionAlternative4Item $i) => clone $i,
                         $this->refAndNotRefArrayOfObjectsUnion,
                     ),
+                default => $this->refAndNotRefArrayOfObjectsUnion,
             };
         }
         if (isset($this->arrayOfObjAndStringUnion)) {
             $this->arrayOfObjAndStringUnion = match (true) {
+                is_string($this->arrayOfObjAndStringUnion) => ($this->arrayOfObjAndStringUnion),
                 (is_array($this->arrayOfObjAndStringUnion)
                     && count($this->arrayOfObjAndStringUnion) === count(array_filter(
                         $this->arrayOfObjAndStringUnion,
@@ -898,7 +908,7 @@ class MyClass
                         fn (MyClassArrayOfObjAndStringUnionAlternative1Item $i) => clone $i,
                         $this->arrayOfObjAndStringUnion,
                     ),
-                is_string($this->arrayOfObjAndStringUnion) => $this->arrayOfObjAndStringUnion,
+                default => $this->arrayOfObjAndStringUnion,
             };
         }
         if (isset($this->unionOfOneArrayOfObjects)) {

--- a/tests/Generator/Fixtures/UnionArrayTyped/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayTyped/Output-7.4/MyClass.php
@@ -380,28 +380,13 @@ class MyClass
             static::validateInput($input);
         }
 
-        $unionOfTypedArrays = isset($input->{'unionOfTypedArrays'})
-            ? ((is_array($input->{'unionOfTypedArrays'})) ? $input->{'unionOfTypedArrays'} : null)
-            : null;
-        $refUnionOfTypedArrays = isset($input->{'refUnionOfTypedArrays'})
-            ? ((is_array($input->{'refUnionOfTypedArrays'}))
-                ? $input->{'refUnionOfTypedArrays'}
-                : null
-            )
-            : null;
+        $unionOfTypedArrays = isset($input->{'unionOfTypedArrays'}) ? $input->{'unionOfTypedArrays'} : null;
+        $refUnionOfTypedArrays = isset($input->{'refUnionOfTypedArrays'}) ? $input->{'refUnionOfTypedArrays'} : null;
         $refAndNotRefUnionOfTypedArrays = isset($input->{'refAndNotRefUnionOfTypedArrays'})
-            ? ((is_array($input->{'refAndNotRefUnionOfTypedArrays'}))
-                ? $input->{'refAndNotRefUnionOfTypedArrays'}
-                : null
-            )
+            ? $input->{'refAndNotRefUnionOfTypedArrays'}
             : null;
         $unionOfTypedArrayAndString = isset($input->{'unionOfTypedArrayAndString'})
-            ? ((is_array($input->{'unionOfTypedArrayAndString'})
-                || is_string($input->{'unionOfTypedArrayAndString'})
-            )
-                ? $input->{'unionOfTypedArrayAndString'}
-                : null
-            )
+            ? $input->{'unionOfTypedArrayAndString'}
             : null;
         $unionOfOneTypedArray = isset($input->{'unionOfOneTypedArray'}) ? $input->{'unionOfOneTypedArray'} : null;
 
@@ -431,24 +416,16 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         if (isset($this->unionOfTypedArrays)) {
-            if (is_array($this->unionOfTypedArrays)) {
-                $output['unionOfTypedArrays'] = $this->unionOfTypedArrays;
-            }
+            $output['unionOfTypedArrays'] = $this->unionOfTypedArrays;
         }
         if (isset($this->refUnionOfTypedArrays)) {
-            if (is_array($this->refUnionOfTypedArrays)) {
-                $output['refUnionOfTypedArrays'] = $this->refUnionOfTypedArrays;
-            }
+            $output['refUnionOfTypedArrays'] = $this->refUnionOfTypedArrays;
         }
         if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            if (is_array($this->refAndNotRefUnionOfTypedArrays)) {
-                $output['refAndNotRefUnionOfTypedArrays'] = $this->refAndNotRefUnionOfTypedArrays;
-            }
+            $output['refAndNotRefUnionOfTypedArrays'] = $this->refAndNotRefUnionOfTypedArrays;
         }
         if (isset($this->unionOfTypedArrayAndString)) {
-            if (is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString)) {
-                $output['unionOfTypedArrayAndString'] = $this->unionOfTypedArrayAndString;
-            }
+            $output['unionOfTypedArrayAndString'] = $this->unionOfTypedArrayAndString;
         }
         if (isset($this->unionOfOneTypedArray)) {
             $output['unionOfOneTypedArray'] = $this->unionOfOneTypedArray;
@@ -467,24 +444,16 @@ class MyClass
         $output = $this->_additionalProperties;
 
         if (isset($this->unionOfTypedArrays)) {
-            if (is_array($this->unionOfTypedArrays)) {
-                $output->{'unionOfTypedArrays'} = $this->unionOfTypedArrays;
-            }
+            $output->{'unionOfTypedArrays'} = $this->unionOfTypedArrays;
         }
         if (isset($this->refUnionOfTypedArrays)) {
-            if (is_array($this->refUnionOfTypedArrays)) {
-                $output->{'refUnionOfTypedArrays'} = $this->refUnionOfTypedArrays;
-            }
+            $output->{'refUnionOfTypedArrays'} = $this->refUnionOfTypedArrays;
         }
         if (isset($this->refAndNotRefUnionOfTypedArrays)) {
-            if (is_array($this->refAndNotRefUnionOfTypedArrays)) {
-                $output->{'refAndNotRefUnionOfTypedArrays'} = $this->refAndNotRefUnionOfTypedArrays;
-            }
+            $output->{'refAndNotRefUnionOfTypedArrays'} = $this->refAndNotRefUnionOfTypedArrays;
         }
         if (isset($this->unionOfTypedArrayAndString)) {
-            if (is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString)) {
-                $output->{'unionOfTypedArrayAndString'} = $this->unionOfTypedArrayAndString;
-            }
+            $output->{'unionOfTypedArrayAndString'} = $this->unionOfTypedArrayAndString;
         }
         if (isset($this->unionOfOneTypedArray)) {
             $output->{'unionOfOneTypedArray'} = $this->unionOfOneTypedArray;

--- a/tests/Generator/Fixtures/UnionArrayTyped/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionArrayTyped/Output-8.4/MyClass.php
@@ -375,28 +375,28 @@ class MyClass
 
         $unionOfTypedArrays = isset($input->{'unionOfTypedArrays'})
             ? match (true) {
-                is_array($input->{'unionOfTypedArrays'}) => $input->{'unionOfTypedArrays'},
-                default => null,
+                is_array($input->{'unionOfTypedArrays'}) => ($input->{'unionOfTypedArrays'}),
+                default => $input->{'unionOfTypedArrays'},
             }
             : null;
         $refUnionOfTypedArrays = isset($input->{'refUnionOfTypedArrays'})
             ? match (true) {
-                is_array($input->{'refUnionOfTypedArrays'}) => $input->{'refUnionOfTypedArrays'},
-                default => null,
+                is_array($input->{'refUnionOfTypedArrays'}) => ($input->{'refUnionOfTypedArrays'}),
+                default => $input->{'refUnionOfTypedArrays'},
             }
             : null;
         $refAndNotRefUnionOfTypedArrays = isset($input->{'refAndNotRefUnionOfTypedArrays'})
             ? match (true) {
-                is_array($input->{'refAndNotRefUnionOfTypedArrays'}) => $input->{'refAndNotRefUnionOfTypedArrays'},
-                default => null,
+                is_array($input->{'refAndNotRefUnionOfTypedArrays'}) => ($input->{'refAndNotRefUnionOfTypedArrays'}),
+                default => $input->{'refAndNotRefUnionOfTypedArrays'},
             }
             : null;
         $unionOfTypedArrayAndString = isset($input->{'unionOfTypedArrayAndString'})
             ? match (true) {
                 is_array($input->{'unionOfTypedArrayAndString'})
                     || is_string($input->{'unionOfTypedArrayAndString'}) =>
-                    $input->{'unionOfTypedArrayAndString'},
-                default => null,
+                    ($input->{'unionOfTypedArrayAndString'}),
+                default => $input->{'unionOfTypedArrayAndString'},
             }
             : null;
         $unionOfOneTypedArray = isset($input->{'unionOfOneTypedArray'}) ? $input->{'unionOfOneTypedArray'} : null;
@@ -428,23 +428,22 @@ class MyClass
 
         if (isset($this->unionOfTypedArrays)) {
             $output['unionOfTypedArrays'] = match (true) {
-                is_array($this->unionOfTypedArrays) => $this->unionOfTypedArrays,
+                default => $this->unionOfTypedArrays,
             };
         }
         if (isset($this->refUnionOfTypedArrays)) {
             $output['refUnionOfTypedArrays'] = match (true) {
-                is_array($this->refUnionOfTypedArrays) => $this->refUnionOfTypedArrays,
+                default => $this->refUnionOfTypedArrays,
             };
         }
         if (isset($this->refAndNotRefUnionOfTypedArrays)) {
             $output['refAndNotRefUnionOfTypedArrays'] = match (true) {
-                is_array($this->refAndNotRefUnionOfTypedArrays) => $this->refAndNotRefUnionOfTypedArrays,
+                default => $this->refAndNotRefUnionOfTypedArrays,
             };
         }
         if (isset($this->unionOfTypedArrayAndString)) {
             $output['unionOfTypedArrayAndString'] = match (true) {
-                is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString) =>
-                    $this->unionOfTypedArrayAndString,
+                default => $this->unionOfTypedArrayAndString,
             };
         }
         if (isset($this->unionOfOneTypedArray)) {
@@ -465,23 +464,22 @@ class MyClass
 
         if (isset($this->unionOfTypedArrays)) {
             $output->{'unionOfTypedArrays'} = match (true) {
-                is_array($this->unionOfTypedArrays) => $this->unionOfTypedArrays,
+                default => $this->unionOfTypedArrays,
             };
         }
         if (isset($this->refUnionOfTypedArrays)) {
             $output->{'refUnionOfTypedArrays'} = match (true) {
-                is_array($this->refUnionOfTypedArrays) => $this->refUnionOfTypedArrays,
+                default => $this->refUnionOfTypedArrays,
             };
         }
         if (isset($this->refAndNotRefUnionOfTypedArrays)) {
             $output->{'refAndNotRefUnionOfTypedArrays'} = match (true) {
-                is_array($this->refAndNotRefUnionOfTypedArrays) => $this->refAndNotRefUnionOfTypedArrays,
+                default => $this->refAndNotRefUnionOfTypedArrays,
             };
         }
         if (isset($this->unionOfTypedArrayAndString)) {
             $output->{'unionOfTypedArrayAndString'} = match (true) {
-                is_array($this->unionOfTypedArrayAndString) || is_string($this->unionOfTypedArrayAndString) =>
-                    $this->unionOfTypedArrayAndString,
+                default => $this->unionOfTypedArrayAndString,
             };
         }
         if (isset($this->unionOfOneTypedArray)) {

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-5.6/MyClass.php
@@ -310,10 +310,7 @@ class MyClass
         $foo = $input->{'foo'};
         $bar = $input->{'bar'};
         $baz = $input->{'baz'};
-        $qux = ($input->{'qux'} !== null
-            ? ((is_string($input->{'qux'})) ? $input->{'qux'} : null)
-            : null
-        );
+        $qux = ($input->{'qux'} !== null ? $input->{'qux'} : null);
 
         $obj = new self($foo, $bar, $baz, $qux);
 
@@ -334,18 +331,10 @@ class MyClass
     {
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
-        if (is_string($this->foo)) {
-            $output['foo'] = $this->foo;
-        }
-        if (is_string($this->bar)) {
-            $output['bar'] = $this->bar;
-        }
-        if (is_string($this->baz)) {
-            $output['baz'] = $this->baz;
-        }
-        if (is_string($this->qux)) {
-            $output['qux'] = $this->qux;
-        }
+        $output['foo'] = $this->foo;
+        $output['bar'] = $this->bar;
+        $output['baz'] = $this->baz;
+        $output['qux'] = $this->qux;
 
         return $output;
     }
@@ -359,18 +348,10 @@ class MyClass
     {
         $output = $this->_additionalProperties;
 
-        if (is_string($this->foo)) {
-            $output->{'foo'} = $this->foo;
-        }
-        if (is_string($this->bar)) {
-            $output->{'bar'} = $this->bar;
-        }
-        if (is_string($this->baz)) {
-            $output->{'baz'} = $this->baz;
-        }
-        if (is_string($this->qux)) {
-            $output->{'qux'} = $this->qux;
-        }
+        $output->{'foo'} = $this->foo;
+        $output->{'bar'} = $this->bar;
+        $output->{'baz'} = $this->baz;
+        $output->{'qux'} = $this->qux;
 
         return $output;
     }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-7.4/MyClass.php
@@ -253,10 +253,7 @@ class MyClass
         $foo = $input->{'foo'};
         $bar = $input->{'bar'};
         $baz = $input->{'baz'};
-        $qux = ($input->{'qux'} !== null
-            ? ((is_string($input->{'qux'})) ? $input->{'qux'} : null)
-            : null
-        );
+        $qux = ($input->{'qux'} !== null ? $input->{'qux'} : null);
 
         $obj = new self($foo, $bar, $baz, $qux);
 
@@ -277,18 +274,10 @@ class MyClass
     {
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
-        if (is_string($this->foo)) {
-            $output['foo'] = $this->foo;
-        }
-        if (is_string($this->bar)) {
-            $output['bar'] = $this->bar;
-        }
-        if (is_string($this->baz)) {
-            $output['baz'] = $this->baz;
-        }
-        if (is_string($this->qux)) {
-            $output['qux'] = $this->qux;
-        }
+        $output['foo'] = $this->foo;
+        $output['bar'] = $this->bar;
+        $output['baz'] = $this->baz;
+        $output['qux'] = $this->qux;
 
         return $output;
     }
@@ -302,18 +291,10 @@ class MyClass
     {
         $output = $this->_additionalProperties;
 
-        if (is_string($this->foo)) {
-            $output->{'foo'} = $this->foo;
-        }
-        if (is_string($this->bar)) {
-            $output->{'bar'} = $this->bar;
-        }
-        if (is_string($this->baz)) {
-            $output->{'baz'} = $this->baz;
-        }
-        if (is_string($this->qux)) {
-            $output->{'qux'} = $this->qux;
-        }
+        $output->{'foo'} = $this->foo;
+        $output->{'bar'} = $this->bar;
+        $output->{'baz'} = $this->baz;
+        $output->{'qux'} = $this->qux;
 
         return $output;
     }

--- a/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionCollapsing/Output-8.4/MyClass.php
@@ -257,8 +257,8 @@ class MyClass
         };
         $qux = ($input->{'qux'} !== null
             ? match (true) {
-                is_string($input->{'qux'}) => $input->{'qux'},
-                default => null,
+                is_string($input->{'qux'}) => ($input->{'qux'}),
+                default => $input->{'qux'},
             }
             : null
         );
@@ -283,16 +283,16 @@ class MyClass
         $output = json_decode(json_encode($this->_additionalProperties), true);
 
         $output['foo'] = match (true) {
-            is_string($this->foo) => $this->foo,
+            default => $this->foo,
         };
         $output['bar'] = match (true) {
-            is_string($this->bar) => $this->bar,
+            default => $this->bar,
         };
         $output['baz'] = match (true) {
-            is_string($this->baz) => $this->baz,
+            default => $this->baz,
         };
         $output['qux'] = match (true) {
-            is_string($this->qux) => $this->qux,
+            default => $this->qux,
         };
 
         return $output;
@@ -308,16 +308,16 @@ class MyClass
         $output = $this->_additionalProperties;
 
         $output->{'foo'} = match (true) {
-            is_string($this->foo) => $this->foo,
+            default => $this->foo,
         };
         $output->{'bar'} = match (true) {
-            is_string($this->bar) => $this->bar,
+            default => $this->bar,
         };
         $output->{'baz'} = match (true) {
-            is_string($this->baz) => $this->baz,
+            default => $this->baz,
         };
         $output->{'qux'} = match (true) {
-            is_string($this->qux) => $this->qux,
+            default => $this->qux,
         };
 
         return $output;

--- a/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-7.4/MyClass.php
@@ -434,42 +434,42 @@ class MyClass
 
         $_providedOptionals = [];
         $objectsUnion = isset($input->{'objectsUnion'})
-            ? ((MyClassObjectsUnionAlternative1::validateInput($input->{'objectsUnion'}, true))
+            ? ((((is_object($input->{'objectsUnion'}) || is_array($input->{'objectsUnion'})) && MyClassObjectsUnionAlternative1::validateInput($input->{'objectsUnion'}, true)))
                 ? MyClassObjectsUnionAlternative1::fromInput($input->{'objectsUnion'}, $validate)
-                : ((MyClassObjectsUnionAlternative2::validateInput($input->{'objectsUnion'}, true))
+                : ((((is_object($input->{'objectsUnion'}) || is_array($input->{'objectsUnion'})) && MyClassObjectsUnionAlternative2::validateInput($input->{'objectsUnion'}, true)))
                     ? MyClassObjectsUnionAlternative2::fromInput($input->{'objectsUnion'}, $validate)
-                    : null
+                    : $input->{'objectsUnion'}
                 )
             )
             : null;
         $refObjectsUnion = isset($input->{'refObjectsUnion'})
-            ? ((SomeObj1::validateInput($input->{'refObjectsUnion'}, true))
+            ? ((((is_object($input->{'refObjectsUnion'}) || is_array($input->{'refObjectsUnion'})) && SomeObj1::validateInput($input->{'refObjectsUnion'}, true)))
                 ? SomeObj1::fromInput($input->{'refObjectsUnion'}, $validate)
-                : ((SomeObj2::validateInput($input->{'refObjectsUnion'}, true))
+                : ((((is_object($input->{'refObjectsUnion'}) || is_array($input->{'refObjectsUnion'})) && SomeObj2::validateInput($input->{'refObjectsUnion'}, true)))
                     ? SomeObj2::fromInput($input->{'refObjectsUnion'}, $validate)
-                    : null
+                    : $input->{'refObjectsUnion'}
                 )
             )
             : null;
         $refAndNotRefObjectsUnion = isset($input->{'refAndNotRefObjectsUnion'})
-            ? ((SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
+            ? ((((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true)))
                 ? SomeObj1::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                : ((MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
+                : ((((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)))
                     ? MyClassRefAndNotRefObjectsUnionAlternative2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                    : ((SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
+                    : ((((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)))
                         ? SomeObj2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                        : ((MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true))
+                        : ((((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true)))
                             ? MyClassRefAndNotRefObjectsUnionAlternative4::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate)
-                            : null
+                            : $input->{'refAndNotRefObjectsUnion'}
                         )
                     )
                 )
             )
             : null;
         $objAndStringUnion = isset($input->{'objAndStringUnion'})
-            ? ((MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true))
+            ? ((((is_object($input->{'objAndStringUnion'}) || is_array($input->{'objAndStringUnion'})) && MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true)))
                 ? MyClassObjAndStringUnionAlternative1::fromInput($input->{'objAndStringUnion'}, $validate)
-                : ((is_string($input->{'objAndStringUnion'})) ? $input->{'objAndStringUnion'} : null)
+                : $input->{'objAndStringUnion'}
             )
             : null;
         $unionOfOneObj = isset($input->{'unionOfOneObj'})
@@ -513,11 +513,15 @@ class MyClass
                 || $this->objectsUnion instanceof MyClassObjectsUnionAlternative2
             ) {
                 $output['objectsUnion'] = $this->objectsUnion->toArray();
+            } else {
+                $output['objectsUnion'] = $this->objectsUnion;
             }
         }
         if (isset($this->refObjectsUnion)) {
             if ($this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2) {
                 $output['refObjectsUnion'] = $this->refObjectsUnion->toArray();
+            } else {
+                $output['refObjectsUnion'] = $this->refObjectsUnion;
             }
         }
         if (isset($this->refAndNotRefObjectsUnion)) {
@@ -527,12 +531,14 @@ class MyClass
                 || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4
             ) {
                 $output['refAndNotRefObjectsUnion'] = $this->refAndNotRefObjectsUnion->toArray();
+            } else {
+                $output['refAndNotRefObjectsUnion'] = $this->refAndNotRefObjectsUnion;
             }
         }
         if (isset($this->objAndStringUnion)) {
             if ($this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1) {
                 $output['objAndStringUnion'] = $this->objAndStringUnion->toArray();
-            } elseif (is_string($this->objAndStringUnion)) {
+            } else {
                 $output['objAndStringUnion'] = $this->objAndStringUnion;
             }
         }
@@ -560,11 +566,15 @@ class MyClass
                 || $this->objectsUnion instanceof MyClassObjectsUnionAlternative2
             ) {
                 $output->{'objectsUnion'} = $this->objectsUnion->toStdClass();
+            } else {
+                $output->{'objectsUnion'} = $this->objectsUnion;
             }
         }
         if (isset($this->refObjectsUnion)) {
             if ($this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2) {
                 $output->{'refObjectsUnion'} = $this->refObjectsUnion->toStdClass();
+            } else {
+                $output->{'refObjectsUnion'} = $this->refObjectsUnion;
             }
         }
         if (isset($this->refAndNotRefObjectsUnion)) {
@@ -574,12 +584,14 @@ class MyClass
                 || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4
             ) {
                 $output->{'refAndNotRefObjectsUnion'} = $this->refAndNotRefObjectsUnion->toStdClass();
+            } else {
+                $output->{'refAndNotRefObjectsUnion'} = $this->refAndNotRefObjectsUnion;
             }
         }
         if (isset($this->objAndStringUnion)) {
             if ($this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1) {
                 $output->{'objAndStringUnion'} = $this->objAndStringUnion->toStdClass();
-            } elseif (is_string($this->objAndStringUnion)) {
+            } else {
                 $output->{'objAndStringUnion'} = $this->objAndStringUnion;
             }
         }

--- a/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/UnionObject/Output-8.4/MyClass.php
@@ -368,39 +368,41 @@ class MyClass
         $_providedOptionals = [];
         $objectsUnion = isset($input->{'objectsUnion'})
             ? match (true) {
-                MyClassObjectsUnionAlternative1::validateInput($input->{'objectsUnion'}, true) =>
+                ((is_object($input->{'objectsUnion'}) || is_array($input->{'objectsUnion'})) && MyClassObjectsUnionAlternative1::validateInput($input->{'objectsUnion'}, true)) =>
                     MyClassObjectsUnionAlternative1::fromInput($input->{'objectsUnion'}, $validate),
-                MyClassObjectsUnionAlternative2::validateInput($input->{'objectsUnion'}, true) =>
+                ((is_object($input->{'objectsUnion'}) || is_array($input->{'objectsUnion'})) && MyClassObjectsUnionAlternative2::validateInput($input->{'objectsUnion'}, true)) =>
                     MyClassObjectsUnionAlternative2::fromInput($input->{'objectsUnion'}, $validate),
-                default => null,
+                default => $input->{'objectsUnion'},
             }
             : null;
         $refObjectsUnion = isset($input->{'refObjectsUnion'})
             ? match (true) {
-                SomeObj1::validateInput($input->{'refObjectsUnion'}, true) => SomeObj1::fromInput($input->{'refObjectsUnion'}, $validate),
-                SomeObj2::validateInput($input->{'refObjectsUnion'}, true) => SomeObj2::fromInput($input->{'refObjectsUnion'}, $validate),
-                default => null,
+                ((is_object($input->{'refObjectsUnion'}) || is_array($input->{'refObjectsUnion'})) && SomeObj1::validateInput($input->{'refObjectsUnion'}, true)) =>
+                    SomeObj1::fromInput($input->{'refObjectsUnion'}, $validate),
+                ((is_object($input->{'refObjectsUnion'}) || is_array($input->{'refObjectsUnion'})) && SomeObj2::validateInput($input->{'refObjectsUnion'}, true)) =>
+                    SomeObj2::fromInput($input->{'refObjectsUnion'}, $validate),
+                default => $input->{'refObjectsUnion'},
             }
             : null;
         $refAndNotRefObjectsUnion = isset($input->{'refAndNotRefObjectsUnion'})
             ? match (true) {
-                SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true) =>
+                ((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && SomeObj1::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) =>
                     SomeObj1::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate),
-                MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true) =>
+                ((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && MyClassRefAndNotRefObjectsUnionAlternative2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) =>
                     MyClassRefAndNotRefObjectsUnionAlternative2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate),
-                SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true) =>
+                ((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && SomeObj2::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) =>
                     SomeObj2::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate),
-                MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true) =>
+                ((is_object($input->{'refAndNotRefObjectsUnion'}) || is_array($input->{'refAndNotRefObjectsUnion'})) && MyClassRefAndNotRefObjectsUnionAlternative4::validateInput($input->{'refAndNotRefObjectsUnion'}, true)) =>
                     MyClassRefAndNotRefObjectsUnionAlternative4::fromInput($input->{'refAndNotRefObjectsUnion'}, $validate),
-                default => null,
+                default => $input->{'refAndNotRefObjectsUnion'},
             }
             : null;
         $objAndStringUnion = isset($input->{'objAndStringUnion'})
             ? match (true) {
-                MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true) =>
+                is_string($input->{'objAndStringUnion'}) => ($input->{'objAndStringUnion'}),
+                ((is_object($input->{'objAndStringUnion'}) || is_array($input->{'objAndStringUnion'})) && MyClassObjAndStringUnionAlternative1::validateInput($input->{'objAndStringUnion'}, true)) =>
                     MyClassObjAndStringUnionAlternative1::fromInput($input->{'objAndStringUnion'}, $validate),
-                is_string($input->{'objAndStringUnion'}) => $input->{'objAndStringUnion'},
-                default => null,
+                default => $input->{'objAndStringUnion'},
             }
             : null;
         $unionOfOneObj = isset($input->{'unionOfOneObj'})
@@ -444,12 +446,14 @@ class MyClass
                 $this->objectsUnion instanceof MyClassObjectsUnionAlternative1
                     || $this->objectsUnion instanceof MyClassObjectsUnionAlternative2 =>
                     $this->objectsUnion->toArray(),
+                default => $this->objectsUnion,
             };
         }
         if (isset($this->refObjectsUnion)) {
             $output['refObjectsUnion'] = match (true) {
                 $this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2 =>
                     $this->refObjectsUnion->toArray(),
+                default => $this->refObjectsUnion,
             };
         }
         if (isset($this->refAndNotRefObjectsUnion)) {
@@ -459,12 +463,13 @@ class MyClass
                     || $this->refAndNotRefObjectsUnion instanceof SomeObj2
                     || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4 =>
                     $this->refAndNotRefObjectsUnion->toArray(),
+                default => $this->refAndNotRefObjectsUnion,
             };
         }
         if (isset($this->objAndStringUnion)) {
             $output['objAndStringUnion'] = match (true) {
                 $this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1 => $this->objAndStringUnion->toArray(),
-                is_string($this->objAndStringUnion) => $this->objAndStringUnion,
+                default => $this->objAndStringUnion,
             };
         }
         if (isset($this->unionOfOneObj)) {
@@ -491,12 +496,14 @@ class MyClass
                 $this->objectsUnion instanceof MyClassObjectsUnionAlternative1
                     || $this->objectsUnion instanceof MyClassObjectsUnionAlternative2 =>
                     $this->objectsUnion->toStdClass(),
+                default => $this->objectsUnion,
             };
         }
         if (isset($this->refObjectsUnion)) {
             $output->{'refObjectsUnion'} = match (true) {
                 $this->refObjectsUnion instanceof SomeObj1 || $this->refObjectsUnion instanceof SomeObj2 =>
                     $this->refObjectsUnion->toStdClass(),
+                default => $this->refObjectsUnion,
             };
         }
         if (isset($this->refAndNotRefObjectsUnion)) {
@@ -506,12 +513,13 @@ class MyClass
                     || $this->refAndNotRefObjectsUnion instanceof SomeObj2
                     || $this->refAndNotRefObjectsUnion instanceof MyClassRefAndNotRefObjectsUnionAlternative4 =>
                     $this->refAndNotRefObjectsUnion->toStdClass(),
+                default => $this->refAndNotRefObjectsUnion,
             };
         }
         if (isset($this->objAndStringUnion)) {
             $output->{'objAndStringUnion'} = match (true) {
                 $this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1 => $this->objAndStringUnion->toStdClass(),
-                is_string($this->objAndStringUnion) => $this->objAndStringUnion,
+                default => $this->objAndStringUnion,
             };
         }
         if (isset($this->unionOfOneObj)) {
@@ -574,8 +582,9 @@ class MyClass
         }
         if (isset($this->objAndStringUnion)) {
             $this->objAndStringUnion = match (true) {
+                is_string($this->objAndStringUnion) => ($this->objAndStringUnion),
                 $this->objAndStringUnion instanceof MyClassObjAndStringUnionAlternative1 => clone $this->objAndStringUnion,
-                is_string($this->objAndStringUnion) => $this->objAndStringUnion,
+                default => $this->objAndStringUnion,
             };
         }
         if (isset($this->unionOfOneObj)) {

--- a/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
+++ b/tests/Generator/Fixtures/UnionWithRepeatedType/Output-8.4/Cat.php
@@ -168,13 +168,13 @@ class Cat
                     ) =>
                         ($input->{'hasFur'} !== null
                             ? match (true) {
-                                is_string($input->{'hasFur'}) => $input->{'hasFur'},
+                                is_string($input->{'hasFur'}) => ($input->{'hasFur'}),
                                 (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})) =>
                                     (str_contains((string)$input->{'hasFur'}, '.')
                                         ? (float)$input->{'hasFur'}
                                         : (int)$input->{'hasFur'}
                                     ),
-                                default => null,
+                                default => $input->{'hasFur'},
                             }
                             : null
                         ),
@@ -183,16 +183,16 @@ class Cat
                         || is_bool($input->{'hasFur'})
                     ) =>
                         match (true) {
-                            is_string($input->{'hasFur'}) => $input->{'hasFur'},
+                            is_string($input->{'hasFur'}) => ($input->{'hasFur'}),
                             (is_int($input->{'hasFur'}) || is_float($input->{'hasFur'})) =>
                                 (str_contains((string)$input->{'hasFur'}, '.')
                                     ? (float)$input->{'hasFur'}
                                     : (int)$input->{'hasFur'}
                                 ),
                             is_bool($input->{'hasFur'}) => (bool)$input->{'hasFur'},
-                            default => null,
+                            default => $input->{'hasFur'},
                         },
-                    default => null,
+                    default => $input->{'hasFur'},
                 }
                 : null
             );
@@ -228,8 +228,8 @@ class Cat
                     ) =>
                         ($this->hasFur !== null
                             ? match (true) {
-                                is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
-                                default => null,
+                                is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => ($this->hasFur),
+                                default => $this->hasFur,
                             }
                             : null
                         ),
@@ -241,10 +241,10 @@ class Cat
                             is_string($this->hasFur)
                                 || (is_int($this->hasFur) || is_float($this->hasFur))
                                 || is_bool($this->hasFur) =>
-                                $this->hasFur,
-                            default => null,
+                                ($this->hasFur),
+                            default => $this->hasFur,
                         },
-                    default => null,
+                    default => $this->hasFur,
                 }
                 : null
             );
@@ -271,8 +271,8 @@ class Cat
                     ) =>
                         ($this->hasFur !== null
                             ? match (true) {
-                                is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => $this->hasFur,
-                                default => null,
+                                is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)) => ($this->hasFur),
+                                default => $this->hasFur,
                             }
                             : null
                         ),
@@ -284,10 +284,10 @@ class Cat
                             is_string($this->hasFur)
                                 || (is_int($this->hasFur) || is_float($this->hasFur))
                                 || is_bool($this->hasFur) =>
-                                $this->hasFur,
-                            default => null,
+                                ($this->hasFur),
+                            default => $this->hasFur,
                         },
-                    default => null,
+                    default => $this->hasFur,
                 }
                 : null
             );
@@ -337,16 +337,17 @@ class Cat
     {
         if (isset($this->hasFur)) {
             $this->hasFur = match (true) {
+                (is_string($this->hasFur)
+                    || (is_int($this->hasFur) || is_float($this->hasFur))
+                    || is_bool($this->hasFur)
+                ) =>
+                    ($this->hasFur),
                 ($this->hasFur === null || is_bool($this->hasFur))
                     || ($this->hasFur === null
                         || (is_string($this->hasFur) || (is_int($this->hasFur) || is_float($this->hasFur)))
                     ) =>
                     (isset($this->hasFur) ? clone $this->hasFur : null),
-                (is_string($this->hasFur)
-                    || (is_int($this->hasFur) || is_float($this->hasFur))
-                    || is_bool($this->hasFur)
-                ) =>
-                    $this->hasFur,
+                default => $this->hasFur,
             };
         }
     }

--- a/tests/Generator/Property/UnionPropertyTest.php
+++ b/tests/Generator/Property/UnionPropertyTest.php
@@ -56,9 +56,9 @@ class UnionPropertyTest extends TestCase
 
         $expected = <<<'EOCODE'
 $myPropertyName = match (true) {
-    FooMyPropertyNameAlternative1::validateInput($input->{'myPropertyName'}, true) =>
+    ((is_object($input->{'myPropertyName'}) || is_array($input->{'myPropertyName'})) && FooMyPropertyNameAlternative1::validateInput($input->{'myPropertyName'}, true)) =>
         FooMyPropertyNameAlternative1::fromInput($input->{'myPropertyName'}, $validate),
-    FooMyPropertyNameAlternative2::validateInput($input->{'myPropertyName'}, true) =>
+    ((is_object($input->{'myPropertyName'}) || is_array($input->{'myPropertyName'})) && FooMyPropertyNameAlternative2::validateInput($input->{'myPropertyName'}, true)) =>
         FooMyPropertyNameAlternative2::fromInput($input->{'myPropertyName'}, $validate),
     default => throw new \InvalidArgumentException("could not build property 'myPropertyName' from JSON"),
 };
@@ -78,6 +78,7 @@ $output['myPropertyName'] = match (true) {
     $this->myPropertyName instanceof FooMyPropertyNameAlternative1
         || $this->myPropertyName instanceof FooMyPropertyNameAlternative2 =>
         $this->myPropertyName->toArray(),
+    default => $this->myPropertyName,
 };
 EOCODE;
 
@@ -95,6 +96,7 @@ $output->{'myPropertyName'} = match (true) {
     $this->myPropertyName instanceof FooMyPropertyNameAlternative1
         || $this->myPropertyName instanceof FooMyPropertyNameAlternative2 =>
         $this->myPropertyName->toStdClass(),
+    default => $this->myPropertyName,
 };
 EOCODE;
 


### PR DESCRIPTION
## Summary
- keep original value when none of a union's branches validate
- guard union branch validation to avoid calling object validators on scalars
- ensure unions serialize raw values when no branch matches

## Testing
- `UPDATE_SNAPSHOTS=1 vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: Match expression does not handle remaining value: true)*

------
https://chatgpt.com/codex/tasks/task_e_68a2daffe270832d8a82e383587bc987