### PR TITLE
Preserve const literal values in union enum properties

### DIFF
--- a/src/Generator/Property/PropertyBuilder.php
+++ b/src/Generator/Property/PropertyBuilder.php
@@ -80,6 +80,7 @@ class PropertyBuilder
     ): PropertyInterface
     {
         $definition = self::collapseSingleUnion($definition);
+        $definition = self::convertConstToEnum($definition);
         $definition = self::sanitizeEnum($definition);
         $definition = self::collapseSingleTypeArray($definition);
         
@@ -464,6 +465,18 @@ class PropertyBuilder
         if (is_array($definition['type']) && count($definition['type']) === 1 && !$originalIsArray) {
             $definition['type'] = $definition['type'][0];
         }
+
+        return $definition;
+    }
+
+    private static function convertConstToEnum(array $definition): array
+    {
+        if (!array_key_exists('const', $definition)) {
+            return $definition;
+        }
+
+        $definition['enum'] = [$definition['const']];
+        unset($definition['const']);
 
         return $definition;
     }

--- a/tests/Generator/Fixtures/AnyOfEnumConst/Output-8.4/AddressAdminData.php
+++ b/tests/Generator/Fixtures/AnyOfEnumConst/Output-8.4/AddressAdminData.php
@@ -66,12 +66,12 @@ class AddressAdminData
     private \stdClass $_additionalProperties;
 
     /**
-     * @var string|'1'|'8'|null
+     * @var '0'|'1'|'8'|'75'|'-1'|null
      */
     private ?string $fiasLevel;
 
     /**
-     * @param string|'1'|'8'|null $fiasLevel
+     * @param '0'|'1'|'8'|'75'|'-1'|null $fiasLevel
      */
     public function __construct(?string $fiasLevel)
     {
@@ -118,7 +118,7 @@ class AddressAdminData
     }
 
     /**
-     * @return string|'1'|'8'|null
+     * @return '0'|'1'|'8'|'75'|'-1'|null
      */
     public function getFiasLevel(): ?string
     {
@@ -126,7 +126,7 @@ class AddressAdminData
     }
 
     /**
-     * @param string|'1'|'8'|null $fiasLevel
+     * @param '0'|'1'|'8'|'75'|'-1'|null $fiasLevel
      */
     public function withFiasLevel(?string $fiasLevel, bool $validate = true): self
     {


### PR DESCRIPTION
## Summary
- normalize `const` keywords into enum values during property building so literal types survive union handling
- regenerate the AnyOfEnumConst fixture to reflect the preserved literal values in docblocks

## Testing
- vendor/bin/phpunit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b96a6394832d801057345b02ba37)