### PR TITLE
Fix duplicate clone guard for optional nullable properties

### DIFF
--- a/src/Generator/Property/PropertyBuilder.php
+++ b/src/Generator/Property/PropertyBuilder.php
@@ -320,7 +320,7 @@ class PropertyBuilder
                     $singleSchema[$k] = $definition[$k];
                 }
             }
-            $inner = self::buildPropertyFromSchema($req, $name, $singleSchema, $isRequired);
+            $inner = self::buildPropertyFromSchema($req, $name, $singleSchema, true);
             return $isRequired
                 ? new NullablePropertyDecorator($name, $inner, $req)
                 : self::wrapProperty($req, $inner, $definition, $name, false);

--- a/tests/Generator/Fixtures/OptionalNullable/Output-8.4/User.php
+++ b/tests/Generator/Fixtures/OptionalNullable/Output-8.4/User.php
@@ -233,9 +233,7 @@ class User
         $this->_additionalProperties = json_decode(json_encode($this->_additionalProperties));
 
         if (isset($this->address)) {
-            if (isset($this->address)) {
-                $this->address = clone $this->address;
-            }
+            $this->address = clone $this->address;
         }
     }
 

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-5.6/MyClass.php
@@ -854,14 +854,10 @@ class MyClass
         $this->_additionalProperties = json_decode(json_encode($this->_additionalProperties));
 
         if (isset($this->grox)) {
-            if (isset($this->grox)) {
-                $this->grox = clone $this->grox;
-            }
+            $this->grox = clone $this->grox;
         }
         if (isset($this->gooks)) {
-            if (isset($this->gooks)) {
-                $this->gooks = clone $this->gooks;
-            }
+            $this->gooks = clone $this->gooks;
         }
     }
 

--- a/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
+++ b/tests/Generator/Fixtures/OptionalNullableDefault/Output-8.4/MyClass.php
@@ -675,14 +675,10 @@ class MyClass
         $this->_additionalProperties = json_decode(json_encode($this->_additionalProperties));
 
         if (isset($this->grox)) {
-            if (isset($this->grox)) {
-                $this->grox = clone $this->grox;
-            }
+            $this->grox = clone $this->grox;
         }
         if (isset($this->gooks)) {
-            if (isset($this->gooks)) {
-                $this->gooks = clone $this->gooks;
-            }
+            $this->gooks = clone $this->gooks;
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid double-wrapping optional nullable properties when splitting null unions
- regenerate fixtures to ensure __clone only guards properties once

## Testing
- UPDATE_SNAPSHOTS=1 vendor/bin/phpunit tests/Generator/ClassGenerationTest.php --filter OptionalNullable


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930bffa1f10832dba185a2d4f3479f9)