### PR TITLE
Preserve const values in anyOf enum unions

### DIFF
--- a/src/Generator/Property/PropertyBuilder.php
+++ b/src/Generator/Property/PropertyBuilder.php
@@ -80,6 +80,7 @@ class PropertyBuilder
     ): PropertyInterface
     {
         $definition = self::collapseSingleUnion($definition);
+        $definition = self::convertConstToEnum($definition);
         $definition = self::sanitizeEnum($definition);
         $definition = self::collapseSingleTypeArray($definition);
         
@@ -144,6 +145,41 @@ class PropertyBuilder
         $defType = $definition['type'] ?? null;
         if (is_array($defType) && count($defType) === 1) {
             $definition['type'] = $defType[0];
+        }
+
+        return $definition;
+    }
+
+    /**
+     * Turn `const` into a single-value enum to reuse enum handling logic.
+     */
+    private static function convertConstToEnum(array $definition): array
+    {
+        if (!array_key_exists('const', $definition)) {
+            return $definition;
+        }
+
+        $const = $definition['const'];
+
+        if (isset($definition['enum']) && is_array($definition['enum'])) {
+            if (!in_array($const, $definition['enum'], true)) {
+                $definition['enum'][] = $const;
+            }
+        } else {
+            $definition['enum'] = [$const];
+        }
+
+        unset($definition['const']);
+
+        if (!isset($definition['type']) && !isset($definition['anyOf']) && !isset($definition['oneOf'])) {
+            $definition['type'] = match (true) {
+                $const === null   => 'null',
+                is_string($const) => 'string',
+                is_int($const)    => 'integer',
+                is_float($const)  => 'number',
+                is_bool($const)   => 'boolean',
+                default           => $definition['type'] ?? null,
+            };
         }
 
         return $definition;

--- a/tests/Generator/Fixtures/AnyOfEnumConst/Output-8.4/AddressAdminData.php
+++ b/tests/Generator/Fixtures/AnyOfEnumConst/Output-8.4/AddressAdminData.php
@@ -66,12 +66,12 @@ class AddressAdminData
     private \stdClass $_additionalProperties;
 
     /**
-     * @var string|'1'|'8'|null
+     * @var '0'|'1'|'8'|'75'|'-1'|null
      */
     private ?string $fiasLevel;
 
     /**
-     * @param string|'1'|'8'|null $fiasLevel
+     * @param '0'|'1'|'8'|'75'|'-1'|null $fiasLevel
      */
     public function __construct(?string $fiasLevel)
     {
@@ -118,7 +118,7 @@ class AddressAdminData
     }
 
     /**
-     * @return string|'1'|'8'|null
+     * @return '0'|'1'|'8'|'75'|'-1'|null
      */
     public function getFiasLevel(): ?string
     {
@@ -126,7 +126,7 @@ class AddressAdminData
     }
 
     /**
-     * @param string|'1'|'8'|null $fiasLevel
+     * @param '0'|'1'|'8'|'75'|'-1'|null $fiasLevel
      */
     public function withFiasLevel(?string $fiasLevel, bool $validate = true): self
     {


### PR DESCRIPTION
## Summary
- normalize const-only schema fragments into enums so literal values survive union handling
- update AnyOfEnumConst fixture to reflect retained const literal annotations for fias_level

## Testing
- vendor/bin/phpunit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b96a6394832d801057345b02ba37)