### PR TITLE
Preserve const enum literals in unions

### DIFF
--- a/src/Generator/Property/PropertyBuilder.php
+++ b/src/Generator/Property/PropertyBuilder.php
@@ -360,6 +360,11 @@ class PropertyBuilder
      */
     private static function sanitizeEnum(array $definition): array
     {
+        if (!isset($definition['enum']) && array_key_exists('const', $definition)) {
+            $definition['enum'] = [$definition['const']];
+            unset($definition['const']);
+        }
+
         if (!isset($definition['enum'])) {
             return $definition;
         }

--- a/tests/Generator/Fixtures/AnyOfEnumConst/Output-8.4/AddressAdminData.php
+++ b/tests/Generator/Fixtures/AnyOfEnumConst/Output-8.4/AddressAdminData.php
@@ -66,12 +66,12 @@ class AddressAdminData
     private \stdClass $_additionalProperties;
 
     /**
-     * @var string|'1'|'8'|null
+     * @var '0'|'1'|'8'|'75'|'-1'|null
      */
     private ?string $fiasLevel;
 
     /**
-     * @param string|'1'|'8'|null $fiasLevel
+     * @param '0'|'1'|'8'|'75'|'-1'|null $fiasLevel
      */
     public function __construct(?string $fiasLevel)
     {
@@ -118,7 +118,7 @@ class AddressAdminData
     }
 
     /**
-     * @return string|'1'|'8'|null
+     * @return '0'|'1'|'8'|'75'|'-1'|null
      */
     public function getFiasLevel(): ?string
     {
@@ -126,7 +126,7 @@ class AddressAdminData
     }
 
     /**
-     * @param string|'1'|'8'|null $fiasLevel
+     * @param '0'|'1'|'8'|'75'|'-1'|null $fiasLevel
      */
     public function withFiasLevel(?string $fiasLevel, bool $validate = true): self
     {


### PR DESCRIPTION
## Summary
- normalize const-only schemas into enums so union type inference keeps literal values
- regenerate AnyOfEnumConst fixture to reflect preserved literal types

## Testing
- UPDATE_SNAPSHOTS=1 vendor/bin/phpunit --filter AnyOfEnumConst
- vendor/bin/phpunit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b96a6394832d801057345b02ba37)